### PR TITLE
fix: Remove Cargo.lock from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,6 @@ zig-cache/
 # Rust/Cargo artifacts
 target/
 **/*.rs.bk
-Cargo.lock
-**/Cargo.lock
 
 # IDE and editor files
 .vscode/


### PR DESCRIPTION
The docker build is failing due to API changes in the fiat-shamir dependency. The ProverState and VerifierState structs changed from 3 generic arguments to 2, and the new function signature changed.

Cargo was in the .dockerignore file, which causes Cargo to regenerate the lockfile during Docker build, pulling the latest (incompatible) versions of dependencies instead of the pinned versions.