### PR TITLE
minimal-process_attestation-test-port

### DIFF
--- a/pkgs/state-transition/src/lib.zig
+++ b/pkgs/state-transition/src/lib.zig
@@ -16,6 +16,9 @@ pub const StateTransitionError = transition.StateTransitionError;
 pub const StateTransitionOpts = transition.StateTransitionOpts;
 pub const is_justifiable_slot = transition.is_justifiable_slot;
 pub const verify_signatures = transition.verify_signatures;
+pub const process_slots = transition.process_slots;
+pub const process_block = transition.process_block;
+pub const process_attestations = transition.process_attestations;
 
 const mockImport = @import("./mock.zig");
 pub const genMockChain = mockImport.genMockChain;

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -40,7 +40,7 @@ fn process_slot(allocator: Allocator, state: *types.BeamState) !void {
 }
 
 // prepare the state to be pre state of the slot
-fn process_slots(allocator: Allocator, state: *types.BeamState, slot: types.Slot, logger: zeam_utils.ModuleLogger) !void {
+pub fn process_slots(allocator: Allocator, state: *types.BeamState, slot: types.Slot, logger: zeam_utils.ModuleLogger) !void {
     if (slot <= state.slot) {
         logger.err("Invalid block slot={d} >= pre-state slot={d}\n", .{ slot, state.slot });
         return StateTransitionError.InvalidPreState;
@@ -140,7 +140,7 @@ fn process_operations(allocator: Allocator, state: *types.BeamState, block: type
     try process_attestations(allocator, state, block.body.attestations, logger);
 }
 
-fn process_attestations(allocator: Allocator, state: *types.BeamState, attestations: types.SignedVotes, logger: zeam_utils.ModuleLogger) !void {
+pub fn process_attestations(allocator: Allocator, state: *types.BeamState, attestations: types.SignedVotes, logger: zeam_utils.ModuleLogger) !void {
     logger.debug("process attestations slot={d} \n prestate:historical hashes={d} justified slots ={d} votes={d}, ", .{ state.slot, state.historical_block_hashes.len(), state.justified_slots.len(), attestations.constSlice().len });
     logger.debug("prestate justified={any} finalized={any}", .{ state.latest_justified, state.latest_finalized });
 
@@ -153,8 +153,8 @@ fn process_attestations(allocator: Allocator, state: *types.BeamState, attestati
         while (iterator.next()) |entry| {
             allocator.free(entry.value_ptr.*);
         }
+        justifications.deinit(allocator);
     }
-    errdefer justifications.deinit(allocator);
     try state.getJustification(allocator, &justifications);
 
     // need to cast to usize for slicing ops but does this makes the STF target arch dependent?
@@ -263,7 +263,7 @@ fn process_attestations(allocator: Allocator, state: *types.BeamState, attestati
     logger.debug("poststate: justified={any} finalized={any}", .{ state.latest_justified, state.latest_finalized });
 }
 
-fn process_block(allocator: Allocator, state: *types.BeamState, block: types.BeamBlock, logger: zeam_utils.ModuleLogger) !void {
+pub fn process_block(allocator: Allocator, state: *types.BeamState, block: types.BeamBlock, logger: zeam_utils.ModuleLogger) !void {
     // start block processing
     try process_block_header(allocator, state, block, logger);
     // PQ devner-0 has no execution


### PR DESCRIPTION
## Summary

This PR adds the spectest: [`test_process_attestations_justification_and_finalization`](test_process_attestations_justification_and_finalization) for `process_attestations` from lean-specs. In the current form:

- just ports the test
- the process_attestation function needs to be ported over to BeamState(creates circular dependency)

The idea is to highlight the mismatch between the failure due to design differences.