### PR TITLE
feat: add `override_genesis_time` flag in `node` cmd

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -317,6 +317,18 @@ pub fn build(b: *Builder) !void {
     const run_network_tests = b.addRunArtifact(network_tests);
     test_step.dependOn(&run_network_tests.step);
 
+    const configs_tests = b.addTest(.{
+        .root_module = zeam_configs,
+        .optimize = optimize,
+        .target = target,
+    });
+    configs_tests.root_module.addImport("@zeam/utils", zeam_utils);
+    configs_tests.root_module.addImport("@zeam/types", zeam_types);
+    configs_tests.root_module.addImport("@zeam/params", zeam_params);
+    configs_tests.root_module.addImport("yaml", yaml);
+    const run_configs_tests = b.addRunArtifact(configs_tests);
+    test_step.dependOn(&run_configs_tests.step);
+
     manager_tests.step.dependOn(&zkvm_host_cmd.step);
     cli_tests.step.dependOn(&zkvm_host_cmd.step);
 

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -341,3 +341,7 @@ pub fn main() !void {
         },
     }
 }
+
+test {
+    @import("std").testing.refAllDeclsRecursive(@This());
+}

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -93,6 +93,7 @@ const ZeamArgs = struct {
         node: struct {
             help: bool = false,
             custom_genesis: []const u8,
+            override_genesis_time: ?u64,
             node_id: u32 = 0,
             metrics_enable: bool = false,
             metrics_port: u16 = 9667,
@@ -103,6 +104,7 @@ const ZeamArgs = struct {
 
             pub const __messages__ = .{
                 .custom_genesis = "Custom genesis directory path",
+                .override_genesis_time = "Override genesis time in the config.yaml",
                 .node_id = "Node id for this lean node",
                 .metrics_port = "Port to use for publishing metrics",
                 .metrics_enable = "Enable metrics endpoint",
@@ -335,7 +337,7 @@ pub fn main() !void {
             };
             defer start_options.deinit(allocator);
 
-            try node.loadGenesisConfig(allocator, custom_genesis, &start_options);
+            try node.loadGenesisConfig(allocator, custom_genesis, leancmd.override_genesis_time, &start_options);
 
             try node.startNode(allocator, &start_options);
         },

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -44,7 +44,7 @@ pub const StartNodeOptions = struct {
 /// - `nodes.yaml`: Contains the bootnodes in ENR format.
 /// - `validators.yaml`: Contains the validator indices for each node.
 /// The function updates the provided `StartNodeOptions` with the loaded data.
-pub fn loadGenesisConfig(allocator: std.mem.Allocator, path: []const u8, opts: *StartNodeOptions) !void {
+pub fn loadGenesisConfig(allocator: std.mem.Allocator, path: []const u8, override_genesis_time: ?u64, opts: *StartNodeOptions) !void {
     if (std.fs.path.isAbsolute(path)) {
         var dir = try std.fs.openDirAbsolute(path, .{});
         defer dir.close();
@@ -74,7 +74,7 @@ pub fn loadGenesisConfig(allocator: std.mem.Allocator, path: []const u8, opts: *
 
     const bootnodes = try nodesFromYAML(allocator, parsed_bootnodes);
 
-    const genesis_spec = try configs.genesisConfigFromYAML(parsed_config);
+    const genesis_spec = try configs.genesisConfigFromYAML(parsed_config, override_genesis_time);
 
     const validator_indices = try validatorIndicesFromYAML(allocator, opts.node_id, parsed_validators);
 
@@ -230,7 +230,7 @@ pub fn validatorIndicesFromYAML(allocator: std.mem.Allocator, node_id: u32, vali
 test "config yaml parsing" {
     var config1 = try utils_lib.loadFromYAMLFile(std.testing.allocator, "pkgs/cli/src/test/fixtures/config.yaml");
     defer config1.deinit(std.testing.allocator);
-    const genesis_spec = try configs.genesisConfigFromYAML(config1);
+    const genesis_spec = try configs.genesisConfigFromYAML(config1, null);
     try std.testing.expectEqual(9, genesis_spec.num_validators);
     try std.testing.expectEqual(1704085200, genesis_spec.genesis_time);
 

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -246,7 +246,10 @@ test "config yaml parsing" {
     var config3 = try utils_lib.loadFromYAMLFile(std.testing.allocator, "pkgs/cli/src/test/fixtures/nodes.yaml");
     defer config3.deinit(std.testing.allocator);
     const nodes = try nodesFromYAML(std.testing.allocator, config3);
-    defer std.testing.allocator.free(nodes);
+    defer {
+        for (nodes) |node| std.testing.allocator.free(node);
+        std.testing.allocator.free(nodes);
+    }
     try std.testing.expectEqual(3, nodes.len);
     try std.testing.expectEqualStrings("enr:-IW4QA0pljjdLfxS_EyUxNAxJSoGCwmOVNJauYWsTiYHyWG5Bky-7yCEktSvu_w-PWUrmzbc8vYL_Mx5pgsAix2OfOMBgmlkgnY0gmlwhKwUAAGEcXVpY4IfkIlzZWNwMjU2azGhA6mw8mfwe-3TpjMMSk7GHe3cURhOn9-ufyAqy40wEyui", nodes[0]);
     try std.testing.expectEqualStrings("enr:-IW4QNx7F6OKXCmx9igmSwOAOdUEiQ9Et73HNygWV1BbuFgkXZLMslJVgpLYmKAzBF-AO0qJYq40TtqvtFkfeh2jzqYBgmlkgnY0gmlwhKwUAAKEcXVpY4IfkIlzZWNwMjU2azGhA2hqUIfSG58w4lGPMiPp9llh1pjFuoSRUuoHmwNdHELw", nodes[1]);

--- a/pkgs/configs/src/lib.zig
+++ b/pkgs/configs/src/lib.zig
@@ -63,7 +63,7 @@ test "load genesis config from yaml" {
     ;
 
     var yaml: Yaml = .{ .source = yaml_content };
-    errdefer yaml.deinit(std.testing.allocator);
+    defer yaml.deinit(std.testing.allocator);
     try yaml.load(std.testing.allocator);
 
     const genesis_config = try genesisConfigFromYAML(yaml);
@@ -85,7 +85,7 @@ test "custom dev chain" {
         .ignore_unknown_fields = true,
         .allocate = .alloc_if_needed,
     };
-    const dev_options = (try json.parseFromSlice(ChainOptions, arena_allocator.allocator(), dev_spec, options));
+    const dev_options = (try json.parseFromSlice(ChainOptions, arena_allocator.allocator(), dev_spec, options)).value;
 
     const dev_config = try ChainConfig.init(Chain.custom, dev_options);
     std.debug.print("dev config = {any}\n", .{dev_config});

--- a/pkgs/configs/src/lib.zig
+++ b/pkgs/configs/src/lib.zig
@@ -45,9 +45,10 @@ const ChainConfigError = error{
     InvalidChainSpec,
 };
 
-pub fn genesisConfigFromYAML(config: Yaml) !types.GenesisSpec {
+pub fn genesisConfigFromYAML(config: Yaml, override_genesis_time: ?u64) !types.GenesisSpec {
+    const genesis_time: u64 = if (override_genesis_time) |gen_time| gen_time else @intCast(config.docs.items[0].map.get("GENESIS_TIME").?.int);
     const genesis_spec: types.GenesisSpec = .{
-        .genesis_time = @intCast(config.docs.items[0].map.get("GENESIS_TIME").?.int),
+        .genesis_time = genesis_time,
         .num_validators = @intCast(config.docs.items[0].map.get("VALIDATOR_COUNT").?.int),
     };
     return genesis_spec;
@@ -66,11 +67,14 @@ test "load genesis config from yaml" {
     defer yaml.deinit(std.testing.allocator);
     try yaml.load(std.testing.allocator);
 
-    const genesis_config = try genesisConfigFromYAML(yaml);
-    std.debug.print("genesis config = {any}\n", .{genesis_config});
+    const genesis_config = try genesisConfigFromYAML(yaml, null);
 
     try std.testing.expect(genesis_config.genesis_time == 1704085200);
     try std.testing.expect(genesis_config.num_validators == 9);
+
+    const genesis_config_override = try genesisConfigFromYAML(yaml, 1234);
+    try std.testing.expect(genesis_config_override.genesis_time == 1234);
+    try std.testing.expect(genesis_config_override.num_validators == 9);
 }
 
 test "custom dev chain" {


### PR DESCRIPTION
This pull request introduces support for overriding the genesis time via CLI and configuration. At the same time fixs config and node tests not run bug.
