### PR TITLE
fix checkpoint sync init — optional justified/finalized + ready/initing status

### DIFF
--- a/pkgs/cli/src/api_server.zig
+++ b/pkgs/cli/src/api_server.zig
@@ -298,7 +298,11 @@ pub const ApiServer = struct {
         };
 
         // Get justified checkpoint from chain (chain handles its own locking internally)
-        const justified_checkpoint = chain.getJustifiedCheckpoint();
+        const justified_checkpoint_opt = chain.getJustifiedCheckpoint();
+        const justified_checkpoint = justified_checkpoint_opt orelse {
+            _ = request.respond("{}", .{}) catch {};
+            return;
+        };
 
         // Convert checkpoint to JSON string
         const json_string = justified_checkpoint.toJsonString(self.allocator) catch |err| {

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -619,7 +619,7 @@ fn mainInner() !void {
                     if (self.started) return;
 
                     // Wait until finalization has advanced beyond genesis on the reference node
-                    const finalized_slot = self.reference_node.chain.forkChoice.fcStore.latest_finalized.slot;
+                    const finalized_slot = if (self.reference_node.chain.forkChoice.fcStore.latest_finalized) |lf| lf.slot else 0;
                     if (finalized_slot == 0) return;
 
                     std.debug.print("\n=== STARTING NODE 3 (delayed sync node) at interval {d} ===\n", .{interval});

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -422,7 +422,7 @@ pub const BeamNode = struct {
         signed_block: types.SignedBlockWithAttestation,
         depth: u32,
     ) CacheBlockError!types.Root {
-        const finalized_slot = self.chain.forkChoice.fcStore.latest_finalized.slot;
+        const finalized_slot = if (self.chain.forkChoice.fcStore.latest_finalized) |lf| lf.slot else 0;
         const block_slot = signed_block.message.block.slot;
 
         // Early rejection: don't cache blocks at or before finalized slot
@@ -615,7 +615,7 @@ pub const BeamNode = struct {
                             switch (sync_status) {
                                 .behind_peers => |info| {
                                     // Only sync from this peer if their finalized slot is ahead of ours
-                                    if (status_resp.finalized_slot > self.chain.forkChoice.fcStore.latest_finalized.slot) {
+                                    if (status_resp.finalized_slot > if (self.chain.forkChoice.fcStore.latest_finalized) |lf| lf.slot else 0) {
                                         self.logger.info("peer {s}{f} is ahead (peer_finalized_slot={d} > our_head_slot={d}), initiating sync by requesting head block 0x{x}", .{
                                             status_ctx.peer_id,
                                             self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),

--- a/pkgs/node/src/tree_visualizer.zig
+++ b/pkgs/node/src/tree_visualizer.zig
@@ -196,7 +196,7 @@ pub fn buildForkChoiceGraphJSON(
     // Find the finalized node index to check ancestry
     const finalized_idx = blk: {
         for (proto_nodes, 0..) |n, i| {
-            if (std.mem.eql(u8, &n.blockRoot, &snapshot.latest_finalized_root)) {
+            if (if (snapshot.latest_finalized_root) |lfr| std.mem.eql(u8, &n.blockRoot, &lfr) else false) {
                 break :blk i;
             }
         }
@@ -208,14 +208,14 @@ pub fn buildForkChoiceGraphJSON(
 
         // Determine node role and color
         const is_head = std.mem.eql(u8, &pnode.blockRoot, &snapshot.head.blockRoot);
-        const is_justified = std.mem.eql(u8, &pnode.blockRoot, &snapshot.latest_justified_root);
+        const is_justified = if (snapshot.latest_justified_root) |ljr| std.mem.eql(u8, &pnode.blockRoot, &ljr) else false;
 
         // A block is finalized if:
         // 1. It equals the finalized checkpoint, OR
         // 2. The finalized block is a descendant of it (block is ancestor of finalized)
         const is_finalized = blk: {
             // Check if this block IS the finalized block
-            if (std.mem.eql(u8, &pnode.blockRoot, &snapshot.latest_finalized_root)) {
+            if (if (snapshot.latest_finalized_root) |lfr| std.mem.eql(u8, &pnode.blockRoot, &lfr) else false) {
                 break :blk true;
             }
             // Check if this block is an ancestor of the finalized block


### PR DESCRIPTION
Fixes #608

## Problem

When initializing forkchoice from checkpoint sync or DB using a finalized state as anchor, `latest_justified` and `latest_finalized` were incorrectly set to the anchor checkpoint. This is only correct for genesis. For non-genesis anchors, these fields track the actual latest justified/finalized seen across processed block states — setting them to the anchor misleads every consumer.

## Changes

### `ForkChoiceStore`
- `latest_justified` and `latest_finalized` → `?types.Checkpoint` (optional)
- `update()` now returns `bool` — `true` the first time `latest_justified` transitions from `null` to a real value

### `ForkChoice` — new `status` field
- `.initing` — non-genesis anchor before first `onBlock()`; `latest_justified` not yet set
- `.ready` — `latest_justified` populated; normal participation allowed

### `ForkChoice.init()`
- **Genesis** (`slot == 0`): sets both CPs to anchor, `status = .ready`, runs `updateHeadUnlocked()` as before
- **Non-genesis**: leaves both CPs `null`, `status = .initing`, skips `updateHeadUnlocked()`
- Info logs in both paths describing the init sequence

### `onBlockUnlocked()`
- After `fcStore.update()`, if `became_ready && status == .initing` → transitions to `.ready` + emits info log with justified/finalized slots

### Gated participation APIs (return `ForkChoiceNotReady` when `.initing`)
- `getProposalHead()` — block construction
- `getAttestationTarget()` — attestation production
- `computeFCHeadUnlocked()` — internal head computation
- `getAttestationTargetUnlocked()` — internal attestation target
- `tickIntervalUnlocked()` — clock still ticks but attestation/safe-target work is skipped

### New public API
- `isReady() bool` — node layer can query forkchoice readiness before attempting participation

### Null-safe guards
- `isFinalizedDescendant()` returns `true` (accept all) when `latest_finalized` is null
- `PreFinalizedSlot` check is null-safe
- `getProposalAttestationsUnlocked()` returns empty slice when no justified yet

### `Snapshot`
- `latest_justified_root` / `latest_finalized_root` → `?[32]u8`
- New `status` field

### Tests
- All 3 direct `ForkChoice` literal constructions get `.status = .ready`
- `latest_finalized` test assertions updated to use `.?.root`