### PR TITLE
fix debug log format for Zig 0.15.2

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -94,9 +94,7 @@ const BeamCmd = struct {
     @"api-port": u16 = constants.DEFAULT_API_PORT,
     data_dir: []const u8 = constants.DEFAULT_DATA_DIR,
 
-    pub fn format(self: BeamCmd, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: BeamCmd, writer: anytype) !void {
         try writer.print("BeamCmd{{ mockNetwork={}, api-port={d}, data_dir=\"{s}\" }}", .{
             self.mockNetwork,
             self.@"api-port",
@@ -182,14 +180,7 @@ const ZeamArgs = struct {
         .version = .v,
     };
 
-    pub fn format(
-        self: ZeamArgs,
-        comptime fmt: []const u8,
-        options: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: ZeamArgs, writer: anytype) !void {
         try writer.print("ZeamArgs(genesis={d}, log_filename=\"{s}\", console_log_level={s}, file_log_level={s}", .{
             self.genesis,
             self.log_filename,
@@ -199,7 +190,7 @@ const ZeamArgs = struct {
         try writer.writeAll(", command=");
         switch (self.__commands__) {
             .clock => try writer.writeAll("clock"),
-            .beam => |cmd| try writer.print("{any}", .{cmd}),
+            .beam => |cmd| try writer.print("{f}", .{cmd}),
             .prove => |cmd| try writer.print("prove(zkvm={s}, dist_dir=\"{s}\")", .{ @tagName(cmd.zkvm), cmd.dist_dir }),
             .prometheus => |cmd| switch (cmd.__commands__) {
                 .genconfig => |genconfig| try writer.print("prometheus.genconfig(api_port={d}, filename=\"{s}\")", .{ genconfig.@"api-port", genconfig.filename }),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -33,9 +33,7 @@ pub const BlockProductionParams = struct {
     slot: usize,
     proposer_index: usize,
 
-    pub fn format(self: BlockProductionParams, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: BlockProductionParams, writer: anytype) !void {
         try writer.print("BlockProductionParams{{ slot={d}, proposer_index={d} }}", .{ self.slot, self.proposer_index });
     }
 };
@@ -762,7 +760,7 @@ pub const BeamChain = struct {
 
                     self.forkChoice.onAttestation(attestation, true) catch |e| {
                         zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
-                        self.module_logger.err("error processing block attestation={any} error={any}", .{ attestation, e });
+                        self.module_logger.err("error processing block attestation={f} error={any}", .{ attestation, e });
                         continue;
                     };
                     zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "block" }) catch {};
@@ -784,7 +782,7 @@ pub const BeamChain = struct {
             .signature = proposer_signature,
         };
         self.forkChoice.onGossipAttestation(signed_proposer_attestation, false) catch |e| {
-            self.module_logger.err("error processing proposer attestation={any} error={any}", .{ signed_proposer_attestation, e });
+            self.module_logger.err("error processing proposer attestation={f} error={any}", .{ signed_proposer_attestation, e });
         };
 
         const processing_time = onblock_timer.observe();

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -23,9 +23,7 @@ pub const Clock = struct {
 
     const Self = @This();
 
-    pub fn format(self: Self, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: Self, writer: anytype) !void {
         try writer.print("Clock{{ genesis_time_ms={d}, current_interval={d} }}", .{ self.genesis_time_ms, self.current_interval });
     }
 

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -44,9 +44,7 @@ pub const ProtoNode = struct {
     // info populated lazily for tree visualization in snapshot for efficiency purposes
     numBranches: ?usize = null,
 
-    pub fn format(self: ProtoNode, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: ProtoNode, writer: anytype) !void {
         try writer.print("ProtoNode{{ slot={d}, weight={d}, blockRoot=0x{x} }}", .{
             self.slot,
             self.weight,
@@ -943,7 +941,7 @@ pub const ForkChoice = struct {
         const best_descendant_idx = justified_node.bestDescendant orelse justified_idx;
         const best_descendant = self.protoArray.nodes.items[best_descendant_idx];
 
-        self.logger.debug("computeFCHead from_known={} cutoff_weight={d} deltas_len={d} justified_node={any} best_descendant_idx={d}", .{
+        self.logger.debug("computeFCHead from_known={} cutoff_weight={d} deltas_len={d} justified_node={f} best_descendant_idx={d}", .{
             from_known,
             cutoff_weight,
             deltas.len,

--- a/pkgs/spectest/src/json_expect.zig
+++ b/pkgs/spectest/src/json_expect.zig
@@ -22,9 +22,7 @@ pub const Context = struct {
 pub const StepSuffix = struct {
     step: ?usize,
 
-    pub fn format(self: StepSuffix, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: StepSuffix, writer: anytype) !void {
         if (self.step) |idx| {
             try writer.print(" step #{}", .{idx});
         }

--- a/pkgs/types/src/attestation.zig
+++ b/pkgs/types/src/attestation.zig
@@ -56,9 +56,7 @@ pub const Attestation = struct {
     validator_id: ValidatorIndex,
     data: AttestationData,
 
-    pub fn format(self: Attestation, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: Attestation, writer: anytype) !void {
         try writer.print("Attestation{{ validator={d}, slot={d}, source_slot={d}, target_slot={d} }}", .{
             self.validator_id,
             self.data.slot,
@@ -86,9 +84,7 @@ pub const SignedAttestation = struct {
     message: AttestationData,
     signature: SIGBYTES,
 
-    pub fn format(self: SignedAttestation, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-        _ = options;
+    pub fn format(self: SignedAttestation, writer: anytype) !void {
         try writer.print("SignedAttestation{{ validator={d}, slot={d}, source_slot={d}, target_slot={d} }}", .{
             self.validator_id,
             self.message.slot,

--- a/pkgs/utils/src/fmt.zig
+++ b/pkgs/utils/src/fmt.zig
@@ -20,15 +20,7 @@ pub fn LazyJson(comptime T: type) type {
             };
         }
 
-        pub fn format(
-            self: @This(),
-            comptime fmt: []const u8,
-            options: std.fmt.FormatOptions,
-            writer: anytype,
-        ) !void {
-            _ = fmt;
-            _ = options;
-
+        pub fn format(self: @This(), writer: anytype) !void {
             const json_str = self.value.toJsonString(self.allocator) catch |e| {
                 try writer.print("<json error: {any}>", .{e});
                 return;
@@ -54,7 +46,7 @@ test "LazyJson formats JSON and frees allocation" {
 
     var buffer: std.ArrayList(u8) = .empty;
     defer buffer.deinit(allocator);
-    try lazy_json.format("", .{}, buffer.writer(allocator));
+    try lazy_json.format(buffer.writer(allocator));
 
     try std.testing.expectEqualStrings("{\"ok\":true}", buffer.items);
 }
@@ -75,7 +67,7 @@ test "LazyJson formats error on toJsonString failure" {
 
     var buffer: std.ArrayList(u8) = .empty;
     defer buffer.deinit(allocator);
-    try lazy_json.format("", .{}, buffer.writer(allocator));
+    try lazy_json.format(buffer.writer(allocator));
 
     try std.testing.expect(std.mem.containsAtLeast(u8, buffer.items, 1, "<json error:"));
 }


### PR DESCRIPTION
[info] (zeam-n2): [node] peer connected: zeam_n1(zeam_n1), direction=outbound, total peers: 1
  [info] (zeam-n2): [node] sent status request to peer zeam_n1(zeam_n1): request_id=1, head_slot=0, finalized_slot=0
  [info] (zeam-n1): [node] peer connected: zeam_n2(zeam_n2), direction=inbound, total peers: 1
  [info] (zeam-n1): [node] sent status request to peer zeam_n2(zeam_n2): request_id=2, head_slot=0, finalized_slot=0
  [info] (zeam-n2): [node] received status response from peer zeam_n1(zeam_n1) head_slot=0, finalized_slot=0
  [info] (zeam-n1): [node] received status response from peer zeam_n2(zeam_n2) head_slot=0, finalized_slot=0
  [info] (zeam-n2): [node] published attestation to network: slot=0 validator=1(zeam_n2)
  [info] (zeam-n1): [node] received gossip attestation for slot=0 validator=1(zeam_n2) from peer=zeam_n1(zeam_n1)
  [info] (zeam-n1): [chain] processed gossip attestation for slot=0 validator=1(zeam_n2)
  [info] (zeam-n2): [node] published block to network: slot=1 proposer=1(zeam_n2)
  [info] (zeam-n1): [node] received gossip block for slot=1 proposer=1(zeam_n2) hasParentBlock=true from peer=zeam_n1(zeam_n1)
  [info] (zeam-n1): [node] published attestation to network: slot=1 validator=0(zeam_n1)
  [info] (zeam-n1): [node] received gossip attestation for slot=1 validator=0(zeam_n1) from peer=zeam_n1(zeam_n1)
  [info] (zeam-n2): [node] received gossip attestation for slot=1 validator=0(zeam_n1) from peer=zeam_n1(zeam_n1)