### PR TITLE
feat: skip incoming gossip attestations unless node is aggregator with registered validators in subnet

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -736,6 +736,30 @@ pub const BeamChain = struct {
                     sender_node_name,
                 });
 
+                // Only process incoming gossip attestations if we are an aggregator
+                // and have registered validator IDs in this attestation's subnet.
+                if (!self.is_aggregator_enabled or self.registered_validator_ids.len == 0) {
+                    self.logger.debug("skipping gossip attestation subnet={d}: node is not an aggregator", .{signed_attestation.subnet_id});
+                    return .{};
+                }
+
+                // Check if any of our registered validator IDs belong to this subnet
+                const committee_count = self.config.spec.attestation_committee_count;
+                if (committee_count > 0) {
+                    var subnet_has_our_validator = false;
+                    for (self.registered_validator_ids) |vid| {
+                        const subnet = try types.computeSubnetId(@intCast(vid), committee_count);
+                        if (subnet == @as(u64, signed_attestation.subnet_id)) {
+                            subnet_has_our_validator = true;
+                            break;
+                        }
+                    }
+                    if (!subnet_has_our_validator) {
+                        self.logger.debug("skipping gossip attestation subnet={d}: no registered validators in subnet", .{signed_attestation.subnet_id});
+                        return .{};
+                    }
+                }
+
                 // Validate attestation before processing (gossip = not from block)
                 self.validateAttestation(signed_attestation.message.toAttestation(), false) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};


### PR DESCRIPTION
## Summary

Fixes attestation gossip listen/processing behavior in `pkgs/node/src/chain.zig`.

## Problem

Previously, the `onGossip` function’s `.attestation` case processed **all** incoming gossip attestations unconditionally, regardless of whether the node is configured as an aggregator or has registered validators in the attestation’s subnet.

## Desired Behavior

1. A node should subscribe to attestation subnet gossip only if it has registered validator IDs for that subnet (already correctly implemented in `node.zig`).
2. When a gossip attestation arrives, the node should **NOT** process it unless:
   - `is_aggregator_enabled == true` AND
   - The node has registered validator IDs in that attestation’s subnet
3. The node publishes its own attestations regardless, but only listens/processes incoming ones if it’s an aggregator with validators in that subnet.

## Changes

In `pkgs/node/src/chain.zig`, in the `.attestation` arm of `onGossip`, added a guard before `validateAttestation`:

- If `is_aggregator_enabled == false` or `registered_validator_ids` is empty, skip processing and return early.
- If `committee_count > 0`, check whether any registered validator ID maps to the incoming attestation’s subnet. If none match, skip processing.
- If `committee_count == 0`, skip the subnet check (pass-through, no subnets defined).

All existing tests are unaffected because they call `onGossipAttestation` directly, bypassing the `onGossip` filter.