### PR TITLE
fix: mock network allocation of onloop data

### DIFF
--- a/pkgs/node/src/validator.zig
+++ b/pkgs/node/src/validator.zig
@@ -62,10 +62,9 @@ pub const BeamValidator = struct {
                 .message = block,
                 .signature = [_]u8{0} ** 48,
             };
-            const signed_block_message = try self.allocator.create(networks.GossipMessage);
-            signed_block_message.* = networks.GossipMessage{ .block = signed_block };
+            const signed_block_message = networks.GossipMessage{ .block = signed_block };
             std.debug.print("validator block production slot={any} block={any}\n", .{ slot, signed_block_message });
-            try self.network.publish(signed_block_message);
+            try self.network.publish(&signed_block_message);
         }
     }
 


### PR DESCRIPTION
mock network puts the data on loop and assumed that it would be heap allocated which would outlive the loop scheduling call

this PR removes that assumption by re-cloning data on heap before scheduling it on loop so that the publish caller can independently free the data and the loop completion should independently free that data as well (a TODO)

@noopur23  can you create an issue for freeing of the `publishWrapper` and its data once the onGossip call is done on completion.

