### PR TITLE
limit CI concurrency to cancel previous runs on new commit on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# only one can run at a time in PRs
+concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 name: CI
 
 jobs:

--- a/.github/workflows/risc0.yml
+++ b/.github/workflows/risc0.yml
@@ -5,6 +5,11 @@ on:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
 
+# only one can run at a time in PRs
+concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 name: risc0
 


### PR DESCRIPTION
if there are consecutive commits pushed to github within a short timespan, CI runs on all the commits.
this PR makes the CI cancel previous runs.

however this will not change any effect on PR merges in main because we do want CI to run and finish on all the PR merges in main.