### PR TITLE
feat: implement snappy for gossip objects follow the spec

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -71,10 +71,10 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
     }).module("yaml");
 
-    const snappyframesz = b.dependency("snappyframesz", .{
+    const snappyz = b.dependency("zig_snappy", .{
         .target = target,
         .optimize = optimize,
-    }).module("snappyframesz.zig");
+    }).module("snappyz");
 
     // add zeam-utils
     const zeam_utils = b.addModule("@zeam/utils", .{
@@ -164,7 +164,7 @@ pub fn build(b: *Builder) !void {
     zeam_network.addImport("xev", xev);
     zeam_network.addImport("ssz", ssz);
     zeam_network.addImport("multiformats", multiformats);
-    zeam_network.addImport("snappyframesz", snappyframesz);
+    zeam_network.addImport("snappyz", snappyz);
 
     // add beam node
     const zeam_beam_node = b.addModule("@zeam/node", .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zeam,
-    .fingerprint = 0x243fd12ce9ee69c2,
+    .fingerprint = 0x243fd12c24350f93,
     .version = "0.0.0",
     .dependencies = .{
         .ssz = .{
@@ -31,9 +31,9 @@
             .url = "git+https://github.com/kubkon/zig-yaml#a37be441b042d8aa119213f82f715c0dd1019655",
             .hash = "zig_yaml-0.1.0-C1161hmEAgBeNkAzDaTpcf-2HBydmS1KpJ6FVfGIZfr_",
         },
-        .snappyframesz = .{
-            .url = "git+https://github.com/blockblaz/snappyframesz#416f93e110c934107a9f2e80bc5637ad65eed2fb",
-            .hash = "snappyframesz-0.0.1-COCLy_4tAAD8bqTGdkqyEMS60Dzt5lGnfeDe3iwiVtvE",
+        .zig_snappy = .{
+            .url = "git+https://github.com/blockblaz/zig-snappy#dd63108bd8e41c7cd799385dd9aa5085314eeafa",
+            .hash = "zig_snappy-0.0.1-bDFzXpJWAAA3c5bLc8JZK_HCwd0mGLTuFgz4LndjnVao",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
This pull request introduces Snappy compression support for network message handling in the `ethlibp2p` Zig module. The main changes include integrating the `zig-snappy` dependency, updating the build system to support it, and modifying message serialization and deserialization to use Snappy compression and decompression. This improves network efficiency and robustness by compressing outgoing messages and handling decompression errors gracefully.

Fix #219 