### PR TITLE
Meterics for lean_head_slot

### DIFF
--- a/pkgs/api/README.md
+++ b/pkgs/api/README.md
@@ -26,6 +26,11 @@ The following metrics are currently available:
   - **Description**: Measures the time taken to process a block in the state transition function.
   - **Labels**: None.
 
+- **`lean_head_slot`** (Gauge)
+  - **Description**: Latest slot of the lean chain (canonical chain head as determined by fork choice).
+  - **Labels**: None.
+  - **Sample Collection Event**: Updated on every fork choice head update.
+
 ## How It Works
 
 The API system is initialized at application startup in `pkgs/cli/src/main.zig`. 

--- a/pkgs/api/src/lib.zig
+++ b/pkgs/api/src/lib.zig
@@ -34,9 +34,11 @@ var g_initialized: bool = false;
 const Metrics = struct {
     chain_onblock_duration_seconds: ChainHistogram,
     block_processing_duration_seconds: BlockProcessingHistogram,
+    lean_head_slot: LeanHeadSlotGauge,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const BlockProcessingHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
+    const LeanHeadSlotGauge = metrics_lib.Gauge(u64);
 };
 
 /// Timer struct returned to the application.
@@ -96,6 +98,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .chain_onblock_duration_seconds = Metrics.ChainHistogram.init("chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .block_processing_duration_seconds = Metrics.BlockProcessingHistogram.init("block_processing_duration_seconds", .{ .help = "Time taken to process a block in the state transition function." }, .{}),
+        .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain." }, .{}),
     };
 
     g_initialized = true;
@@ -120,6 +123,13 @@ pub const routes = @import("./routes.zig");
 // Event system modules
 pub const events = @import("./events.zig");
 pub const event_broadcaster = @import("./event_broadcaster.zig");
+
+/// Sets the lean head slot metric.
+/// This should be called whenever the fork choice head is updated.
+pub fn setLeanHeadSlot(slot: u64) void {
+    if (!g_initialized or isZKVM()) return;
+    metrics.lean_head_slot.set(slot);
+}
 
 // Compatibility functions for the old API
 pub fn chain_onblock_duration_seconds_start() Timer {

--- a/pkgs/api/src/noop.zig
+++ b/pkgs/api/src/noop.zig
@@ -30,6 +30,10 @@ pub fn startListener(allocator: std.mem.Allocator, port: u16) !void {
     _ = port;
 }
 
+pub fn setLeanHeadSlot(slot: u64) void {
+    _ = slot;
+}
+
 pub fn chain_onblock_duration_seconds_start() Timer {
     return chain_onblock_duration_seconds.start();
 }

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -7,6 +7,7 @@ const types = @import("@zeam/types");
 const configs = @import("@zeam/configs");
 const zeam_utils = @import("@zeam/utils");
 const stf = @import("@zeam/state-transition");
+const api = @import("@zeam/api");
 
 const constants = @import("./constants.zig");
 
@@ -466,6 +467,8 @@ pub const ForkChoice = struct {
 
     pub fn updateHead(self: *Self) !ProtoBlock {
         self.head = try self.computeFCHead(true, 0);
+        // Update the lean_head_slot metric
+        api.setLeanHeadSlot(self.head.slot);
         return self.head;
     }
 


### PR DESCRIPTION
Closes this https://github.com/blockblaz/zeam/issues/277
lean_head_slot
<img width="1291" height="782" alt="Screenshot 2025-10-04 at 10 53 41" src="https://github.com/user-attachments/assets/aafd0c20-da8d-40f9-b6fe-f3e4df1aa44a" />

increase(lean_head_slot[5m])
<img width="1291" height="782" alt="Screenshot 2025-10-04 at 10 56 38" src="https://github.com/user-attachments/assets/417f8995-94a5-436a-b20e-cdde892244b5" />

3. delta(lean_head_slot[1m])
<img width="1291" height="782" alt="Screenshot 2025-10-04 at 10 57 22" src="https://github.com/user-attachments/assets/bdde0194-0d42-49e7-84e3-f236a14dd348" />

