### PR TITLE
fix: merge known+new attestation pools for safe target calculation

### DIFF
--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -250,9 +250,8 @@ const AttestationSource = enum {
     new,
     /// Merge both pools: for each validator, use the attestation with the
     /// higher slot. This is needed for safe-target calculation at interval 3,
-    /// where "new" has not yet been promoted but "known" may contain
-    /// attestations that bypassed the gossip pipeline (e.g. proposer's own
-    /// attestation bundled in a block, or a node's self-attestation).
+    /// where "new" has not yet been promoted but "known" contains the
+    /// proposer's attestation (bundled in the block, never enters "new").
     merged,
 };
 
@@ -1009,9 +1008,8 @@ pub const ForkChoice = struct {
                 .new => attestation_tracker.latestNew,
                 .merged => blk: {
                     // Merge both pools: pick whichever has the higher slot.
-                    // This ensures attestations that bypassed gossip (e.g.
-                    // proposer's own attestation in a block, or self-attestation)
-                    // are included in the safe target calculation.
+                    // The proposer's attestation is only in "known" (bundled
+                    // in the block); without merging it would be missed.
                     const known = attestation_tracker.latestKnown;
                     const new = attestation_tracker.latestNew;
                     if (known == null) break :blk new;
@@ -1090,10 +1088,9 @@ pub const ForkChoice = struct {
     fn updateSafeTargetUnlocked(self: *Self) !ProtoBlock {
         const cutoff_weight = try std.math.divCeil(u64, 2 * self.config.genesis.numValidators(), 3);
         // Merge both known and new attestation pools for safe target calculation.
-        // At interval 3, some attestations may only exist in "known" (e.g.
-        // proposer's own attestation bundled in a block, or self-attestation
-        // that bypasses the gossip pipeline). Using only "new" would undercount
-        // support and cause the safe target to stall.
+        // At interval 3, the proposer's attestation only exists in "known"
+        // (bundled in the block via onBlock, skipped by mayBeDoAttestation).
+        // Using only "new" would miss that vote and undercount support.
         self.safeTarget = try self.computeFCHeadUnlocked(.merged, cutoff_weight);
         // Update safe target slot metric
         zeam_metrics.metrics.lean_safe_target_slot.set(self.safeTarget.slot);


### PR DESCRIPTION
## Motivation

In the 3SF-mini slot cycle, **interval 3** computes the *safe target* — the deepest block with 2/3+ supermajority attestation weight. Validators use this safe target at interval 1 of the next slot to decide which block to attest to (see `get_attestation_target`).

Previously, zeam's safe target computation only read from the `latestNew` (gossip) attestation pool. However, at interval 3 the migration step (interval 4: new → known) has **not yet run**, and the **proposer's attestation** enters `latestKnown` through a path that bypasses gossip:

- The block proposer bundles their attestation directly in `BlockWithAttestation`
- When the block is processed via `onBlock`, `onAttestationUnlocked(att, is_from_block=true)` writes it to `latestKnown`
- Meanwhile, `mayBeDoAttestation` explicitly skips the proposer (`if (validator_id == slot_proposer_id) continue`), so the proposer's attestation **never enters `latestNew`**

Using only `latestNew` made the proposer's attestation invisible to the safe target calculation, undercounting support by 1 vote and potentially causing the safe target to stall when that vote is needed for 2/3 quorum.

## Spec Reference

This aligns zeam with leanSpec's `Store.update_safe_target()` ([store.py L850-L952](https://github.com/LeanEthereum/leanSpec/blob/main/src/lean_spec/subspecs/forkchoice/store.py#L850-L952)), which explicitly merges both pools:

> Both pools must be merged to get the full attestation picture.
> Using only one pool undercounts support.
>
> — leanSpec `update_safe_target()` docstring (L871-L873)

The spec code (L917-L926):
```python
all_payloads = dict(self.latest_known_aggregated_payloads)
for sig_key, proofs in self.latest_new_aggregated_payloads.items():
    if sig_key in all_payloads:
        all_payloads[sig_key] = all_payloads[sig_key] + proofs
    else:
        all_payloads[sig_key] = proofs
```

The spec also notes (L875): *"the Ream reference implementation uses only the 'new' pool. Our merge approach is more conservative."*

## Changes

- Introduce `AttestationSource` enum (`known` / `new` / `merged`) replacing the `from_known: bool` parameter in `computeDeltasUnlocked`
- `.merged` mode picks the higher-slot attestation from both `latestKnown` and `latestNew` per validator
- `updateSafeTargetUnlocked` now uses `.merged`; `updateHeadUnlocked` continues to use `.known`

## Test plan
- [x] All existing forkchoice tests updated and passing (`computeDeltas(true)` → `.known`, `computeDeltas(false)` → `.new`)
- [x] 4-node simtest finalization interop verified