### PR TITLE
Fix: peer discovery race condition during initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ prometheus.yml
 # Data files (RocksDB)
 data/
 .DS_Store
+
+# VSCode files
+.vscode/

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -81,10 +81,6 @@ pub const BeamNode = struct {
             .logger = opts.logger_config.logger(.node),
             .connected_peers = connected_peers,
         };
-
-        // Subscribe to peer events
-        const peer_handler = self.getPeerEventHandler();
-        try opts.backend.peers.subscribe(peer_handler);
     }
 
     pub fn deinit(self: *Self) void {
@@ -263,6 +259,10 @@ pub const BeamNode = struct {
         const handler = try self.getOnGossipCbHandler();
         var topics = [_]networks.GossipTopic{ .block, .vote };
         try self.network.backend.gossip.subscribe(&topics, handler);
+
+        // Subscribe to peer events
+        const peer_handler = self.getPeerEventHandler();
+        try self.network.backend.peers.subscribe(peer_handler);
 
         const chainOnSlot = try self.getOnIntervalCbWrapper();
         try self.clock.subscribeOnSlot(chainOnSlot);


### PR DESCRIPTION
Previously, the network was started before the nodes, causing peer connections to occur before Node subscribed to network events. As a result, the peer map wasn’t updated, and `./zig-out/bin/zeam` beam showed 0 peers.

This change ensures that node startup happens before network startup so that Node is properly subscribed when peer connections are established.