### PR TITLE
abstract out logging functionality in an extendable way

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -162,7 +162,8 @@ pub fn build(b: *Builder) !void {
     });
     types_tests.root_module.addImport("ssz", ssz);
     const run_types_test = b.addRunArtifact(types_tests);
-    test_step.dependOn(&run_types_test.step);
+    _ = run_types_test;
+    // test_step.dependOn(&run_types_test.step);
 
     const transition_tests = b.addTest(.{
         .root_module = zeam_state_transition,
@@ -184,7 +185,8 @@ pub fn build(b: *Builder) !void {
     });
     manager_tests.root_module.addImport("@zeam/types", zeam_types);
     const run_manager_test = b.addRunArtifact(manager_tests);
-    test_step.dependOn(&run_manager_test.step);
+    _ = run_manager_test;
+    // test_step.dependOn(&run_manager_test.step);
 
     const node_tests = b.addTest(.{
         .root_module = zeam_beam_node,
@@ -192,7 +194,8 @@ pub fn build(b: *Builder) !void {
         .target = target,
     });
     const run_node_test = b.addRunArtifact(node_tests);
-    test_step.dependOn(&run_node_test.step);
+    _ = run_node_test;
+    // test_step.dependOn(&run_node_test.step);
 
     const cli_tests = b.addTest(.{
         .root_module = cli_exe.root_module,
@@ -201,7 +204,8 @@ pub fn build(b: *Builder) !void {
     });
     addZkvmGlueLibs(b, cli_tests);
     const run_cli_test = b.addRunArtifact(cli_tests);
-    test_step.dependOn(&run_cli_test.step);
+    _ = run_cli_test;
+    // test_step.dependOn(&run_cli_test.step);
 
     const params_tests = b.addTest(.{
         .root_module = zeam_params,
@@ -209,7 +213,8 @@ pub fn build(b: *Builder) !void {
         .target = target,
     });
     const run_params_tests = b.addRunArtifact(params_tests);
-    test_step.dependOn(&run_params_tests.step);
+    _ = run_params_tests;
+    // test_step.dependOn(&run_params_tests.step);
 
     for (zkvm_targets) |zkvm_target| {
         if (zkvm_target.build_glue) {

--- a/build.zig
+++ b/build.zig
@@ -92,6 +92,7 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
     });
     zeam_state_proving_manager.addImport("@zeam/types", zeam_types);
+    zeam_state_proving_manager.addImport("@zeam/utils", zeam_utils);
     zeam_state_proving_manager.addImport("@zeam/state-transition", zeam_state_transition);
     zeam_state_proving_manager.addImport("ssz", ssz);
 
@@ -162,8 +163,7 @@ pub fn build(b: *Builder) !void {
     });
     types_tests.root_module.addImport("ssz", ssz);
     const run_types_test = b.addRunArtifact(types_tests);
-    _ = run_types_test;
-    // test_step.dependOn(&run_types_test.step);
+    test_step.dependOn(&run_types_test.step);
 
     const transition_tests = b.addTest(.{
         .root_module = zeam_state_transition,
@@ -185,8 +185,7 @@ pub fn build(b: *Builder) !void {
     });
     manager_tests.root_module.addImport("@zeam/types", zeam_types);
     const run_manager_test = b.addRunArtifact(manager_tests);
-    _ = run_manager_test;
-    // test_step.dependOn(&run_manager_test.step);
+    test_step.dependOn(&run_manager_test.step);
 
     const node_tests = b.addTest(.{
         .root_module = zeam_beam_node,
@@ -194,8 +193,7 @@ pub fn build(b: *Builder) !void {
         .target = target,
     });
     const run_node_test = b.addRunArtifact(node_tests);
-    _ = run_node_test;
-    // test_step.dependOn(&run_node_test.step);
+    test_step.dependOn(&run_node_test.step);
 
     const cli_tests = b.addTest(.{
         .root_module = cli_exe.root_module,
@@ -204,8 +202,7 @@ pub fn build(b: *Builder) !void {
     });
     addZkvmGlueLibs(b, cli_tests);
     const run_cli_test = b.addRunArtifact(cli_tests);
-    _ = run_cli_test;
-    // test_step.dependOn(&run_cli_test.step);
+    test_step.dependOn(&run_cli_test.step);
 
     const params_tests = b.addTest(.{
         .root_module = zeam_params,
@@ -213,8 +210,7 @@ pub fn build(b: *Builder) !void {
         .target = target,
     });
     const run_params_tests = b.addRunArtifact(params_tests);
-    _ = run_params_tests;
-    // test_step.dependOn(&run_params_tests.step);
+    test_step.dependOn(&run_params_tests.step);
 
     for (zkvm_targets) |zkvm_target| {
         if (zkvm_target.build_glue) {

--- a/build.zig
+++ b/build.zig
@@ -80,6 +80,7 @@ pub fn build(b: *Builder) !void {
         .target = target,
         .optimize = optimize,
     });
+    zeam_state_transition.addImport("@zeam/utils", zeam_utils);
     zeam_state_transition.addImport("@zeam/params", zeam_params);
     zeam_state_transition.addImport("@zeam/types", zeam_types);
     zeam_state_transition.addImport("ssz", ssz);
@@ -255,11 +256,19 @@ fn build_zkvm_targets(b: *Builder, main_exe: *Builder.Step, host_target: std.Bui
     zeam_types.addImport("@zeam/params", zeam_params);
 
     for (zkvm_targets) |zkvm_target| {
+        // add zeam-params
+        const zeam_utils = b.addModule("@zeam/utils", .{
+            .target = target,
+            .optimize = optimize,
+            .root_source_file = b.path("pkgs/utils/src/lib.zig"),
+        });
+
         const zkvm_module = b.addModule("zkvm", .{
             .optimize = optimize,
             .target = target,
             .root_source_file = b.path(b.fmt("pkgs/state-transition-runtime/src/{s}/lib.zig", .{zkvm_target.name})),
         });
+        zeam_utils.addImport("zkvm", zkvm_module);
 
         // add state transition, create a new module for each zkvm since
         // that module depends on the zkvm module.
@@ -268,6 +277,7 @@ fn build_zkvm_targets(b: *Builder, main_exe: *Builder.Step, host_target: std.Bui
             .target = target,
             .optimize = optimize,
         });
+        zeam_state_transition.addImport("@zeam/utils", zeam_utils);
         zeam_state_transition.addImport("@zeam/params", zeam_params);
         zeam_state_transition.addImport("@zeam/types", zeam_types);
         zeam_state_transition.addImport("ssz", ssz);

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -79,7 +79,7 @@ pub fn main() !void {
                 std.debug.print("\nprestate slot blockslot={d} stateslot={d}\n", .{ block.message.slot, beam_state.slot });
                 const proof = try stateProvingManager.prove_transition(beam_state, block, options, allocator);
                 // transition beam state for the next block
-                try sftFactory.apply_transition(allocator, &beam_state, block);
+                try sftFactory.apply_transition(allocator, &beam_state, block, .{});
 
                 // verify the block
                 try stateProvingManager.verify_transition(proof, [_]u8{0} ** 32, [_]u8{0} ** 32, options);

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -63,7 +63,7 @@ pub fn main() !void {
                 //     .program_path = "zig-out/bin/zeam-stf-powdr",
                 //     .output_dir = "out",
                 // },
-                .risc0 = .{ .program_path = "zig-out/bin/risc0_runtime.elf" },
+                .zkvm = .{ .risc0 = .{ .program_path = "zig-out/bin/risc0_runtime.elf" } },
             };
 
             // generate a mock chain with 2 blocks including genesis i.e. 1 block on top of genesis

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -58,7 +58,7 @@ pub fn main() !void {
         },
         .prove => |provecmd| {
             std.debug.print("distribution dir={s}\n", .{provecmd.dist_dir});
-            const options = stateProvingManager.StateTransitionOpts{
+            const options = stateProvingManager.ZKStateTransitionOpts{
                 // .powdr = .{
                 //     .program_path = "zig-out/bin/zeam-stf-powdr",
                 //     .output_dir = "out",

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -280,7 +280,7 @@ test "forkchoice block tree" {
     for (1..mock_chain.blocks.len) |i| {
         // get the block post state
         const block = mock_chain.blocks[i];
-        try stf.apply_transition(allocator, &beam_state, block);
+        try stf.apply_transition(allocator, &beam_state, block, .{});
 
         // shouldn't accept a future slot
         const current_slot = block.message.slot;

--- a/pkgs/state-proving-manager/src/manager.zig
+++ b/pkgs/state-proving-manager/src/manager.zig
@@ -18,12 +18,12 @@ const Risc0Config = struct {
     program_path: []const u8,
 };
 
-pub const StateTransitionOpts = union(enum) {
+pub const ZKStateTransitionOpts = union(enum) {
     powdr: PowdrConfig,
     risc0: Risc0Config,
 };
 
-pub fn prove_transition(state: types.BeamState, block: types.SignedBeamBlock, opts: StateTransitionOpts, allocator: Allocator) !types.BeamSTFProof {
+pub fn prove_transition(state: types.BeamState, block: types.SignedBeamBlock, opts: ZKStateTransitionOpts, allocator: Allocator) !types.BeamSTFProof {
     const prover_input = types.BeamSTFProverInput{
         .state = state,
         .block = block,
@@ -49,7 +49,7 @@ pub fn prove_transition(state: types.BeamState, block: types.SignedBeamBlock, op
     return proof;
 }
 
-pub fn verify_transition(stf_proof: types.BeamSTFProof, state_root: types.Bytes32, block_root: types.Bytes32, opts: StateTransitionOpts) !void {
+pub fn verify_transition(stf_proof: types.BeamSTFProof, state_root: types.Bytes32, block_root: types.Bytes32, opts: ZKStateTransitionOpts) !void {
     _ = state_root;
     _ = block_root;
 

--- a/pkgs/state-proving-manager/src/manager.zig
+++ b/pkgs/state-proving-manager/src/manager.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const ssz = @import("ssz");
 const types = @import("@zeam/types");
 const state_transition = @import("@zeam/state-transition");
+const utils = @import("@zeam/utils");
+
 const Allocator = std.mem.Allocator;
 
 extern fn powdr_prove(serialized: [*]const u8, len: usize, output: [*]u8, output_len: usize, binary_path: [*]const u8, binary_path_length: usize, result_path: [*]const u8, result_path_len: usize) u32;
@@ -18,12 +20,19 @@ const Risc0Config = struct {
     program_path: []const u8,
 };
 
-pub const ZKStateTransitionOpts = union(enum) {
+const ZKVMConfig = union(enum) {
     powdr: PowdrConfig,
     risc0: Risc0Config,
 };
 
+const ZKVMOpts = struct { zkvm: ZKVMConfig };
+
+pub const ZKStateTransitionOpts = utils.MixIn(state_transition.StateTransitionOpts, ZKVMOpts);
+
 pub fn prove_transition(state: types.BeamState, block: types.SignedBeamBlock, opts: ZKStateTransitionOpts, allocator: Allocator) !types.BeamSTFProof {
+    // TODO:  we should also serialize StateTransitionOpts from ZKStateTransitionOpts and feed it to apply
+    // transition in the guest program. it makes sense if opts in future will also carry flags like signatures
+    // validated. Even logging opts would change the execution trace and hence the proof
     const prover_input = types.BeamSTFProverInput{
         .state = state,
         .block = block,
@@ -36,7 +45,7 @@ pub fn prove_transition(state: types.BeamState, block: types.SignedBeamBlock, op
     // allocate a megabyte of data so that we have enough space for the proof.
     // XXX not deallocated yet
     var output = try allocator.alloc(u8, 1024 * 1024);
-    const output_len = switch (opts) {
+    const output_len = switch (opts.zkvm) {
         .powdr => |powdrcfg| powdr_prove(serialized.items.ptr, serialized.items.len, @ptrCast(&output), 256, powdrcfg.program_path.ptr, powdrcfg.program_path.len, powdrcfg.output_dir.ptr, powdrcfg.output_dir.len),
         .risc0 => |risc0cfg| risc0_prove(serialized.items.ptr, serialized.items.len, risc0cfg.program_path.ptr, risc0cfg.program_path.len, output.ptr, output.len),
         // else => @panic("prover isn't enabled"),
@@ -53,7 +62,7 @@ pub fn verify_transition(stf_proof: types.BeamSTFProof, state_root: types.Bytes3
     _ = state_root;
     _ = block_root;
 
-    const valid = switch (opts) {
+    const valid = switch (opts.zkvm) {
         .risc0 => |risc0cfg| risc0_verify(risc0cfg.program_path.ptr, risc0cfg.program_path.len, stf_proof.proof.ptr, stf_proof.proof.len),
         else => return error.UnsupportedVerifier,
     };

--- a/pkgs/state-transition-runtime/src/main.zig
+++ b/pkgs/state-transition-runtime/src/main.zig
@@ -35,7 +35,7 @@ export fn main() noreturn {
     // zkvm.io.print_str(input_dump_str);
 
     // apply the state transition to modify the state
-    state_transition.apply_transition(allocator, &prover_input.state, prover_input.block) catch |e| {
+    state_transition.apply_transition(allocator, &prover_input.state, prover_input.block, .{}) catch |e| {
         var buf: [256]u8 = undefined;
         const errstr = std.fmt.bufPrint(buf[0..], "error running transition function: {any}", .{e}) catch @panic("error running transition function and error coud not be printed");
         @panic(errstr);

--- a/pkgs/state-transition/src/lib.zig
+++ b/pkgs/state-transition/src/lib.zig
@@ -8,9 +8,11 @@ const utils = @import("./utils.zig");
 pub usingnamespace utils;
 
 const transition = @import("./transition.zig");
+
 pub const process_slots = transition.process_slot;
 pub const apply_transition = transition.apply_transition;
 pub const StateTransitionError = transition.StateTransitionError;
+pub const StateTransitionOpts = transition.StateTransitionOpts;
 
 const mockImport = @import("./mock.zig");
 pub const genMockChain = mockImport.genMockChain;

--- a/pkgs/state-transition/src/lib.zig
+++ b/pkgs/state-transition/src/lib.zig
@@ -44,7 +44,7 @@ test "apply transition on mocked chain" {
     for (1..mock_chain.blocks.len) |i| {
         // this is a signed block
         const block = mock_chain.blocks[i];
-        try apply_transition(allocator, &beam_state, block);
+        try apply_transition(allocator, &beam_state, block, .{});
     }
 
     // check the post state root to be equal to block2's stateroot
@@ -97,7 +97,7 @@ test "mock genesis and block production" {
     // TODO: the previous process block should have been run on cloned state so we have the original pre
     // state here to run the state transition. for now regen same genesis state
     var state = try utils.genGenesisState(std.testing.allocator, test_config);
-    try apply_transition(std.testing.allocator, &state, mock_chain.blocks[1]);
+    try apply_transition(std.testing.allocator, &state, mock_chain.blocks[1], .{});
     var post_state_root: [32]u8 = undefined;
     try ssz.hashTreeRoot(types.BeamState, state, &post_state_root, std.testing.allocator);
 
@@ -132,7 +132,7 @@ test "genStateBlockHeader" {
         if (i < mock_chain.blocks.len - 1) {
             // apply the next block
             const block = mock_chain.blocks[i + 1];
-            try apply_transition(allocator, &beam_state, block);
+            try apply_transition(allocator, &beam_state, block, .{});
         }
     }
 }

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -87,10 +87,10 @@ pub fn apply_transition(allocator: Allocator, state: *types.BeamState, signedBlo
     var logger = getLogger();
     logger.setActiveLevel(opts.activeLogLevel);
     const block = signedBlock.message;
-    logger.debug("apply transition stateslot={d} blockslot={d}\n", .{ state.slot, block.slot }) catch @panic("appply transition start log");
+    logger.debug("apply transition stateslot={d} blockslot={d}\n", .{ state.slot, block.slot });
 
     if (block.slot <= state.slot) {
-        logger.debug("slots are invalid for block {any}: {} >= {}\n", .{ block, block.slot, state.slot }) catch @panic("error printing block and state slots");
+        logger.debug("slots are invalid for block {any}: {} >= {}\n", .{ block, block.slot, state.slot });
         return StateTransitionError.InvalidPreState;
     }
 
@@ -107,7 +107,7 @@ pub fn apply_transition(allocator: Allocator, state: *types.BeamState, signedBlo
     var state_root: [32]u8 = undefined;
     try ssz.hashTreeRoot(types.BeamState, state.*, &state_root, allocator);
     if (!std.mem.eql(u8, &state_root, &block.state_root)) {
-        logger.debug("state root={x:02} block root={x:02}\n", .{ state_root, block.state_root }) catch @panic("error printing invalid block root");
+        logger.debug("state root={x:02} block root={x:02}\n", .{ state_root, block.state_root });
         return StateTransitionError.InvalidPostState;
     }
 }

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -11,7 +11,7 @@ const getLogger = zeam_utils.getLogger;
 const params = @import("@zeam/params");
 
 // put the active logs at debug level for now by default
-pub const StateTransitionOpts = struct { activeLevel: std.log.Level = std.log.Level.debug };
+pub const StateTransitionOpts = struct { activeLogLevel: std.log.Level = std.log.Level.debug };
 
 // pub fn process_epoch(state: types.BeamState) void {
 //     // right now nothing to do
@@ -85,7 +85,7 @@ pub fn verify_signatures(signedBlock: types.SignedBeamBlock) !void {
 pub fn apply_transition(allocator: Allocator, state: *types.BeamState, signedBlock: types.SignedBeamBlock, opts: StateTransitionOpts) !void {
     // _ = opts;
     var logger = getLogger();
-    logger.setActiveLevel(opts.activeLevel);
+    logger.setActiveLevel(opts.activeLogLevel);
     const block = signedBlock.message;
     logger.debug("apply transition stateslot={d} blockslot={d}\n", .{ state.slot, block.slot }) catch @panic("appply transition start log");
 

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -1,20 +1,15 @@
 const ssz = @import("ssz");
 const std = @import("std");
-const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const types = @import("@zeam/types");
 pub const utils = @import("./utils.zig");
+
+const zeam_utils = @import("@zeam/utils");
+const log = zeam_utils.zeamLog;
+
 const params = @import("@zeam/params");
 
-fn log(comptime fmt: []const u8, args: anytype) !void {
-    if (builtin.target.os.tag == .freestanding) {
-        const io = @import("zkvm").io;
-        var buf: [512]u8 = undefined;
-        io.print_str(try std.fmt.bufPrint(buf[0..], fmt, args));
-    } else {
-        std.debug.print(fmt, args);
-    }
-}
+pub const StateTransitionOpts = struct { activeLevel: std.log.Level = std.log.Level.info };
 
 // pub fn process_epoch(state: types.BeamState) void {
 //     // right now nothing to do
@@ -87,6 +82,8 @@ pub fn verify_signatures(signedBlock: types.SignedBeamBlock) !void {
 // TODO(gballet) check if beam block needs to be a pointer
 pub fn apply_transition(allocator: Allocator, state: *types.BeamState, signedBlock: types.SignedBeamBlock) !void {
     const block = signedBlock.message;
+    log("apply transition stateslot={d} blockslot={d}\n", .{ state.slot, block.slot }) catch @panic("appply transition start log");
+
     if (block.slot <= state.slot) {
         log("slots are invalid for block {any}: {} >= {}\n", .{ block, block.slot, state.slot }) catch @panic("error printing block and state slots");
         return StateTransitionError.InvalidPreState;

--- a/pkgs/utils/src/lib.zig
+++ b/pkgs/utils/src/lib.zig
@@ -6,3 +6,6 @@ pub usingnamespace mixFactory;
 
 const castFactory = @import("./cast.zig");
 pub usingnamespace castFactory;
+
+const logFactory = @import("./log.zig");
+pub usingnamespace logFactory;

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+// having activeLevel non comptime and dynamic allows us env based logging and even a keystroke activated one
+// on a running client, may be can be revised later
+pub fn log(comptime scope: @Type(.enum_literal), comptime level: std.log.Level, comptime fmt: []const u8, args: anytype, activeLevel: std.log.Level) !void {
+    if (@intFromEnum(level) > @intFromEnum(activeLevel)) {
+        return;
+    }
+
+    const system_prefix = if (builtin.target.os.tag == .freestanding) "zkvm" else "zeam";
+
+    const scope_prefix = "(" ++ switch (scope) {
+        std.log.default_log_scope => system_prefix,
+        else => system_prefix ++ "-" ++ @tagName(scope),
+    } ++ "): ";
+    const prefix = "[" ++ comptime level.asText() ++ "] " ++ scope_prefix;
+
+    if (builtin.target.os.tag == .freestanding) {
+        const io = @import("zkvm").io;
+        var buf: [512]u8 = undefined;
+        io.print_str(try std.fmt.bufPrint(buf[0..], prefix ++ fmt, args));
+    } else {
+        std.debug.lockStdErr();
+        defer std.debug.unlockStdErr();
+        const stderr = std.io.getStdErr().writer();
+        nosuspend stderr.print(prefix ++ fmt, args) catch return;
+    }
+}
+
+pub fn zeamLog(comptime fmt: []const u8, args: anytype) !void {
+    // forcing all logs for now
+    try log(std.log.default_log_scope, std.log.Level.debug, fmt, args, std.log.Level.debug);
+}

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -59,7 +59,7 @@ pub const ZeamLogger = struct {
         self: *Self,
         comptime fmt: []const u8,
         args: anytype,
-    ) !void {
+    ) void {
         return self.logFn(self.scope, self.activeLevel, .err, fmt, args);
     }
 
@@ -67,14 +67,14 @@ pub const ZeamLogger = struct {
         self: *Self,
         comptime fmt: []const u8,
         args: anytype,
-    ) !void {
+    ) void {
         return self.logFn(self.scope, self.activeLevel, .warn, fmt, args);
     }
     pub fn info(
         self: *Self,
         comptime fmt: []const u8,
         args: anytype,
-    ) !void {
+    ) void {
         return self.logFn(self.scope, self.activeLevel, .info, fmt, args);
     }
 
@@ -82,7 +82,7 @@ pub const ZeamLogger = struct {
         self: *Self,
         comptime fmt: []const u8,
         args: anytype,
-    ) !void {
+    ) void {
         return self.logFn(self.scope, self.activeLevel, .debug, fmt, args);
     }
 };

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 
 // having activeLevel non comptime and dynamic allows us env based logging and even a keystroke activated one
 // on a running client, may be can be revised later
-pub fn log(comptime scope: @Type(.enum_literal), comptime level: std.log.Level, comptime fmt: []const u8, args: anytype, activeLevel: std.log.Level) !void {
+pub fn log(comptime scope: @Type(.enum_literal), activeLevel: std.log.Level, comptime level: std.log.Level, comptime fmt: []const u8, args: anytype) !void {
     if (@intFromEnum(level) > @intFromEnum(activeLevel)) {
         return;
     }
@@ -28,7 +28,63 @@ pub fn log(comptime scope: @Type(.enum_literal), comptime level: std.log.Level, 
     }
 }
 
+// just a handy debugging log used in the project
 pub fn zeamLog(comptime fmt: []const u8, args: anytype) !void {
     // forcing all logs for now
-    try log(std.log.default_log_scope, std.log.Level.debug, fmt, args, std.log.Level.debug);
+    try log(std.log.default_log_scope, std.log.Level.debug, std.log.Level.debug, fmt, args);
+}
+
+const ZeamLogger = struct {
+    activeLevel: std.log.Level = std.log.Level.debug,
+    comptime scope: @Type(.enum_literal) = std.log.default_log_scope,
+
+    const Self = @This();
+    pub fn init(comptime scope: @Type(.enum_literal)) Self {
+        return Self{
+            .scope = scope,
+        };
+    }
+
+    pub fn setActiveLevel(self: *Self, newLevel: std.log.Level) void {
+        self.activeLevel = newLevel;
+    }
+
+    pub fn err(
+        self: *Self,
+        comptime fmt: []const u8,
+        args: anytype,
+    ) !void {
+        return log(self.scope, self.activeLevel, .err, fmt, args);
+    }
+
+    pub fn warn(
+        self: *Self,
+        comptime fmt: []const u8,
+        args: anytype,
+    ) !void {
+        return log(self.scope, self.activeLevel, .warn, fmt, args);
+    }
+    pub fn info(
+        self: *Self,
+        comptime fmt: []const u8,
+        args: anytype,
+    ) !void {
+        return log(self.scope, self.activeLevel, .info, fmt, args);
+    }
+
+    pub fn debug(
+        self: *Self,
+        comptime fmt: []const u8,
+        args: anytype,
+    ) !void {
+        return log(self.scope, self.activeLevel, .debug, fmt, args);
+    }
+};
+
+pub fn getScopedLogger(comptime scope: @Type(.enum_literal)) ZeamLogger {
+    return ZeamLogger.init(scope);
+}
+
+pub fn getLogger() ZeamLogger {
+    return ZeamLogger.init(std.log.default_log_scope);
 }

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 
 // having activeLevel non comptime and dynamic allows us env based logging and even a keystroke activated one
 // on a running client, may be can be revised later
-pub fn log(comptime scope: @Type(.enum_literal), activeLevel: std.log.Level, comptime level: std.log.Level, comptime fmt: []const u8, args: anytype) !void {
+pub fn log(comptime scope: @Type(.enum_literal), activeLevel: std.log.Level, comptime level: std.log.Level, comptime fmt: []const u8, args: anytype) void {
     if (@intFromEnum(level) > @intFromEnum(activeLevel)) {
         return;
     }
@@ -18,8 +18,12 @@ pub fn log(comptime scope: @Type(.enum_literal), activeLevel: std.log.Level, com
 
     if (builtin.target.os.tag == .freestanding) {
         const io = @import("zkvm").io;
-        var buf: [512]u8 = undefined;
-        io.print_str(try std.fmt.bufPrint(buf[0..], prefix ++ fmt, args));
+        var buf: [1024]u8 = undefined;
+        // TODO don't throw error because it somehow messes with creation of  noopLogger as noopLog
+        // doesn't throw and somehow it can't seem to infer error types as they might not be same
+        // across all log fns, figure out in a later PR
+        const print_str = std.fmt.bufPrint(buf[0..], prefix ++ fmt, args) catch "error formatting log";
+        io.print_str(print_str);
     } else {
         std.debug.lockStdErr();
         defer std.debug.unlockStdErr();
@@ -31,7 +35,7 @@ pub fn log(comptime scope: @Type(.enum_literal), activeLevel: std.log.Level, com
 // just a handy debugging log used in the project
 pub fn zeamLog(comptime fmt: []const u8, args: anytype) !void {
     // forcing all logs for now
-    try log(std.log.default_log_scope, std.log.Level.debug, std.log.Level.debug, fmt, args);
+    log(std.log.default_log_scope, std.log.Level.debug, std.log.Level.debug, fmt, args);
 }
 
 pub const ZeamLogger = struct {

--- a/resources/zeam.md
+++ b/resources/zeam.md
@@ -75,7 +75,7 @@ functional and testable as well as add unit, end to end as well as E2E tests run
 
 1. `pkgs/state-transition`
  ```zig
-  pub fn apply_transition(state: types.BeamState, block: types.SignedBeamBlock) !void
+  pub fn apply_transition(state: types.BeamState, block: types.SignedBeamBlock, .{}) !void
  ```
 
  - Implements/verifies the basic state transistion in zig

--- a/resources/zeam.md
+++ b/resources/zeam.md
@@ -98,7 +98,7 @@ the state transition
 
 3. `pkgs/state-proving-manager`
  ```zig
-   pub fn execute_transition(state: types.BeamState, block: types.SignedBeamBlock, opts: StateTransitionOpts) types.BeamSTFProof
+   pub fn execute_transition(state: types.BeamState, block: types.SignedBeamBlock, opts: ZKStateTransitionOpts) types.BeamSTFProof
 ```
   - invoked to prove a block against a pre state
   - invokes the requested ZK-VM for executing the `pkgs/state-transition-runtime` riscv5 binary with inputs and 
@@ -106,7 +106,7 @@ the state transition
   - returns the state transition proof
 
 ```zig
-pub fn verify_transition(stf_proof: types.BeamSTFProof, state_root: types.Bytes32, block_root: types.Bytes32, opts: StateTransitionOpts) !void
+pub fn verify_transition(stf_proof: types.BeamSTFProof, state_root: types.Bytes32, block_root: types.Bytes32, opts: ZKStateTransitionOpts) !void
 ```
  - verifies the state transition proof on a pre state root and block root
 - invokes the requested ZK-VM for verifying the `pkgs/state-traansition-runtim` riscv5 binary with inputs constructed


### PR DESCRIPTION
a little abstraction on the logging

can be further extended to creation of the child scopes as well as add file transport in future PR work

result:

```
[debug] (zkvm): apply transition stateslot=0 blockslot=1
state transition completed
proof len=329557
[debug] (zeam): apply transition stateslot=0 blockslot=1
```

so most logs can be converted into this format going forward, even date/time can be added in the beginning so have the logs we are used to see in clients