### PR TITLE
risc0 trigger on pr target as main only

### DIFF
--- a/.github/workflows/risc0.yml
+++ b/.github/workflows/risc0.yml
@@ -1,10 +1,11 @@
 on:
   pull_request:
+    branches: [ main ]
   workflow_run:
-    workflows: ["CI"]
+    workflows: [ "CI" ]
     types:
-      - completed
-    branches: [main]
+    - completed
+    branches: [ main ]
 
 name: risc0
 


### PR DESCRIPTION
https://github.com/blockblaz/zeam/issues/41

ci: PRs seem to trigger risc0 workflow when they shouldn't #41
