### PR TITLE
fix:fix build error on macOS since missing link CoreFoundation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -156,6 +156,9 @@ pub fn build(b: *Builder) !void {
     addZkvmGlueLibs(b, cli_exe);
     cli_exe.linkLibC(); // for rust static libs to link
     cli_exe.linkSystemLibrary("unwind"); // to be able to display rust backtraces
+    if (target.result.os.tag == .macos) {
+        cli_exe.linkFramework("CoreFoundation");
+    }
     b.installArtifact(cli_exe);
 
     try build_zkvm_targets(b, &cli_exe.step, target);
@@ -217,6 +220,9 @@ pub fn build(b: *Builder) !void {
         .target = target,
     });
     addZkvmGlueLibs(b, cli_tests);
+    if (target.result.os.tag == .macos) {
+        cli_tests.linkFramework("CoreFoundation");
+    }
     const run_cli_test = b.addRunArtifact(cli_tests);
     test_step.dependOn(&run_cli_test.step);
 

--- a/pkgs/state-transition-runtime/src/risc0/lib.zig
+++ b/pkgs/state-transition-runtime/src/risc0/lib.zig
@@ -73,7 +73,6 @@ fn tagged_struct(tag: []const u8, down: []const [32]u8, data: []const u32) [32]u
     return hash_bytes(buffer[0..total_size]);
 }
 
-
 fn sys_halt(out_state: *const [8]u32, status: u32) noreturn {
     asm volatile ("ecall"
         :


### PR DESCRIPTION
This pull request makes platform-specific improvements to the build process for macOS and includes a minor cleanup in the `lib.zig` file. The primary focus is on ensuring that the necessary macOS frameworks are linked for both the main CLI executable and the CLI tests.

Build system improvements for macOS compatibility:

* [`build.zig`](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR159-R161): Added logic to link the `CoreFoundation` framework when building for macOS, both for the main CLI executable and for CLI tests, ensuring compatibility with macOS system libraries. [[1]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR159-R161) [[2]](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccR223-R225)

Code cleanup:

* [`pkgs/state-transition-runtime/src/risc0/lib.zig`](diffhunk://#diff-a2111c0b4d4fcad243ca6d490e472aaa5ae006820f049bb9b583eac4b85cf5cdL76): Removed an unnecessary blank line for minor code tidiness.