### PR TITLE
fix validator name display for Zig 0.15.2

### DIFF
--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -148,7 +148,7 @@ fn serverStreamSendResponse(ptr: *anyopaque, response: *const interface.ReqRespR
     const response_method_name = @tagName(response_method);
     const node_name = ctx.zigHandler.node_registry.getNodeNameFromPeerId(ctx.peer_id);
     ctx.zigHandler.logger.debug(
-        "network-{d}:: serverStreamSendResponse ctx.method={s} response.tag={s} peer={s}{any}",
+        "network-{d}:: serverStreamSendResponse ctx.method={s} response.tag={s} peer={s}{f}",
         .{ ctx.zigHandler.params.networkId, @tagName(ctx.method), @tagName(response_method), ctx.peer_id, node_name },
     );
 
@@ -161,7 +161,7 @@ fn serverStreamSendResponse(ptr: *anyopaque, response: *const interface.ReqRespR
     }
     const encoded = response.serialize(allocator) catch |err| {
         ctx.zigHandler.logger.err(
-            "network-{d}:: Failed to serialize {s} response for peer={s}{any} channel={d}: {any}",
+            "network-{d}:: Failed to serialize {s} response for peer={s}{f} channel={d}: {any}",
             .{ ctx.zigHandler.params.networkId, response_method_name, ctx.peer_id, node_name, ctx.channel_id, err },
         );
         return err;
@@ -170,7 +170,7 @@ fn serverStreamSendResponse(ptr: *anyopaque, response: *const interface.ReqRespR
 
     const framed = snappyframesz.encode(allocator, encoded) catch |err| {
         ctx.zigHandler.logger.err(
-            "network-{d}:: Failed to snappy-frame {s} response for peer={s}{any} channel={d}: {any}",
+            "network-{d}:: Failed to snappy-frame {s} response for peer={s}{f} channel={d}: {any}",
             .{ ctx.zigHandler.params.networkId, response_method_name, ctx.peer_id, node_name, ctx.channel_id, err },
         );
         return err;
@@ -181,7 +181,7 @@ fn serverStreamSendResponse(ptr: *anyopaque, response: *const interface.ReqRespR
     defer allocator.free(frame);
 
     ctx.zigHandler.logger.debug(
-        "network-{d}:: Streaming {s} response to peer={s}{any} channel={d}",
+        "network-{d}:: Streaming {s} response to peer={s}{f} channel={d}",
         .{ ctx.zigHandler.params.networkId, response_method_name, ctx.peer_id, node_name, ctx.channel_id },
     );
 
@@ -205,7 +205,7 @@ fn serverStreamSendError(ptr: *anyopaque, code: u32, message: []const u8) anyerr
 
     const node_name = ctx.zigHandler.node_registry.getNodeNameFromPeerId(ctx.peer_id);
     ctx.zigHandler.logger.warn(
-        "network-{d}:: Streaming RPC error to peer={s}{any} channel={d} code={d}: {s}",
+        "network-{d}:: Streaming RPC error to peer={s}{f} channel={d} code={d}: {s}",
         .{ ctx.zigHandler.params.networkId, ctx.peer_id, node_name, ctx.channel_id, code, message },
     );
 
@@ -330,7 +330,7 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
         .block => |signed_block| {
             const block = signed_block.message.block;
             zigHandler.logger.debug(
-                "network-{d}:: received gossip block slot={d} proposer={d} (compressed={d}B, raw={d}B) from peer={s}{any}",
+                "network-{d}:: received gossip block slot={d} proposer={d} (compressed={d}B, raw={d}B) from peer={s}{f}",
                 .{
                     zigHandler.params.networkId,
                     block.slot,
@@ -346,7 +346,7 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
             const slot = signed_attestation.message.slot;
             const validator_id = signed_attestation.validator_id;
             zigHandler.logger.debug(
-                "network-{d}:: received gossip attestation slot={d} validator={d} (compressed={d}B, raw={d}B) from peer={s}{any}",
+                "network-{d}:: received gossip attestation slot={d} validator={d} (compressed={d}B, raw={d}B) from peer={s}{f}",
                 .{
                     zigHandler.params.networkId,
                     slot,
@@ -362,7 +362,7 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
 
     // Debug-only JSON dump (conversion happens only if debug is actually emitted).
     zigHandler.logger.debug(
-        "network-{d}:: gossip payload json topic={s} from peer={s}{any}: {any}",
+        "network-{d}:: gossip payload json topic={s} from peer={s}{f}: {any}",
         .{
             zigHandler.params.networkId,
             std.mem.span(topic_str),
@@ -374,7 +374,7 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
 
     // TODO: figure out why scheduling on the loop is not working
     zigHandler.gossipHandler.onGossip(&message, sender_peer_id_slice, false) catch |e| {
-        zigHandler.logger.err("onGossip handling of message failed with error e={any} from sender_peer_id={s}{any}", .{ e, sender_peer_id_slice, node_name });
+        zigHandler.logger.err("onGossip handling of message failed with error e={any} from sender_peer_id={s}{f}", .{ e, sender_peer_id_slice, node_name });
     };
 }
 
@@ -392,7 +392,7 @@ export fn handleRPCRequestFromRustBridge(
     const node_name = zigHandler.node_registry.getNodeNameFromPeerId(peer_id_slice);
     const rpc_protocol = LeanSupportedProtocol.fromSlice(protocol_slice) orelse {
         zigHandler.logger.warn(
-            "network-{d}:: Unsupported RPC protocol from peer={s}{any} on channel={d}: {s}",
+            "network-{d}:: Unsupported RPC protocol from peer={s}{f} on channel={d}: {s}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, protocol_slice },
         );
         send_rpc_error_response(zigHandler.params.networkId, channel_id, "Unsupported RPC protocol");
@@ -403,7 +403,7 @@ export fn handleRPCRequestFromRustBridge(
 
     const request_frame_info = parseRequestFrame(request_frame) catch |err| {
         zigHandler.logger.err(
-            "network-{d}:: Invalid RPC request frame from peer={s}{any} protocol={s}: {any}",
+            "network-{d}:: Invalid RPC request frame from peer={s}{f} protocol={s}: {any}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, protocol_slice, err },
         );
         send_rpc_error_response(zigHandler.params.networkId, channel_id, "Invalid RPC request frame");
@@ -412,7 +412,7 @@ export fn handleRPCRequestFromRustBridge(
 
     const request_bytes = snappyframesz.decode(zigHandler.allocator, request_frame_info.payload) catch |err| {
         zigHandler.logger.err(
-            "network-{d}:: Failed to decode snappy-framed RPC request from peer={s}{any} protocol={s}: {any}",
+            "network-{d}:: Failed to decode snappy-framed RPC request from peer={s}{f} protocol={s}: {any}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, protocol_slice, err },
         );
         send_rpc_error_response(zigHandler.params.networkId, channel_id, "Failed to decode RPC request");
@@ -421,7 +421,7 @@ export fn handleRPCRequestFromRustBridge(
     defer zigHandler.allocator.free(request_bytes);
     if (request_bytes.len != request_frame_info.declared_len) {
         zigHandler.logger.err(
-            "network-{d}:: Invalid RPC request length from peer={s}{any} protocol={s}: declared={d} decoded={d}",
+            "network-{d}:: Invalid RPC request length from peer={s}{f} protocol={s}: declared={d} decoded={d}",
             .{
                 zigHandler.params.networkId,
                 peer_id_slice,
@@ -439,13 +439,13 @@ export fn handleRPCRequestFromRustBridge(
     var request = interface.ReqRespRequest.deserialize(zigHandler.allocator, method, request_bytes) catch |err| {
         const label = method.name();
         zigHandler.logger.err(
-            "Error in deserializing the {s} RPC request from peer={s}{any}: {any}",
+            "Error in deserializing the {s} RPC request from peer={s}{f}: {any}",
             .{ label, peer_id_slice, node_name, err },
         );
         if (writeFailedBytes(request_bytes, label, zigHandler.allocator, null, zigHandler.logger)) |filename| {
-            zigHandler.logger.err("RPC {s} deserialization failed - debug file created: {s} from peer={s}{any}", .{ label, filename, peer_id_slice, node_name });
+            zigHandler.logger.err("RPC {s} deserialization failed - debug file created: {s} from peer={s}{f}", .{ label, filename, peer_id_slice, node_name });
         } else {
-            zigHandler.logger.err("RPC {s} deserialization failed - could not create debug file from peer={s}{any}", .{ label, peer_id_slice, node_name });
+            zigHandler.logger.err("RPC {s} deserialization failed - could not create debug file from peer={s}{f}", .{ label, peer_id_slice, node_name });
         }
         send_rpc_error_response(zigHandler.params.networkId, channel_id, "Failed to deserialize RPC request");
         return;
@@ -453,13 +453,13 @@ export fn handleRPCRequestFromRustBridge(
     defer request.deinit();
 
     zigHandler.logger.debug(
-        "network-{d}:: received RPC request peer={s}{any} protocol={s} channel={d} size={d}",
+        "network-{d}:: received RPC request peer={s}{f} protocol={s} channel={d} size={d}",
         .{ zigHandler.params.networkId, peer_id_slice, node_name, rpc_protocol.protocolId(), channel_id, request_bytes.len },
     );
 
     // Debug-only JSON dump (conversion happens only if debug is actually emitted).
     zigHandler.logger.debug(
-        "network-{d}:: rpc request json peer={s}{any} protocol={s} channel={d}: {any}",
+        "network-{d}:: rpc request json peer={s}{f} protocol={s} channel={d}: {any}",
         .{
             zigHandler.params.networkId,
             peer_id_slice,
@@ -490,7 +490,7 @@ export fn handleRPCRequestFromRustBridge(
 
     zigHandler.reqrespHandler.onReqRespRequest(&request, stream) catch |e| {
         zigHandler.logger.err(
-            "network-{d}:: Error while handling RPC request from peer={s}{any} on channel={d}: {any}",
+            "network-{d}:: Error while handling RPC request from peer={s}{f} on channel={d}: {any}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, e },
         );
 
@@ -500,14 +500,14 @@ export fn handleRPCRequestFromRustBridge(
                 defer zigHandler.allocator.free(owned);
                 stream.sendError(1, owned) catch |send_err| {
                     zigHandler.logger.err(
-                        "network-{d}:: Failed to send RPC error response for peer={s}{any} channel={d}: {any}",
+                        "network-{d}:: Failed to send RPC error response for peer={s}{f} channel={d}: {any}",
                         .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, send_err },
                     );
                 };
             } else {
                 stream.finish() catch |finish_err| {
                     zigHandler.logger.err(
-                        "network-{d}:: Failed to finalize errored RPC stream for peer={s}{any} channel={d}: {any}",
+                        "network-{d}:: Failed to finalize errored RPC stream for peer={s}{f} channel={d}: {any}",
                         .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, finish_err },
                     );
                 };
@@ -519,7 +519,7 @@ export fn handleRPCRequestFromRustBridge(
     if (!stream.isFinished()) {
         stream.finish() catch |finish_err| {
             zigHandler.logger.err(
-                "network-{d}:: Failed to finalize RPC stream for peer={s}{any} channel={d}: {any}",
+                "network-{d}:: Failed to finalize RPC stream for peer={s}{f} channel={d}: {any}",
                 .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, finish_err },
             );
         };
@@ -540,7 +540,7 @@ export fn handleRPCResponseFromRustBridge(
 
     const callback_ptr = zigHandler.rpcCallbacks.getPtr(request_id) orelse {
         zigHandler.logger.warn(
-            "network-{d}:: Received RPC response for unknown request_id={d} protocol={s} from peer={s}{any}",
+            "network-{d}:: Received RPC response for unknown request_id={d} protocol={s} from peer={s}{f}",
             .{ zigHandler.params.networkId, request_id, protocol_slice, peer_id_slice, node_name },
         );
         return;
@@ -562,7 +562,7 @@ export fn handleRPCResponseFromRustBridge(
     const method = callback_ptr.method;
     if (protocol != method) {
         zigHandler.logger.warn(
-            "network-{d}:: RPC protocol/method mismatch for request_id={d}: protocol={s} method={s} from peer={s}{any}",
+            "network-{d}:: RPC protocol/method mismatch for request_id={d}: protocol={s} method={s} from peer={s}{f}",
             .{ zigHandler.params.networkId, request_id, protocol.protocolId(), @tagName(method), callback_peer_id, callback_node_name },
         );
     }
@@ -582,13 +582,13 @@ export fn handleRPCResponseFromRustBridge(
 
     if (parsed_frame.code != 0) {
         zigHandler.logger.warn(
-            "network-{d}:: RPC error response for request_id={d} protocol={s} code={d} from peer={s}{any}",
+            "network-{d}:: RPC error response for request_id={d} protocol={s} code={d} from peer={s}{f}",
             .{ zigHandler.params.networkId, request_id, protocol.protocolId(), parsed_frame.code, callback_peer_id, callback_node_name },
         );
 
         const owned_message = zigHandler.allocator.dupe(u8, parsed_frame.payload) catch |dup_err| {
             zigHandler.logger.err(
-                "network-{d}:: Failed to duplicate RPC error payload for request_id={d} from peer={s}{any}: {any}",
+                "network-{d}:: Failed to duplicate RPC error payload for request_id={d} from peer={s}{f}: {any}",
                 .{ zigHandler.params.networkId, request_id, callback_peer_id, callback_node_name, dup_err },
             );
             zigHandler.notifyRpcErrorFmt(
@@ -647,13 +647,13 @@ export fn handleRPCResponseFromRustBridge(
     defer event.deinit(zigHandler.allocator);
 
     zigHandler.logger.debug(
-        "network-{d}:: Received RPC response for request_id={d} protocol={s} size={d} from peer={s}{any}",
+        "network-{d}:: Received RPC response for request_id={d} protocol={s} size={d} from peer={s}{f}",
         .{ zigHandler.params.networkId, request_id, protocol.protocolId(), response_bytes.len, callback_peer_id, callback_node_name },
     );
 
     callback_ptr.notify(&event) catch |notify_err| {
         zigHandler.logger.err(
-            "network-{d}:: Failed to notify RPC success callback for request_id={d} from peer={s}{any}: {any}",
+            "network-{d}:: Failed to notify RPC success callback for request_id={d} from peer={s}{f}: {any}",
             .{ zigHandler.params.networkId, request_id, callback_peer_id, callback_node_name, notify_err },
         );
     };
@@ -680,7 +680,7 @@ export fn handleRPCEndOfStreamFromRustBridge(
         defer event.deinit(zigHandler.allocator);
 
         zigHandler.logger.debug(
-            "network-{d}:: Received RPC end-of-stream for request_id={d} protocol={s} from peer={s}{any}",
+            "network-{d}:: Received RPC end-of-stream for request_id={d} protocol={s} from peer={s}{f}",
             .{ zigHandler.params.networkId, request_id, protocol_str, callback_peer_id, callback_node_name },
         );
 
@@ -693,7 +693,7 @@ export fn handleRPCEndOfStreamFromRustBridge(
         callback.deinit();
     } else {
         zigHandler.logger.warn(
-            "network-{d}:: Received RPC end-of-stream for unknown request_id={d} protocol={s} from peer={s}{any}",
+            "network-{d}:: Received RPC end-of-stream for unknown request_id={d} protocol={s} from peer={s}{f}",
             .{ zigHandler.params.networkId, request_id, protocol_str, peer_id_slice, node_name },
         );
     }
@@ -718,7 +718,7 @@ export fn handleRPCErrorFromRustBridge(
 
         const owned_message = zigHandler.allocator.dupe(u8, message_slice) catch |alloc_err| {
             zigHandler.logger.err(
-                "network-{d}:: Failed to duplicate RPC error message for request_id={d} from peer={s}{any}: {any}",
+                "network-{d}:: Failed to duplicate RPC error message for request_id={d} from peer={s}{f}: {any}",
                 .{ zigHandler.params.networkId, request_id, peer_id, node_name, alloc_err },
             );
             callback.deinit();
@@ -732,13 +732,13 @@ export fn handleRPCErrorFromRustBridge(
         defer event.deinit(zigHandler.allocator);
 
         zigHandler.logger.warn(
-            "network-{d}:: Received RPC error for request_id={d} protocol={s} code={d} from peer={s}{any}",
+            "network-{d}:: Received RPC error for request_id={d} protocol={s} code={d} from peer={s}{f}",
             .{ zigHandler.params.networkId, request_id, protocol_str, code, peer_id, node_name },
         );
 
         callback.notify(&event) catch |notify_err| {
             zigHandler.logger.err(
-                "network-{d}:: Failed to notify RPC error for request_id={d} from peer={s}{any}: {any}",
+                "network-{d}:: Failed to notify RPC error for request_id={d} from peer={s}{f}: {any}",
                 .{ zigHandler.params.networkId, request_id, peer_id, node_name, notify_err },
             );
         };
@@ -759,7 +759,7 @@ export fn handlePeerConnectedFromRustBridge(
     const peer_id_slice = std.mem.span(peer_id);
     const node_name = zigHandler.node_registry.getNodeNameFromPeerId(peer_id_slice);
     const dir = @as(interface.PeerDirection, @enumFromInt(direction));
-    zigHandler.logger.info("network-{d}:: Peer connected: {s}{any} direction={s}", .{
+    zigHandler.logger.info("network-{d}:: Peer connected: {s}{f} direction={s}", .{
         zigHandler.params.networkId,
         peer_id_slice,
         node_name,
@@ -781,7 +781,7 @@ export fn handlePeerDisconnectedFromRustBridge(
     const node_name = zigHandler.node_registry.getNodeNameFromPeerId(peer_id_slice);
     const dir = @as(interface.PeerDirection, @enumFromInt(direction));
     const rsn = @as(interface.DisconnectionReason, @enumFromInt(reason));
-    zigHandler.logger.info("network-{d}:: Peer disconnected: {s}{any} direction={s} reason={s}", .{
+    zigHandler.logger.info("network-{d}:: Peer disconnected: {s}{f} direction={s} reason={s}", .{
         zigHandler.params.networkId,
         peer_id_slice,
         node_name,
@@ -1049,7 +1049,7 @@ pub const EthLibp2p = struct {
         const node_name = self.node_registry.getNodeNameFromPeerId(peer_id);
         const encoded_message = req.serialize(self.allocator) catch |err| {
             self.logger.err(
-                "network-{d}:: Failed to serialize RPC request for peer={s}{any} method={s}: {any}",
+                "network-{d}:: Failed to serialize RPC request for peer={s}{f} method={s}: {any}",
                 .{ self.params.networkId, peer_id, node_name, @tagName(method), err },
             );
             return err;
@@ -1059,7 +1059,7 @@ pub const EthLibp2p = struct {
 
         const framed_payload = snappyframesz.encode(self.allocator, encoded_message) catch |err| {
             self.logger.err(
-                "network-{d}:: Failed to snappy-frame RPC request payload for peer={s}{any} protocol_tag={d}: {any}",
+                "network-{d}:: Failed to snappy-frame RPC request payload for peer={s}{f} protocol_tag={d}: {any}",
                 .{ self.params.networkId, peer_id, node_name, protocol_tag, err },
             );
             return err;
@@ -1068,7 +1068,7 @@ pub const EthLibp2p = struct {
 
         const frame = buildRequestFrame(self.allocator, encoded_message.len, framed_payload) catch |err| {
             self.logger.err(
-                "network-{d}:: Failed to build RPC request frame for peer={s}{any} protocol_tag={d}: {any}",
+                "network-{d}:: Failed to build RPC request frame for peer={s}{f} protocol_tag={d}: {any}",
                 .{ self.params.networkId, peer_id, node_name, protocol_tag, err },
             );
             return err;
@@ -1096,7 +1096,7 @@ pub const EthLibp2p = struct {
             self.rpcCallbacks.put(self.allocator, request_id, callback_entry) catch |err| {
                 self.allocator.free(peer_id_copy);
                 self.logger.err(
-                    "network-{d}:: Failed to register RPC callback for request_id={d} peer={s}{any}: {any}",
+                    "network-{d}:: Failed to register RPC callback for request_id={d} peer={s}{f}: {any}",
                     .{ self.params.networkId, request_id, peer_id, node_name, err },
                 );
                 return err;
@@ -1125,7 +1125,7 @@ pub const EthLibp2p = struct {
             const node_name = self.node_registry.getNodeNameFromPeerId(peer_id);
             callback.notify(&event) catch |notify_err| {
                 self.logger.err(
-                    "network-{d}:: Failed to deliver RPC error callback for request_id={d} from peer={s}{any}: {any}",
+                    "network-{d}:: Failed to deliver RPC error callback for request_id={d} from peer={s}{f}: {any}",
                     .{ self.params.networkId, request_id, peer_id, node_name, notify_err },
                 );
             };
@@ -1151,7 +1151,7 @@ pub const EthLibp2p = struct {
         const node_name = if (callback_ptr) |cb| self.node_registry.getNodeNameFromPeerId(cb.peer_id) else zeam_utils.OptionalNode.init(null);
         const owned_message = std.fmt.allocPrint(self.allocator, fmt, args) catch |alloc_err| {
             self.logger.err(
-                "network-{d}:: Failed to allocate RPC error message for request_id={d} from peer={s}{any}: {any}",
+                "network-{d}:: Failed to allocate RPC error message for request_id={d} from peer={s}{f}: {any}",
                 .{ self.params.networkId, request_id, peer_id, node_name, alloc_err },
             );
             return;

--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -621,7 +621,7 @@ pub const ReqRespRequestHandler = struct {
         const peer_id_opt = stream.getPeerId();
         const peer_id = peer_id_opt orelse "unknown";
         const node_name = if (peer_id_opt) |pid| self.node_registry.getNodeNameFromPeerId(pid) else zeam_utils.OptionalNode.init(null);
-        self.logger.debug("network-{d}:: onReqRespRequest={any} handlers={d} from peer={s}{any}", .{ self.networkId, req.*, self.handlers.items.len, peer_id, node_name });
+        self.logger.debug("network-{d}:: onReqRespRequest={any} handlers={d} from peer={s}{f}", .{ self.networkId, req.*, self.handlers.items.len, peer_id, node_name });
         if (self.handlers.items.len == 0) {
             return error.NoHandlerSubscribed;
         }
@@ -631,7 +631,7 @@ pub const ReqRespRequestHandler = struct {
 
         for (self.handlers.items) |handler| {
             handler.onReqRespRequest(req, stream) catch |err| {
-                self.logger.err("network-{d}:: onReqRespRequest handler error={any} from peer={s}{any}", .{ self.networkId, err, peer_id, node_name });
+                self.logger.err("network-{d}:: onReqRespRequest handler error={any} from peer={s}{f}", .{ self.networkId, err, peer_id, node_name });
                 last_err = err;
                 continue;
             };
@@ -746,7 +746,7 @@ pub const PeerEventHandler = struct {
 
     pub fn onPeerConnected(self: *Self, peer_id: []const u8, direction: PeerDirection) anyerror!void {
         const node_name = self.node_registry.getNodeNameFromPeerId(peer_id);
-        self.logger.debug("network-{d}:: PeerEventHandler.onPeerConnected peer_id={s}{any} direction={s}, handlers={d}", .{ self.networkId, peer_id, node_name, @tagName(direction), self.handlers.items.len });
+        self.logger.debug("network-{d}:: PeerEventHandler.onPeerConnected peer_id={s}{f} direction={s}, handlers={d}", .{ self.networkId, peer_id, node_name, @tagName(direction), self.handlers.items.len });
         for (self.handlers.items) |handler| {
             handler.onPeerConnected(peer_id, direction) catch |e| {
                 self.logger.err("network-{d}:: onPeerConnected handler error={any}", .{ self.networkId, e });
@@ -756,7 +756,7 @@ pub const PeerEventHandler = struct {
 
     pub fn onPeerDisconnected(self: *Self, peer_id: []const u8, direction: PeerDirection, reason: DisconnectionReason) anyerror!void {
         const node_name = self.node_registry.getNodeNameFromPeerId(peer_id);
-        self.logger.debug("network-{d}:: PeerEventHandler.onPeerDisconnected peer_id={s}{any} direction={s} reason={s}, handlers={d}", .{ self.networkId, peer_id, node_name, @tagName(direction), @tagName(reason), self.handlers.items.len });
+        self.logger.debug("network-{d}:: PeerEventHandler.onPeerDisconnected peer_id={s}{f} direction={s} reason={s}, handlers={d}", .{ self.networkId, peer_id, node_name, @tagName(direction), @tagName(reason), self.handlers.items.len });
         for (self.handlers.items) |handler| {
             handler.onPeerDisconnected(peer_id, direction, reason) catch |e| {
                 self.logger.err("network-{d}:: onPeerDisconnected handler error={any}", .{ self.networkId, e });
@@ -828,7 +828,7 @@ pub const GenericGossipHandler = struct {
         const gossip_topic = data.getGossipTopic();
         const handlerArr = self.onGossipHandlers.get(gossip_topic).?;
         const node_name = self.node_registry.getNodeNameFromPeerId(sender_peer_id);
-        self.logger.debug("network-{d}:: ongossip handlers={d} topic={s} from peer={s}{any}", .{ self.networkId, handlerArr.items.len, gossip_topic.encode(), sender_peer_id, node_name });
+        self.logger.debug("network-{d}:: ongossip handlers={d} topic={s} from peer={s}{f}", .{ self.networkId, handlerArr.items.len, gossip_topic.encode(), sender_peer_id, node_name });
         for (handlerArr.items) |handler| {
 
             // TODO: figure out why scheduling on the loop is not working for libp2p separate net instance

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -564,7 +564,7 @@ pub const BeamChain = struct {
                 //check if we have the block already in forkchoice
                 const hasBlock = self.forkChoice.hasBlock(block_root);
 
-                self.module_logger.debug("chain received gossip block for slot={d} blockroot=0x{x} proposer={d}{any} hasBlock={} from peer={s}{any}", .{
+                self.module_logger.debug("chain received gossip block for slot={d} blockroot=0x{x} proposer={d}{f} hasBlock={} from peer={s}{f}", .{
                     block.slot,
                     &block_root,
                     block.proposer_index,
@@ -613,7 +613,7 @@ pub const BeamChain = struct {
                 const validator_node_name = self.node_registry.getNodeNameFromValidatorIndex(validator_id);
 
                 const sender_node_name = self.node_registry.getNodeNameFromPeerId(sender_peer_id);
-                self.module_logger.debug("chain received gossip attestation for slot={d} validator={d}{any} from peer={s}{any}", .{
+                self.module_logger.debug("chain received gossip attestation for slot={d} validator={d}{f} from peer={s}{f}", .{
                     slot,
                     validator_id,
                     validator_node_name,
@@ -641,7 +641,7 @@ pub const BeamChain = struct {
                     self.module_logger.err("attestation processing error: {any}", .{err});
                     return err;
                 };
-                self.module_logger.info("processed gossip attestation for slot={d} validator={d}{any}", .{
+                self.module_logger.info("processed gossip attestation for slot={d} validator={d}{f}", .{
                     slot,
                     validator_id,
                     validator_node_name,

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -123,7 +123,7 @@ pub const BeamNode = struct {
                 const parent_root = block.parent_root;
                 const hasParentBlock = self.chain.forkChoice.hasBlock(parent_root);
 
-                self.logger.info("received gossip block for slot={d} parent_root=0x{x} proposer={d}{any} hasParentBlock={} from peer={s}{any}", .{
+                self.logger.info("received gossip block for slot={d} parent_root=0x{x} proposer={d}{f} hasParentBlock={} from peer={s}{f}", .{
                     block.slot,
                     &parent_root,
                     block.proposer_index,
@@ -180,7 +180,7 @@ pub const BeamNode = struct {
                 const validator_node_name = self.node_registry.getNodeNameFromValidatorIndex(validator_id);
 
                 const sender_node_name = self.node_registry.getNodeNameFromPeerId(sender_peer_id);
-                self.logger.info("received gossip attestation for slot={d} validator={d}{any} from peer={s}{any}", .{
+                self.logger.info("received gossip attestation for slot={d} validator={d}{f} from peer={s}{f}", .{
                     slot,
                     validator_id,
                     validator_node_name,
@@ -479,7 +479,7 @@ pub const BeamNode = struct {
             const current_depth = self.network.getPendingBlockRootDepth(block_root) orelse 0;
             const removed = self.network.removePendingBlockRoot(block_root);
             if (!removed) {
-                self.logger.warn("received unexpected block root 0x{x} from peer {s}{any}", .{
+                self.logger.warn("received unexpected block root 0x{x} from peer {s}{f}", .{
                     &block_root,
                     block_ctx.peer_id,
                     self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id),
@@ -532,7 +532,7 @@ pub const BeamNode = struct {
 
                 if (err == forkchoice.ForkChoiceError.PreFinalizedSlot) {
                     self.logger.info(
-                        "discarding pre-finalized block 0x{x} from peer {s}{any}, pruning cached descendants",
+                        "discarding pre-finalized block 0x{x} from peer {s}{f}, pruning cached descendants",
                         .{
                             &block_root,
                             block_ctx.peer_id,
@@ -543,7 +543,7 @@ pub const BeamNode = struct {
                     return;
                 }
 
-                self.logger.warn("failed to import block fetched via RPC 0x{x} from peer {s}{any}: {any}", .{
+                self.logger.warn("failed to import block fetched via RPC 0x{x} from peer {s}{f}: {any}", .{
                     &block_root,
                     block_ctx.peer_id,
                     self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id),
@@ -570,7 +570,7 @@ pub const BeamNode = struct {
                 self.logger.warn("failed to fetch {d} missing block(s): {any}", .{ missing_roots.len, err });
             };
         } else |err| {
-            self.logger.warn("failed to compute block root from RPC response from peer={s}{any}: {any}", .{ block_ctx.peer_id, self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id), err });
+            self.logger.warn("failed to compute block root from RPC response from peer={s}{f}: {any}", .{ block_ctx.peer_id, self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id), err });
         }
     }
 
@@ -592,14 +592,14 @@ pub const BeamNode = struct {
                 .status => |status_resp| {
                     switch (ctx_ptr.*) {
                         .status => |*status_ctx| {
-                            self.logger.info("received status response from peer {s}{any} head_slot={d}, finalized_slot={d}", .{
+                            self.logger.info("received status response from peer {s}{f} head_slot={d}, finalized_slot={d}", .{
                                 status_ctx.peer_id,
                                 self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
                                 status_resp.head_slot,
                                 status_resp.finalized_slot,
                             });
                             if (!self.network.setPeerLatestStatus(status_ctx.peer_id, status_resp)) {
-                                self.logger.warn("status response received for unknown peer {s}{any}", .{
+                                self.logger.warn("status response received for unknown peer {s}{f}", .{
                                     status_ctx.peer_id,
                                     self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
                                 });
@@ -613,7 +613,7 @@ pub const BeamNode = struct {
                                 .behind_peers => |info| {
                                     // Only sync from this peer if their finalized slot is ahead of ours
                                     if (status_resp.finalized_slot > self.chain.forkChoice.fcStore.latest_finalized.slot) {
-                                        self.logger.info("peer {s}{any} is ahead (peer_finalized_slot={d} > our_head_slot={d}), initiating sync by requesting head block 0x{x}", .{
+                                        self.logger.info("peer {s}{f} is ahead (peer_finalized_slot={d} > our_head_slot={d}), initiating sync by requesting head block 0x{x}", .{
                                             status_ctx.peer_id,
                                             self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
                                             status_resp.finalized_slot,
@@ -622,7 +622,7 @@ pub const BeamNode = struct {
                                         });
                                         const roots = [_]types.Root{status_resp.head_root};
                                         self.fetchBlockByRoots(&roots, 0) catch |err| {
-                                            self.logger.warn("failed to initiate sync by fetching head block from peer {s}{any}: {any}", .{
+                                            self.logger.warn("failed to initiate sync by fetching head block from peer {s}{f}: {any}", .{
                                                 status_ctx.peer_id,
                                                 self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
                                                 err,
@@ -634,14 +634,14 @@ pub const BeamNode = struct {
                             }
                         },
                         else => {
-                            self.logger.warn("status response did not match tracked request_id={d} from peer={s}{any}", .{ request_id, peer_id, node_name });
+                            self.logger.warn("status response did not match tracked request_id={d} from peer={s}{f}", .{ request_id, peer_id, node_name });
                         },
                     }
                 },
                 .blocks_by_root => |block_resp| {
                     switch (ctx_ptr.*) {
                         .blocks_by_root => |*block_ctx| {
-                            self.logger.info("received blocks-by-root chunk from peer {s}{any}", .{
+                            self.logger.info("received blocks-by-root chunk from peer {s}{f}", .{
                                 block_ctx.peer_id,
                                 self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id),
                             });
@@ -649,7 +649,7 @@ pub const BeamNode = struct {
                             try self.processBlockByRootChunk(block_ctx, &block_resp);
                         },
                         else => {
-                            self.logger.warn("blocks-by-root response did not match tracked request_id={d} from peer={s}{any}", .{ request_id, peer_id, node_name });
+                            self.logger.warn("blocks-by-root response did not match tracked request_id={d} from peer={s}{f}", .{ request_id, peer_id, node_name });
                         },
                     }
                 },
@@ -657,7 +657,7 @@ pub const BeamNode = struct {
             .failure => |err_payload| {
                 switch (ctx_ptr.*) {
                     .status => |status_ctx| {
-                        self.logger.warn("status request to peer {s}{any} failed ({d}): {s}", .{
+                        self.logger.warn("status request to peer {s}{f} failed ({d}): {s}", .{
                             status_ctx.peer_id,
                             self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
                             err_payload.code,
@@ -665,7 +665,7 @@ pub const BeamNode = struct {
                         });
                     },
                     .blocks_by_root => |block_ctx| {
-                        self.logger.warn("blocks-by-root request to peer {s}{any} failed ({d}): {s}", .{
+                        self.logger.warn("blocks-by-root request to peer {s}{f} failed ({d}): {s}", .{
                             block_ctx.peer_id,
                             self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id),
                             err_payload.code,
@@ -778,7 +778,7 @@ pub const BeamNode = struct {
         };
 
         if (maybe_request) |request_info| {
-            self.logger.debug("requested {d} block(s) by root from peer {s}{any}, request_id={d}", .{
+            self.logger.debug("requested {d} block(s) by root from peer {s}{f}, request_id={d}", .{
                 missing_roots.items.len,
                 request_info.peer_id,
                 self.node_registry.getNodeNameFromPeerId(request_info.peer_id),
@@ -792,7 +792,7 @@ pub const BeamNode = struct {
 
         try self.network.connectPeer(peer_id);
         const node_name = self.node_registry.getNodeNameFromPeerId(peer_id);
-        self.logger.info("peer connected: {s}{any}, direction={s}, total peers: {d}", .{
+        self.logger.info("peer connected: {s}{f}, direction={s}, total peers: {d}", .{
             peer_id,
             node_name,
             @tagName(direction),
@@ -807,7 +807,7 @@ pub const BeamNode = struct {
         const status = self.chain.getStatus();
 
         const request_id = self.network.sendStatusToPeer(peer_id, status, handler) catch |err| {
-            self.logger.warn("failed to send status request to peer {s}{any} {any}", .{
+            self.logger.warn("failed to send status request to peer {s}{f} {any}", .{
                 peer_id,
                 self.node_registry.getNodeNameFromPeerId(peer_id),
                 err,
@@ -815,7 +815,7 @@ pub const BeamNode = struct {
             return;
         };
 
-        self.logger.info("sent status request to peer {s}{any}: request_id={d}, head_slot={d}, finalized_slot={d}", .{
+        self.logger.info("sent status request to peer {s}{f}: request_id={d}, head_slot={d}, finalized_slot={d}", .{
             peer_id,
             self.node_registry.getNodeNameFromPeerId(peer_id),
             request_id,
@@ -828,7 +828,7 @@ pub const BeamNode = struct {
         const self: *Self = @ptrCast(@alignCast(ptr));
 
         if (self.network.disconnectPeer(peer_id)) {
-            self.logger.info("peer disconnected: {s}{any}, direction={s}, reason={s}, total peers: {d}", .{
+            self.logger.info("peer disconnected: {s}{f}, direction={s}, reason={s}, total peers: {d}", .{
                 peer_id,
                 self.node_registry.getNodeNameFromPeerId(peer_id),
                 @tagName(direction),
@@ -962,7 +962,7 @@ pub const BeamNode = struct {
                         roots_to_retry.append(self.allocator, .{ .root = root, .depth = depth }) catch continue;
                     }
 
-                    self.logger.warn("RPC request_id={d} to peer {s}{any} timed out after {d}s, retrying {d} roots", .{
+                    self.logger.warn("RPC request_id={d} to peer {s}{f} timed out after {d}s, retrying {d} roots", .{
                         request_id,
                         block_ctx.peer_id,
                         self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id),
@@ -982,7 +982,7 @@ pub const BeamNode = struct {
                     }
                 },
                 .status => |status_ctx| {
-                    self.logger.warn("status RPC request_id={d} to peer {s}{any} timed out, finalizing", .{
+                    self.logger.warn("status RPC request_id={d} to peer {s}{f} timed out, finalizing", .{
                         request_id,
                         status_ctx.peer_id,
                         self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
@@ -1027,7 +1027,7 @@ pub const BeamNode = struct {
         // 2. publish gossip message
         const gossip_msg = networks.GossipMessage{ .block = signed_block };
         try self.network.publish(&gossip_msg);
-        self.logger.info("published block to network: slot={d} proposer={d}{any}", .{
+        self.logger.info("published block to network: slot={d} proposer={d}{f}", .{
             block.slot,
             block.proposer_index,
             self.node_registry.getNodeNameFromValidatorIndex(block.proposer_index),
@@ -1052,7 +1052,7 @@ pub const BeamNode = struct {
         const gossip_msg = networks.GossipMessage{ .attestation = signed_attestation };
         try self.network.publish(&gossip_msg);
 
-        self.logger.info("published attestation to network: slot={d} validator={d}{any}", .{
+        self.logger.info("published attestation to network: slot={d} validator={d}{f}", .{
             data.slot,
             validator_id,
             self.node_registry.getNodeNameFromValidatorIndex(validator_id),

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -334,7 +334,7 @@ pub const ModuleLogger = struct {
 };
 
 /// Formatter for optional node names in logs
-/// Usage: logger.info("{}message", .{OptionalNode.init(maybe_node_name)})
+/// Usage: logger.info("{f}message", .{OptionalNode.init(maybe_node_name)})
 /// Outputs: "message" or "(node1) message"
 pub const OptionalNode = struct {
     name: ?[]const u8,
@@ -343,17 +343,10 @@ pub const OptionalNode = struct {
         return .{ .name = name };
     }
 
-    pub fn format(
-        self: OptionalNode,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
+    pub fn format(self: OptionalNode, writer: anytype) !void {
         const peer_color = Colors.peer;
         const reset_color = Colors.reset;
 
-        _ = fmt;
-        _ = options;
         if (self.name) |n| {
             try writer.print("({s}{s}{s})", .{ peer_color, n, reset_color });
         }
@@ -496,7 +489,7 @@ test "OptionalNode formatter" {
         const writer = buffer.writer(allocator);
 
         const node = OptionalNode.init("alice");
-        try node.format("", .{}, writer);
+        try node.format(writer);
         try writer.print(" Peer connected: {s}, total peers: {d}", .{
             "peer123",
             5,
@@ -512,7 +505,7 @@ test "OptionalNode formatter" {
         const writer = buffer.writer(allocator);
 
         const node = OptionalNode.init(null);
-        try node.format("", .{}, writer);
+        try node.format(writer);
         try writer.print("Peer connected: {s}, total peers: {d}", .{
             "peer456",
             3,
@@ -528,7 +521,7 @@ test "OptionalNode formatter" {
         const writer = buffer.writer(allocator);
 
         const node = OptionalNode.init("validator-7");
-        try node.format("", .{}, writer);
+        try node.format(writer);
         try writer.print(" Published block: slot={d} proposer={d}", .{
             100,
             7,
@@ -544,7 +537,7 @@ test "OptionalNode formatter" {
         const writer = buffer.writer(allocator);
 
         const node = OptionalNode.init("");
-        try node.format("", .{}, writer);
+        try node.format(writer);
         try writer.writeAll(" Message");
 
         try testing.expectEqualStrings("(" ++ Colors.peer ++ Colors.reset ++ ") Message", buffer.items);


### PR DESCRIPTION
 Updated OptionalNode.format signature to use Zig 0.15.2's new 2-parameter format method. Changed format specifiers from {any} to {f} across logging statements to properly display validator names as strings instead of byte arrays fixes https://github.com/blockblaz/zeam/issues/588


<img width="960" height="486" alt="Screenshot 2026-02-22 at 23 08 23" src="https://github.com/user-attachments/assets/a23e6d10-1749-49b9-bd13-740c12e6c2b1" />
