### PR TITLE
ci: add docker workflow to make sure that the image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,24 @@ jobs:
     - name: Test
       # figure out how to build the monorepo builds
       run: zig build test --summary all
+
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch full history to get git commit info
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        push: false  # Don't push, just build to verify
+        tags: zeam:pr-${{ github.event.number }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,6 @@ jobs:
         context: .
         file: ./Dockerfile
         push: false  # Don't push, just build to verify
-        tags: zeam:pr-${{ github.event.number }}
+        tags: zeam:ci-${{ github.run_number }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
   docker-build:
     name: docker-build
     runs-on: ubuntu-latest
+    needs: [lint, build, test]
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,14 @@ RUN curl -L https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz |
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85.0
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install RISC0 toolchain using rzup
-RUN curl -L https://risczero.com/install | bash
+# Install RISC0 toolchain using rzup (only for linux/amd64)
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        curl -L https://risczero.com/install | bash && \
+        export PATH="/root/.risc0/bin:${PATH}" && \
+        rzup install; \
+    fi
 ENV PATH="/root/.risc0/bin:${PATH}"
-RUN rzup install
 
 # Set working directory
 WORKDIR /app
@@ -80,8 +84,8 @@ COPY --from=builder /app/zig-out/ /app/zig-out/
 # Copy runtime resources
 COPY --from=builder /app/resources/ /app/resources/
 
-# Set the zeam binary as the entrypoint
-ENTRYPOINT ["/app/zig-out/bin/zeam"]
+# Set the zeam binary as the entrypoint with beam parameter by default
+ENTRYPOINT ["/app/zig-out/bin/zeam", "beam"]
 
 # IMPORTANT NOTES:
 #


### PR DESCRIPTION
This also disables the installation of risc0 tools when building for non-amd64 target