### PR TITLE
fix: fix the gossipsub config follow the spec

### DIFF
--- a/rust/src/libp2p_bridge.rs
+++ b/rust/src/libp2p_bridge.rs
@@ -371,20 +371,23 @@ impl Behaviour {
 
         // Set a custom gossipsub configuration
         let gossipsub_config = gossipsub::ConfigBuilder::default()
-            // .heartbeat_interval(Duration::from_secs(10)) // This is set to aid debugging by not cluttering the log space
-            .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message
-            // signing)
+            .mesh_n(8)
+            .mesh_n_low(6)
+            .mesh_n_high(12)
+            .gossip_lazy(6)
+            .heartbeat_interval(Duration::from_millis(700))
+            .validation_mode(gossipsub::ValidationMode::Anonymous)
+            .history_length(6)
+            .duplicate_cache_time(Duration::from_secs(3 * 4 * 2))
             .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
             .build()
             .unwrap();
         // .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
 
         // build a gossipsub network behaviour
-        let gossipsub = gossipsub::Behaviour::new(
-            gossipsub::MessageAuthenticity::Signed(key.clone()),
-            gossipsub_config,
-        )
-        .unwrap();
+        let gossipsub =
+            gossipsub::Behaviour::new(gossipsub::MessageAuthenticity::Anonymous, gossipsub_config)
+                .unwrap();
 
         Self {
             identify: identify::Behaviour::new(identify::Config::new(


### PR DESCRIPTION
Fix the sign/validation policy bug found in the interop test