### PR TITLE
refactor: combine justified/finalized slot+root into Checkpoint in ForkChoice Snapshot

### DIFF
--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -311,10 +311,8 @@ pub const ForkChoice = struct {
     /// Thread-safe snapshot for observability
     pub const Snapshot = struct {
         head: ProtoNode,
-        latest_justified_root: [32]u8,
-        latest_justified_slot: types.Slot,
-        latest_finalized_root: [32]u8,
-        latest_finalized_slot: types.Slot,
+        latest_justified: types.Checkpoint,
+        latest_finalized: types.Checkpoint,
         safe_target_root: [32]u8,
         validator_count: u64,
         nodes: []ProtoNode,
@@ -440,10 +438,8 @@ pub const ForkChoice = struct {
             };
             return Snapshot{
                 .head = head_node,
-                .latest_justified_root = self.fcStore.latest_justified.root,
-                .latest_justified_slot = self.fcStore.latest_justified.slot,
-                .latest_finalized_root = self.fcStore.latest_finalized.root,
-                .latest_finalized_slot = self.fcStore.latest_finalized.slot,
+                .latest_justified = self.fcStore.latest_justified,
+                .latest_finalized = self.fcStore.latest_finalized,
                 .safe_target_root = self.safeTarget.blockRoot,
                 .validator_count = self.config.genesis.numValidators(),
                 .nodes = nodes_copy,
@@ -452,10 +448,8 @@ pub const ForkChoice = struct {
 
         return Snapshot{
             .head = self.protoArray.nodes.items[head_idx],
-            .latest_justified_root = self.fcStore.latest_justified.root,
-            .latest_justified_slot = self.fcStore.latest_justified.slot,
-            .latest_finalized_root = self.fcStore.latest_finalized.root,
-            .latest_finalized_slot = self.fcStore.latest_finalized.slot,
+            .latest_justified = self.fcStore.latest_justified,
+            .latest_finalized = self.fcStore.latest_finalized,
             .safe_target_root = self.safeTarget.blockRoot,
             .validator_count = self.config.genesis.numValidators(),
             .nodes = nodes_copy,

--- a/pkgs/node/src/tree_visualizer.zig
+++ b/pkgs/node/src/tree_visualizer.zig
@@ -174,10 +174,10 @@ pub fn buildForkChoiceJSON(
     , .{
         snapshot.head.slot,
         &snapshot.head.blockRoot,
-        snapshot.latest_justified_slot,
-        &snapshot.latest_justified_root,
-        snapshot.latest_finalized_slot,
-        &snapshot.latest_finalized_root,
+        snapshot.latest_justified.slot,
+        &snapshot.latest_justified.root,
+        snapshot.latest_finalized.slot,
+        &snapshot.latest_finalized.root,
         &snapshot.safe_target_root,
         snapshot.validator_count,
     });
@@ -227,7 +227,7 @@ pub fn buildForkChoiceGraphJSON(
     // Find the finalized node index to check ancestry
     const finalized_idx = blk: {
         for (proto_nodes, 0..) |n, i| {
-            if (std.mem.eql(u8, &n.blockRoot, &snapshot.latest_finalized_root)) {
+            if (std.mem.eql(u8, &n.blockRoot, &snapshot.latest_finalized.root)) {
                 break :blk i;
             }
         }
@@ -239,14 +239,14 @@ pub fn buildForkChoiceGraphJSON(
 
         // Determine node role and color
         const is_head = std.mem.eql(u8, &pnode.blockRoot, &snapshot.head.blockRoot);
-        const is_justified = std.mem.eql(u8, &pnode.blockRoot, &snapshot.latest_justified_root);
+        const is_justified = std.mem.eql(u8, &pnode.blockRoot, &snapshot.latest_justified.root);
 
         // A block is finalized if:
         // 1. It equals the finalized checkpoint, OR
         // 2. The finalized block is a descendant of it (block is ancestor of finalized)
         const is_finalized = blk: {
             // Check if this block IS the finalized block
-            if (std.mem.eql(u8, &pnode.blockRoot, &snapshot.latest_finalized_root)) {
+            if (std.mem.eql(u8, &pnode.blockRoot, &snapshot.latest_finalized.root)) {
                 break :blk true;
             }
             // Check if this block is an ancestor of the finalized block


### PR DESCRIPTION
Requested by @g11tech in https://github.com/blockblaz/zeam/pull/607#discussion_r2877938683

## Summary

Replace the separate `latest_justified_root: [32]u8` and `latest_finalized_root: [32]u8` fields in `ForkChoice.Snapshot` with unified `types.Checkpoint` objects — `latest_justified` and `latest_finalized` — mirroring the `ForkChoiceStore` fields they are derived from.

Similarly the `latest_finalized_root` / `latest_justified_root` references in `tree_visualizer.zig` are updated to use `.root` on the new checkpoint fields.

### Changes
- `pkgs/node/src/forkchoice.zig`: `Snapshot` struct updated; both construction sites now pass the full checkpoint object
- `pkgs/node/src/tree_visualizer.zig`: callers updated to `snapshot.latest_justified.root` / `snapshot.latest_finalized.root`

## Testing
- [ ] `zig build test` passes