### PR TITLE
docs: add note about proxy env vars causing build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ at the root of the repository.
 > zig build -Doptimize=ReleaseFast install run -- prove
 ```
 
+#### Troubleshooting
+
+**Build fails with `EndOfStream` error**
+
+If you encounter errors like:
+```
+error: invalid HTTP response: EndOfStream
+```
+
+This may be caused by proxy environment variables interfering with Zig's HTTP client (related to the [Zig HTTP connection pool bug](https://github.com/ziglang/zig/issues/21316) mentioned above).
+
+Try building without proxy settings:
+```bash
+env -u https_proxy -u HTTPS_PROXY -u http_proxy -u HTTP_PROXY \
+    -u all_proxy -u ALL_PROXY -u no_proxy -u NO_PROXY \
+    zig build -Doptimize=ReleaseFast
+```
+
 ### Local Lean Devnet
 
 To run a local devnet with multiple nodes for testing and development, see the [Local Devnet Setup Guide](./pkgs/cli/test/fixtures/README.md) which provides detailed instructions for running a 2-node setup with finalization.


### PR DESCRIPTION
I got `error: invalid HTTP response: EndOfStream` when building. The way of dealing with it is unsetting proxy env vars. It works for me. I think, it's related to the Zig HTTP issue mentioned before, so I added a troubleshooting note for this.