### PR TITLE
fix: transition steps depends on hashsig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -519,10 +519,11 @@ pub fn build(b: *Builder) !void {
     spectests.root_module.addImport("ssz", ssz);
 
     manager_tests.step.dependOn(&build_rust_lib_steps.step);
-    cli_tests.step.dependOn(&build_rust_lib_steps.step);
+
     network_tests.step.dependOn(&build_rust_lib_steps.step);
     node_tests.step.dependOn(&build_rust_lib_steps.step);
     transition_tests.step.dependOn(&build_rust_lib_steps.step);
+    addRustGlueLib(b, transition_tests, target, prover);
 
     const tools_test_step = b.step("test-tools", "Run zeam tools tests");
     const tools_cli_tests = b.addTest(.{


### PR DESCRIPTION
`transition_tests` were not dependent on building the libraries, which introduced a race condition that would break the build. See #357, #356 and #360 for an example of failing builds.