### PR TITLE
fix: missing symbols in tests on aarch64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,8 @@ const zkvm_targets: []const zkvmTarget = &.{
 // Add the glue libs to a compile target
 fn addRustGlueLib(b: *Builder, comp: *Builder.Step.Compile, target: Builder.ResolvedTarget) void {
     comp.addObjectFile(b.path("rust/target/release/librustglue.a"));
+    comp.linkLibC();
+    comp.linkSystemLibrary("unwind"); // to be able to display rust backtraces
     // Add macOS framework linking for CLI tests
     if (target.result.os.tag == .macos) {
         comp.linkFramework("CoreFoundation");


### PR DESCRIPTION
Tests are failing on my local machine, complaining about missing symbols. It seems that this is connected to tests not linking against libunwind and libc. It's strange this wasn't caught by CI.