### PR TITLE
fix: allocator optimized out in risc0

### DIFF
--- a/pkgs/state-transition-runtime/src/risc0/lib.zig
+++ b/pkgs/state-transition-runtime/src/risc0/lib.zig
@@ -30,7 +30,7 @@ pub fn free_input(allocator: std.mem.Allocator, input: []const u8) void {
 }
 
 var fixed_mem = [_]u8{0} ** (128 * 1024 * 1024);
-var fixed_allocator = undefined;
+var fixed_allocator: std.heap.FixedBufferAllocator = undefined;
 var fixed_allocator_initialized = false;
 
 pub fn get_allocator() std.mem.Allocator {

--- a/pkgs/state-transition-runtime/src/risc0/lib.zig
+++ b/pkgs/state-transition-runtime/src/risc0/lib.zig
@@ -30,8 +30,10 @@ pub fn free_input(allocator: std.mem.Allocator, input: []const u8) void {
 }
 
 var fixed_mem = [_]u8{0} ** (128 * 1024 * 1024);
+var fixed_allocator = undefined;
+var fixed_allocator_initialized = false;
 
 pub fn get_allocator() std.mem.Allocator {
-    var fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_mem[0..]);
+    fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_mem[0..]);
     return fixed_allocator.allocator();
 }

--- a/pkgs/state-transition-runtime/src/risc0/lib.zig
+++ b/pkgs/state-transition-runtime/src/risc0/lib.zig
@@ -34,6 +34,9 @@ var fixed_allocator = undefined;
 var fixed_allocator_initialized = false;
 
 pub fn get_allocator() std.mem.Allocator {
-    fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_mem[0..]);
+    if (!fixed_allocator_initialized) {
+        fixed_allocator = std.heap.FixedBufferAllocator.init(fixed_mem[0..]);
+        fixed_allocator_initialized = true;
+    }
     return fixed_allocator.allocator();
 }


### PR DESCRIPTION
This is a tricky aspect of zig that I wasn't aware of until now: if a local variable is stack allocated, and one returns an object with a pointer to it, then the pointer will be dangling and so the compiler will optimize out the call to the allocator optimization.

This is normally never a problem, because at any other time, one is supposed to use the allocator. But in this `FixedBufferAllocator` context, the corner case happens. The fix is to make the fixed buffer allocator a global variable.

In case you ask, I still think a borrow checker is too much trouble for what it brings.