### PR TITLE
update snappy deps

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -36,12 +36,12 @@
             .hash = "rocksdb-9.7.4-z_CUTmO5AAD0CQ2ZvShSDZHjC2x9MKrTnpvbNAIU7ah0",
         },
         .zig_snappy = .{
-            .url = "git+https://github.com/blockblaz/zig-snappy#6084220140937f5909090eb75199c6a3430cc277",
-            .hash = "zig_snappy-0.0.1-bDFzXpRWAAB7OvKIiOndOdHZPK8Sg1U5pboBywo-pj2y",
+            .url = "https://github.com/blockblaz/zig-snappy/archive/77cb4c2a0e0c337a40454f62590459e671bc74bc.tar.gz",
+            .hash = "zig_snappy-0.0.1-bDFzXvtdAAAO8v80PSHrSZauByEckEZGYjWjJL8gWlvO",
         },
         .snappyframesz = .{
-            .url = "https://github.com/blockblaz/snappyframesz/archive/78e66c2d42dc44dd1177ad007e28838a82157aa3.tar.gz",
-            .hash = "snappyframesz-0.0.1-COCLy9EQBADDWj8BS-OdrIFOwHfiY9KUUiClsyBHgETn",
+            .url = "https://github.com/blockblaz/snappyframesz/archive/b7bfa2b46c656977e89aac54a95eb041f656104d.tar.gz",
+            .hash = "snappyframesz-0.0.1-COCLy_IQBAAORhLHhOU2D5bJwydiLh5asdzOxo79zuc5",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
### Summary

This PR updates [zig-snappy](https://github.com/blockblaz/zig-snappy) and [snappyframesz](https://github.com/blockblaz/snappyframesz) to their latest version. These version provide higher stability and introduce bug fixes for https://github.com/blockblaz/zeam/issues/465