### PR TITLE
use github action cache, in order to avoid having to download the packages each time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       with:
         version: 0.14.1
 
+    - name: Cache Zig packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/zig
+        key: ${{ runner.os }}-zig-packages-${{ hashFiles('build.zig.zon') }}
+        restore-keys: |
+          ${{ runner.os }}-zig-packages-
+
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
@@ -64,6 +72,14 @@ jobs:
       with:
         version: 0.14.1
 
+    - name: Cache Zig packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/zig
+        key: ${{ runner.os }}-zig-packages-${{ hashFiles('build.zig.zon') }}
+        restore-keys: |
+          ${{ runner.os }}-zig-packages-
+
     - name: build
       run: zig build all
 
@@ -80,6 +96,14 @@ jobs:
       uses: mlugg/setup-zig@v2.0.5
       with:
         version: 0.14.1
+
+    - name: Cache Zig packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/zig
+        key: ${{ runner.os }}-zig-packages-${{ hashFiles('build.zig.zon') }}
+        restore-keys: |
+          ${{ runner.os }}-zig-packages-
 
     - name: Run all unit tests
       run: zig build test --summary all

--- a/.github/workflows/risc0.yml
+++ b/.github/workflows/risc0.yml
@@ -27,6 +27,14 @@ jobs:
       with:
         version: 0.14.1
 
+    - name: Cache Zig packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/zig
+        key: ${{ runner.os }}-zig-packages-${{ hashFiles('build.zig.zon') }}
+        restore-keys: |
+          ${{ runner.os }}-zig-packages-
+
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:


### PR DESCRIPTION
This is a take that is complementary to #309. Ensure that the zig cache is being saved, so that it limits the need for downloading it every time.

Note that this is **NOT** going to solve two of the major problems:

 1. the slow build in docker
 2. the package download failures _inside_ docker