### PR TITLE
fix: resolve CI test failures from RocksDB LLD archive size and matrix misconfiguration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
 
   build-all-provers:
     name: build-all-provers
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: build  # Only run if the build job succeeds
     strategy:
       matrix:
@@ -182,7 +182,7 @@ jobs:
 
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/build.zig
+++ b/build.zig
@@ -127,10 +127,11 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
     }).module("yaml");
 
-    // add rocksdb
+    // add rocksdb — always build with ReleaseSafe to avoid LLD UnableToWriteArchive
+    // on Debug builds (the Debug archive exceeds LLD's size limits on CI runners)
     const rocksdb = b.dependency("rocksdb", .{
         .target = target,
-        .optimize = optimize,
+        .optimize = .ReleaseSafe,
     }).module("bindings");
 
     // add snappyz


### PR DESCRIPTION
## Summary

- **RocksDB LLD fix**: Always build RocksDB with `ReleaseSafe` in `build.zig` instead of inheriting the project-wide optimization level. In Debug mode (used by `zig build test`), RocksDB produces an archive that exceeds LLD's write limits, causing `UnableToWriteArchive` errors consistently on CI runners. This was affecting all PRs, not just specific branches.
- **CI matrix fix**: The `test` and `build-all-provers` jobs had `runs-on: ubuntu-latest` hardcoded while defining a matrix with `[ubuntu-latest, macos-latest]`. The `matrix.os` variable was never referenced in `runs-on`, so both matrix entries ran on ubuntu — doubling failure probability without ever testing on macOS. Fixed to use `${{ matrix.os }}`.

## Test plan

- [ ] CI `test (ubuntu-latest)` passes without `UnableToWriteArchive`
- [ ] CI `test (macos-latest)` now actually runs on macOS
- [ ] `build-all-provers` runs on both platforms
- [ ] Local `zig build test` passes (verified)