### PR TITLE
feat: load private key from file and pass it rust libp2p bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ CLAUDE.md
 .codeium/
 
 # Log files
-zeam.log
+*.log
 
 # Config files
 prometheus.yml

--- a/build.zig
+++ b/build.zig
@@ -329,6 +329,14 @@ pub fn build(b: *Builder) !void {
     const run_configs_tests = b.addRunArtifact(configs_tests);
     test_step.dependOn(&run_configs_tests.step);
 
+    const utils_tests = b.addTest(.{
+        .root_module = zeam_utils,
+        .optimize = optimize,
+        .target = target,
+    });
+    const run_utils_tests = b.addRunArtifact(utils_tests);
+    test_step.dependOn(&run_utils_tests.step);
+
     manager_tests.step.dependOn(&zkvm_host_cmd.step);
     cli_tests.step.dependOn(&zkvm_host_cmd.step);
 

--- a/pkgs/utils/src/fs.zig
+++ b/pkgs/utils/src/fs.zig
@@ -1,0 +1,93 @@
+const std = @import("std");
+
+/// Checks if a directory exists at the given path.
+/// The path can be absolute or relative to the current working directory.
+/// Returns an error if the directory does not exist or cannot be opened.
+pub fn checkDIRExists(path: []const u8) !void {
+    if (std.fs.path.isAbsolute(path)) {
+        var dir = try std.fs.openDirAbsolute(path, .{});
+        defer dir.close();
+    } else {
+        var dir = try std.fs.cwd().openDir(path, .{});
+        defer dir.close();
+    }
+}
+
+/// Reads the entire content of a file at the given path into a byte slice.
+/// The path can be absolute or relative to the current working directory.
+/// The caller is responsible for freeing the returned byte slice.
+/// `max_bytes` limits the maximum number of bytes to read to prevent excessive memory usage.
+pub fn readFileToEndAlloc(allocator: std.mem.Allocator, file_path: []const u8, max_bytes: usize) ![]u8 {
+    const resolved_path = if (std.fs.path.isAbsolute(file_path))
+        try allocator.dupe(u8, file_path)
+    else
+        try std.fs.cwd().realpathAlloc(allocator, file_path);
+    defer allocator.free(resolved_path);
+
+    const file = try std.fs.openFileAbsolute(resolved_path, .{});
+    defer file.close();
+
+    return try file.readToEndAlloc(allocator, max_bytes);
+}
+
+test "checkDIRExists with absolute path" {
+    const cwd_path = try std.fs.cwd().realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(cwd_path);
+
+    try checkDIRExists(cwd_path);
+}
+
+test "checkDIRExists with relative path" {
+    try checkDIRExists(".");
+}
+
+test "checkDIRExists with created directory" {
+    const test_dir = "fs_test_dir";
+    try std.fs.cwd().makeDir(test_dir);
+    defer std.fs.cwd().deleteDir(test_dir) catch {};
+
+    try checkDIRExists(test_dir);
+}
+
+test "checkDIRExists with non-existent directory" {
+    const result = checkDIRExists("definitely_does_not_exist_12345");
+    try std.testing.expectError(error.FileNotFound, result);
+}
+
+test "readFileToEndAlloc with relative path" {
+    const test_file = "test_read_relative.txt";
+    const test_content = "Hello from relative path!";
+
+    const file = try std.fs.cwd().createFile(test_file, .{});
+    try file.writeAll(test_content);
+    file.close();
+    defer std.fs.cwd().deleteFile(test_file) catch {};
+
+    const content = try readFileToEndAlloc(std.testing.allocator, test_file, 1024);
+    defer std.testing.allocator.free(content);
+
+    try std.testing.expectEqualStrings(test_content, content);
+}
+
+test "readFileToEndAlloc with absolute path" {
+    const test_file = "test_read_absolute.txt";
+    const test_content = "Hello from absolute path!";
+
+    const file = try std.fs.cwd().createFile(test_file, .{});
+    try file.writeAll(test_content);
+    file.close();
+    defer std.fs.cwd().deleteFile(test_file) catch {};
+
+    const abs_path = try std.fs.cwd().realpathAlloc(std.testing.allocator, test_file);
+    defer std.testing.allocator.free(abs_path);
+
+    const content = try readFileToEndAlloc(std.testing.allocator, abs_path, 1024);
+    defer std.testing.allocator.free(content);
+
+    try std.testing.expectEqualStrings(test_content, content);
+}
+
+test "readFileToEndAlloc with non-existent file" {
+    const result = readFileToEndAlloc(std.testing.allocator, "non_existent_file.txt", 1024);
+    try std.testing.expectError(error.FileNotFound, result);
+}

--- a/pkgs/utils/src/lib.zig
+++ b/pkgs/utils/src/lib.zig
@@ -13,3 +13,12 @@ pub usingnamespace logFactory;
 const yaml_factory = @import("./yaml.zig");
 // Avoid to use `usingnamespace` to make upgrade easier in the future.
 pub const loadFromYAMLFile = yaml_factory.loadFromYAMLFile;
+
+const fs_factory = @import("./fs.zig");
+// Avoid to use `usingnamespace` to make upgrade easier in the future.
+pub const checkDIRExists = fs_factory.checkDIRExists;
+pub const readFileToEndAlloc = fs_factory.readFileToEndAlloc;
+
+test {
+    @import("std").testing.refAllDeclsRecursive(@This());
+}

--- a/pkgs/utils/src/yaml.zig
+++ b/pkgs/utils/src/yaml.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Yaml = @import("yaml").Yaml;
+const fs = @import("./fs.zig");
 
 const max_file_size = 1024 * 1024; // 1MB
 
@@ -9,20 +10,7 @@ const max_file_size = 1024 * 1024; // 1MB
 /// Returns a `Yaml` struct containing the parsed content.
 /// The caller is responsible for freeing the resources associated with the `Yaml` struct.
 pub fn loadFromYAMLFile(allocator: Allocator, file_path: []const u8) !Yaml {
-    const resolved_path = if (std.fs.path.isAbsolute(file_path))
-        try allocator.dupe(u8, file_path)
-    else
-        try std.fs.cwd().realpathAlloc(allocator, file_path);
-    defer allocator.free(resolved_path);
-
-    const file = try std.fs.openFileAbsolute(resolved_path, .{});
-    defer file.close();
-
-    if (try file.getEndPos() > max_file_size) {
-        return error.FileTooLarge;
-    }
-
-    const source = try file.readToEndAlloc(allocator, max_file_size);
+    const source = try fs.readFileToEndAlloc(allocator, file_path, max_file_size);
     defer allocator.free(source);
 
     var yaml: Yaml = .{ .source = source };

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3774,6 +3774,7 @@ name = "rustglue"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "hex",
  "libp2p",
  "libp2p-mplex",
  "risc0-zkvm",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ libp2p-mplex = "0.42"
 futures = "0.3.31"
 tokio = { version = "1", features = ["full"] }
 slog = { version = "2", features = ["max_level_debug", "release_max_level_debug", "nested-values"] }
+hex = "0.4.3"
 
 [dependencies.libp2p]
 version = "0.54"


### PR DESCRIPTION
This pull request introduces  a new flag `network_dir` in the `node` command for reading the node private key. Since right now we read ENR from `nodes.yaml` which only includes public key, we must use the consistent private key for starting the p2p module. 

And several improvements and refactorings to the node startup process, configuration loading, and network initialization in the Zig codebase, along with some supporting changes in the Rust bridge and utility modules. 

Also change the `beam` command to generate private key in Zig side and pass it to p2p module as well.

Fix #187 

