### PR TITLE
Add macOS frameworks to Rust glue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
 
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
 

--- a/build.zig
+++ b/build.zig
@@ -15,8 +15,13 @@ const zkvm_targets: []const zkvmTarget = &.{
 };
 
 // Add the glue libs to a compile target
-fn addZkvmGlueLibs(b: *Builder, comp: *Builder.Step.Compile) void {
+fn addRustGlueLib(b: *Builder, comp: *Builder.Step.Compile, target: Builder.ResolvedTarget) void {
     comp.addObjectFile(b.path("rust/target/release/librustglue.a"));
+    // Add macOS framework linking for CLI tests
+    if (target.result.os.tag == .macos) {
+        comp.linkFramework("CoreFoundation");
+        comp.linkFramework("SystemConfiguration");
+    }
 }
 
 pub fn build(b: *Builder) !void {
@@ -153,19 +158,16 @@ pub fn build(b: *Builder) !void {
     cli_exe.root_module.addImport("@zeam/network", zeam_network);
     cli_exe.root_module.addImport("@zeam/node", zeam_beam_node);
 
-    addZkvmGlueLibs(b, cli_exe);
+    addRustGlueLib(b, cli_exe, target);
     cli_exe.linkLibC(); // for rust static libs to link
     cli_exe.linkSystemLibrary("unwind"); // to be able to display rust backtraces
-
-    // Add macOS framework linking for Core Foundation symbols
-    if (target.result.os.tag == .macos) {
-        cli_exe.linkFramework("CoreFoundation");
-        cli_exe.linkFramework("SystemConfiguration");
-    }
 
     b.installArtifact(cli_exe);
 
     try build_zkvm_targets(b, &cli_exe.step, target);
+
+    var zkvm_host_cmd = build_rust_project(b, "rust");
+    cli_exe.step.dependOn(&zkvm_host_cmd.step);
 
     const run_prover = b.addRunArtifact(cli_exe);
     const prover_step = b.step("run", "Run cli executable");
@@ -207,12 +209,7 @@ pub fn build(b: *Builder) !void {
         .target = target,
     });
     manager_tests.root_module.addImport("@zeam/types", zeam_types);
-    addZkvmGlueLibs(b, manager_tests);
-    // Add macOS framework linking for tests that use Rust glue
-    if (target.result.os.tag == .macos) {
-        manager_tests.linkFramework("CoreFoundation");
-        manager_tests.linkFramework("SystemConfiguration");
-    }
+    addRustGlueLib(b, manager_tests, target);
     const run_manager_test = b.addRunArtifact(manager_tests);
     test_step.dependOn(&run_manager_test.step);
 
@@ -229,12 +226,7 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
         .target = target,
     });
-    addZkvmGlueLibs(b, cli_tests);
-    // Add macOS framework linking for CLI tests
-    if (target.result.os.tag == .macos) {
-        cli_tests.linkFramework("CoreFoundation");
-        cli_tests.linkFramework("SystemConfiguration");
-    }
+    addRustGlueLib(b, cli_tests, target);
     const run_cli_test = b.addRunArtifact(cli_tests);
     test_step.dependOn(&run_cli_test.step);
 
@@ -245,9 +237,7 @@ pub fn build(b: *Builder) !void {
     });
     const run_params_tests = b.addRunArtifact(params_tests);
     test_step.dependOn(&run_params_tests.step);
-
-    var zkvm_host_cmd = build_rust_project(b, "rust");
-    cli_exe.step.dependOn(&zkvm_host_cmd.step);
+    manager_tests.step.dependOn(&zkvm_host_cmd.step);
     cli_tests.step.dependOn(&zkvm_host_cmd.step);
 }
 


### PR DESCRIPTION
Add macOS-specific framework links (`CoreFoundation`, `SystemConfiguration`) in the Rust glue library build to ensure compatibility on macOS targets.