### PR TITLE
fix: fix block by root not found

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -558,7 +558,7 @@ pub const BeamChain = struct {
     }
 
     /// Update block database with block, state, and slot indices
-    fn updateBlockDb(self: *Self, signedBlock: types.SignedBlockWithAttestation, blockRoot: types.Root, postState: types.BeamState, slot: types.Slot, finalizedSlot: types.Slot) !void {
+    pub fn updateBlockDb(self: *Self, signedBlock: types.SignedBlockWithAttestation, blockRoot: types.Root, postState: types.BeamState, slot: types.Slot, finalizedSlot: types.Slot) !void {
         var batch = self.db.initWriteBatch();
         defer batch.deinit();
 


### PR DESCRIPTION
This pull request enhances the logic for persisting produced blocks to the database in the node implementation. It makes the block database update function publicly accessible and ensures that blocks already present in fork choice are consistently persisted to the database, with improved error handling and logging.

**Block persistence improvements:**

* Changed the debug log message to clarify that blocks already in fork choice are now being persisted to the database, improving observability.
* Added logic to persist produced blocks to the database if their post state is available in the cache, with error handling for missing post state or database failures.
* Improved error logging for cases where the post state required for persistence is not found in the cache.

**API visibility changes:**

* Made the `updateBlockDb` function in `BeamChain` public to allow external calls for block persistence.
 
Fix #433 