### PR TITLE
fix: patch Zig stdlib to avoid Rosetta 128-bit arithmetic bug in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN ZIG_VERSION="0.15.2" && \
     esac && \
     curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz" | tar -xJ && \
     mv "zig-${ZIG_ARCH}-linux-${ZIG_VERSION}" /opt/zig && \
-    ln -s /opt/zig/zig /usr/local/bin/zig
+    ln -s /opt/zig/zig /usr/local/bin/zig && \
+    sed -i 's/const j: MinInt = @intCast(r\.intRangeLessThan(Index, i, max));/const j: MinInt = i + @as(MinInt, @intCast(r.int(Index) % @as(Index, @intCast(max - i))));/' /opt/zig/lib/std/Random.zig
 
 # Install Rust nightly (required by build.zig which uses +nightly)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly


### PR DESCRIPTION
## Summary

- Patches Zig 0.15.2's `std.Random.shuffleWithIndex` in the Docker image to avoid 128-bit arithmetic (`math.mulWide`) that Rosetta mistranslates on Apple Silicon Macs.
- Replaces `intRangeLessThan` (which uses `mulWide` internally) with a simple modulo approach using only 64-bit operations.
- Fixes multi-platform Docker builds (`--platform linux/amd64,linux/arm64`) that previously crashed consistently on the linux/amd64 build.

## Root Cause

Zig's `uintLessThan` generates bounded random numbers via `math.mulWide(u64, x, less_than)` which produces a `u128`. Apple's Rosetta x86_64 translation has a bug with this 128-bit multiplication, causing `uintLessThan(usize, N)` to return `N` (out of bounds) instead of a value strictly less than `N`. This crashes the build runner's dependency graph shuffle every time.

## The Fix

A single `sed` in the Dockerfile replaces the problematic line in `/opt/zig/lib/std/Random.zig`:

```diff
- const j: MinInt = @intCast(r.intRangeLessThan(Index, i, max));
+ const j: MinInt = i + @as(MinInt, @intCast(r.int(Index) % @as(Index, @intCast(max - i))));
```

The modulo approach is slightly biased but that's irrelevant for the build runner's shuffle (used only for dependency loop detection ordering).

## Test plan

- [ ] `docker buildx build --platform linux/amd64,linux/arm64 -t 0xpartha/zeam:latest --push .` completes successfully on Apple Silicon Mac
- [ ] CI builds (real x86_64 hardware) still pass — the patch is harmless there
- [ ] Remove this patch when Zig releases a fix or when Rosetta fixes 128-bit arithmetic

Closes #577