### PR TITLE
add buildTreeVisualization tests and fix applyDeltas bug

### DIFF
--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -3064,7 +3064,7 @@ test "rebase: bestChild/bestDescendant null handled in rebase (issue #545)" {
 
     // applyDeltas with cutoff_weight=1 can leave some nodes with bestChild set, bestDescendant null
     const deltas = try ctx.fork_choice.computeDeltas(true);
-    try ctx.fork_choice.protoArray.applyDeltas(deltas, 1);
+    try ctx.fork_choice.applyDeltas(deltas, 1);
 
     // Rebase to C — must not panic (previously hit "null best descendant for a non null best child")
     try ctx.fork_choice.rebase(createTestRoot(0xCC), null);


### PR DESCRIPTION
closes https://github.com/blockblaz/zeam/issues/546
Unit tests (tree_visualizer.zig):
  - Empty array, single root, linear chain, forks, missing slots
  - Depth/branch truncation with ... markers
  - Multiple roots, recency sorting, printSlot-style fork scenarios

  Integration test (chain.zig):
  - Exercises full pipeline: genMockChain → BeamChain.init → onBlock → snapshot() → buildTreeVisualization
  - Asserts output contains slot markers (0), (1), (2)
  - Verifies chain connectors and absence of fork indicators for linear chain