### PR TITLE
fix: only assign one aggregator in simtest

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -617,7 +617,8 @@ fn mainInner() !void {
                 .db = db_2,
                 .logger_config = &logger2_config,
                 .node_registry = registry_2,
-                .is_aggregator = beamcmd.@"is-aggregator",
+                // Node 1 is not the aggregator; only one aggregator per subnet (node 0).
+                .is_aggregator = false,
             });
 
             // Node 3 setup - delayed start for initial sync testing
@@ -635,7 +636,8 @@ fn mainInner() !void {
                 .db = db_3,
                 .logger_config = &logger3_config,
                 .node_registry = registry_3,
-                .is_aggregator = beamcmd.@"is-aggregator",
+                // Node 2 is not the aggregator; only one aggregator per subnet (node 0).
+                .is_aggregator = false,
             });
 
             // Delayed runner - starts both network3 and node3 together


### PR DESCRIPTION
Closes #641

## Summary

When running `zig build simtest`, all three simulated nodes were initialized with `is_aggregator = beamcmd.@"is-aggregator"`. Since a subnet should have exactly one aggregator, nodes 1 and 2 (`beam_node_2` and `beam_node_3`) now always have `is_aggregator = false`; only node 0 (`beam_node_1`) inherits the `--is-aggregator` flag from the CLI argument.

## Testing
- [ ] `zig build test` passes