### PR TITLE
update to arraylist implementation of ssz list

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .ssz = .{
-            .url = "https://github.com/blockblaz/ssz.zig/archive/2248ecb866e576f8f74af64b7c9aa15c026fec99.tar.gz",
-            .hash = "ssz-0.0.4-Lfwd66ppAgDmm2mFO3cAE7lOCNWaCais2M6lX620ssdO",
+            .url = "https://github.com/blockblaz/ssz.zig/archive/98cd12602e9a0125d76a6a93456dcfeaa30f9950.tar.gz",
+            .hash = "ssz-0.0.4-Lfwd60qdAgDXXMYkQzFYYArXl7IldYDL1JkHUjDBOER-",
         },
         .zigcli = .{
             .url = "https://github.com/jiacai2050/zigcli/archive/v0.2.3.tar.gz",

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -81,7 +81,7 @@ pub const Node = struct {
         chain_options.num_validators = options.genesis_spec.num_validators;
         const chain_config = try ChainConfig.init(Chain.custom, chain_options);
         var anchorState = try sft.genGenesisState(allocator, chain_config.genesis);
-        errdefer anchorState.deinit(allocator);
+        errdefer anchorState.deinit();
 
         // TODO we seem to be needing one loop because then the events added to loop are not being fired
         // in the order to which they have been added even with the an appropriate delay added

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -371,7 +371,7 @@ pub const ForkChoice = struct {
     }
 
     pub fn getProposalVotes(self: *Self) !types.SignedVotes {
-        var included_votes = try types.SignedVotes.init(0);
+        var included_votes = try types.SignedVotes.init(self.allocator);
         const latest_justified = self.fcStore.latest_justified;
 
         // TODO naive strategy to include all votes that are consistent with the latest justified

--- a/pkgs/params/src/presets/mainnet.zig
+++ b/pkgs/params/src/presets/mainnet.zig
@@ -4,10 +4,6 @@ pub const preset = types.PresetConfig{
     .SECONDS_PER_SLOT = 4,
 
     // SSZ capacity constants based on leanSpecs
-    // reduced size of roots limit because of following build issue
-    // caused by super big stack allocated bounded lists
-    // error: warning: mock.zig:27:0: stack frame size (5002379528) exceeds limit (4294967295) in function 'mock.genMockChain'
-    // even beam run command results into core dumped
     .HISTORICAL_ROOTS_LIMIT = 1 << 18, // 2^18 = 262144
     .VALIDATOR_REGISTRY_LIMIT = 1 << 12, // 2^12 = 4096
     .MAX_REQUEST_BLOCKS = 1024,

--- a/pkgs/params/src/presets/mainnet.zig
+++ b/pkgs/params/src/presets/mainnet.zig
@@ -8,7 +8,7 @@ pub const preset = types.PresetConfig{
     // caused by super big stack allocated bounded lists
     // error: warning: mock.zig:27:0: stack frame size (5002379528) exceeds limit (4294967295) in function 'mock.genMockChain'
     // even beam run command results into core dumped
-    .HISTORICAL_ROOTS_LIMIT = 1 << 10, // 2^18 = 262144
-    .VALIDATOR_REGISTRY_LIMIT = 1 << 4, // 2^12 = 4096
+    .HISTORICAL_ROOTS_LIMIT = 1 << 18, // 2^18 = 262144
+    .VALIDATOR_REGISTRY_LIMIT = 1 << 12, // 2^12 = 4096
     .MAX_REQUEST_BLOCKS = 1024,
 };

--- a/pkgs/state-transition/src/mock.zig
+++ b/pkgs/state-transition/src/mock.zig
@@ -233,7 +233,7 @@ pub fn genMockChain(allocator: Allocator, numBlocks: usize, from_genesis: ?types
             .body = types.BeamBlockBody{
                 // .execution_payload_header = .{ .timestamp = timestamp },
                 .attestations = blk: {
-                    var attestations = try types.SignedVotes.init(0);
+                    var attestations = try types.SignedVotes.init(allocator);
                     for (votes.items) |vote| {
                         try attestations.append(vote);
                     }

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -294,12 +294,12 @@ fn loadJustifications(allocator: Allocator, justifications: *std.AutoHashMapUnma
 
 /// Helper function to flatten justifications map back to state arrays
 fn flattenJustifications(allocator: Allocator, justifications: *std.AutoHashMapUnmanaged(types.Root, []u8), state: *types.BeamState) !void {
-    // right now lists are stack allocated bounded array but this will change when we have heap allocated
-    // array lists and will require allocator to reinit
-    _ = allocator;
-    // Clear existing lists
-    state.justifications_roots = try types.JustificationsRoots.init(0);
-    state.justifications_validators = try types.JustificationsValidators.init(0);
+    // Lists are now heap allocated ArrayLists using the allocator
+    // Deinit existing lists and reinitialize
+    state.justifications_roots.deinit();
+    state.justifications_validators.deinit();
+    state.justifications_roots = try types.JustificationsRoots.init(allocator);
+    state.justifications_validators = try types.JustificationsValidators.init(allocator);
 
     // First, collect all keys
     var iterator = justifications.iterator();

--- a/pkgs/state-transition/src/utils.zig
+++ b/pkgs/state-transition/src/utils.zig
@@ -64,14 +64,14 @@ pub fn genGenesisBlock(allocator: Allocator, genesis_state: types.BeamState) !ty
         .body = types.BeamBlockBody{
             // .execution_payload_header = .{ .timestamp = 0 },
             // 3sf mini
-            .attestations = try types.SignedVotes.init(0),
+            .attestations = try types.SignedVotes.init(allocator),
         },
     };
 
     return genesis_latest_block;
 }
 
-pub fn genGenesisLatestBlock() !types.BeamBlock {
+pub fn genGenesisLatestBlock(allocator: Allocator) !types.BeamBlock {
     const genesis_latest_block = types.BeamBlock{
         .slot = 0,
         .proposer_index = 0,
@@ -80,7 +80,7 @@ pub fn genGenesisLatestBlock() !types.BeamBlock {
         .body = types.BeamBlockBody{
             // .execution_payload_header = .{ .timestamp = 0 },
             // 3sf mini votes
-            .attestations = try types.SignedVotes.init(0),
+            .attestations = try types.SignedVotes.init(allocator),
         },
     };
 
@@ -88,7 +88,7 @@ pub fn genGenesisLatestBlock() !types.BeamBlock {
 }
 
 pub fn genGenesisState(allocator: Allocator, genesis: types.GenesisSpec) !types.BeamState {
-    const genesis_latest_block = try genGenesisLatestBlock();
+    const genesis_latest_block = try genGenesisLatestBlock(allocator);
 
     const state = types.BeamState{
         .config = .{
@@ -100,11 +100,11 @@ pub fn genGenesisState(allocator: Allocator, genesis: types.GenesisSpec) !types.
         // mini3sf
         .latest_justified = .{ .root = [_]u8{0} ** 32, .slot = 0 },
         .latest_finalized = .{ .root = [_]u8{0} ** 32, .slot = 0 },
-        .historical_block_hashes = try types.HistoricalBlockHashes.init(0),
-        .justified_slots = try types.JustifiedSlots.init(0),
+        .historical_block_hashes = try types.HistoricalBlockHashes.init(allocator),
+        .justified_slots = try types.JustifiedSlots.init(allocator),
         // justifications map is empty
-        .justifications_roots = try ssz.utils.List(types.Root, params.HISTORICAL_ROOTS_LIMIT).init(0),
-        .justifications_validators = try ssz.utils.Bitlist(params.HISTORICAL_ROOTS_LIMIT * params.VALIDATOR_REGISTRY_LIMIT).init(0),
+        .justifications_roots = try ssz.utils.List(types.Root, params.HISTORICAL_ROOTS_LIMIT).init(allocator),
+        .justifications_validators = try ssz.utils.Bitlist(params.HISTORICAL_ROOTS_LIMIT * params.VALIDATOR_REGISTRY_LIMIT).init(allocator),
     };
 
     return state;


### PR DESCRIPTION
## Summary

Migrate SSZ types from BoundedArray to ArrayList for dynamic memory management

## Changes

- Updated SSZ dependency to latest version with ArrayList support
- Migrated BeamState lists (justifications_roots, justifications_validators, historical_block_hashes, justified_slots) from stack-allocated BoundedArray to heap-allocated ArrayList
- Fixed memory management in `flattenJustifications()` - now properly deinits existing lists before reinitializing to prevent memory leaks
- Updated `BeamState.deinit()` to clean up all ArrayList fields without requiring allocator parameter

