### PR TITLE
fix: deadlock and SSZ list for BlockByRootRequest

### DIFF
--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -342,7 +342,7 @@ pub const ReqRespRequest = union(LeanSupportedProtocol) {
     pub fn toJson(self: *const ReqRespRequest, allocator: Allocator) !json.Value {
         return switch (self.*) {
             .status => |status| status.toJson(allocator),
-            .blocks_by_root => |request| request.toJson(allocator),
+            .blocks_by_root => |request| types.blockByRootRequestToJson(&request, allocator),
         };
     }
 
@@ -369,16 +369,14 @@ pub const ReqRespRequest = union(LeanSupportedProtocol) {
     fn initPayload(comptime tag: LeanSupportedProtocol, allocator: Allocator) !std.meta.TagPayload(Self, tag) {
         const PayloadType = std.meta.TagPayload(Self, tag);
         return switch (tag) {
-            .blocks_by_root => PayloadType{
-                .roots = try ssz.utils.List(types.Root, consensus_params.MAX_REQUEST_BLOCKS).init(allocator),
-            },
+            .blocks_by_root => try PayloadType.init(allocator),
             inline else => @as(PayloadType, undefined),
         };
     }
 
     fn deinitPayload(comptime tag: LeanSupportedProtocol, payload: *std.meta.TagPayload(Self, tag)) void {
         switch (tag) {
-            .blocks_by_root => payload.roots.deinit(),
+            .blocks_by_root => payload.deinit(),
             inline else => {},
         }
     }

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -169,12 +169,12 @@ pub const Network = struct {
         if (roots.len == 0) return error.NoBlockRootsRequested;
 
         var request = networks.ReqRespRequest{
-            .blocks_by_root = .{ .roots = try ssz.utils.List(types.Root, params.MAX_REQUEST_BLOCKS).init(self.allocator) },
+            .blocks_by_root = try types.BlockByRootRequest.init(self.allocator),
         };
         errdefer request.deinit();
 
         for (roots) |root| {
-            try request.blocks_by_root.roots.append(root);
+            try request.blocks_by_root.append(root);
         }
 
         const request_id = try self.backend.reqresp.sendRequest(peer_id, &request, callback);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -698,7 +698,7 @@ pub const BeamNode = struct {
 
         switch (data.*) {
             .blocks_by_root => |request| {
-                const roots = request.roots.constSlice();
+                const roots = request.constSlice();
 
                 self.logger.debug(
                     "node-{d}:: Handling blocks_by_root request for {d} roots",

--- a/pkgs/types/src/lib.zig
+++ b/pkgs/types/src/lib.zig
@@ -13,6 +13,8 @@ pub const aggregationBitsToValidatorIndices = attestation.aggregationBitsToValid
 
 const block = @import("./block.zig");
 pub const BlockByRootRequest = block.BlockByRootRequest;
+pub const blockByRootRequestToJson = block.blockByRootRequestToJson;
+pub const blockByRootRequestToJsonString = block.blockByRootRequestToJsonString;
 pub const ProtoBlock = block.ProtoBlock;
 pub const BeamBlock = block.BeamBlock;
 pub const ExecutionPayloadHeader = block.ExecutionPayloadHeader;


### PR DESCRIPTION
## Summary
Refactors `BlockByRootRequest` to match devnet-2 spec where it's encoded as a raw SSZ list instead of a container.

## Changes
- Changed `BlockByRootRequest` from struct to `ssz.utils.List(Root, MAX_REQUEST_BLOCKS)`
- Converted `toJson` methods to standalone helper functions
- Updated all usages across network, node, and interface modules

## Spec Compliance
Per Ethereum consensus spec: "For objects containing a single field, only the field is SSZ-encoded not a container with a single field."

## Test Plan
- [x] Build succeeds
- [ ] Network sync tested on devnet-2