### PR TITLE
fix: only assign aggregator role to node 1 in simtest

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -617,7 +617,7 @@ fn mainInner() !void {
                 .db = db_2,
                 .logger_config = &logger2_config,
                 .node_registry = registry_2,
-                .is_aggregator = beamcmd.@"is-aggregator",
+                .is_aggregator = false,
             });
 
             // Node 3 setup - delayed start for initial sync testing
@@ -635,7 +635,7 @@ fn mainInner() !void {
                 .db = db_3,
                 .logger_config = &logger3_config,
                 .node_registry = registry_3,
-                .is_aggregator = beamcmd.@"is-aggregator",
+                .is_aggregator = false,
             });
 
             // Delayed runner - starts both network3 and node3 together


### PR DESCRIPTION
## Summary

Fixes #641

When running `zig build simtest`, all three nodes were initialized with `.is_aggregator = beamcmd.@"is-aggregator"`, causing all of them to act as aggregators when `--is-aggregator true` is passed. Per spec, only one aggregator should exist per subnet.

## Fix

Hardcode `is_aggregator = false` for nodes 2 and 3. Only node 1 (the primary node) inherits the `--is-aggregator` CLI flag.

## Changes

- `pkgs/cli/src/main.zig`: `beam_node_2` and `beam_node_3` now always initialize with `is_aggregator = false`