### PR TITLE
fix capture original finalized slot for justifiability

### DIFF
--- a/pkgs/types/src/state.zig
+++ b/pkgs/types/src/state.zig
@@ -374,6 +374,7 @@ pub const BeamState = struct {
         }
         try self.getJustification(allocator, &justifications);
 
+        const original_finalized_slot: Slot = self.latest_finalized.slot;
         var finalized_slot: Slot = self.latest_finalized.slot;
 
         // Use the global cache directly if provided, otherwise build a local cache.
@@ -430,7 +431,7 @@ pub const BeamState = struct {
             const has_known_root = has_correct_source_root and has_correct_target_root;
 
             const target_not_ahead = target_slot <= source_slot;
-            const is_target_justifiable = try utils.IsJustifiableSlot(self.latest_finalized.slot, target_slot);
+            const is_target_justifiable = try utils.IsJustifiableSlot(original_finalized_slot, target_slot);
 
             if (!is_source_justified or
                 // not present in 3sf mini but once a target is justified no need to run loop
@@ -495,7 +496,7 @@ pub const BeamState = struct {
                 const end_slot_usize: usize = @intCast(target_slot);
                 for (start_slot_usize..end_slot_usize) |slot_usize| {
                     const slot: Slot = @intCast(slot_usize);
-                    if (try utils.IsJustifiableSlot(self.latest_finalized.slot, slot)) {
+                    if (try utils.IsJustifiableSlot(original_finalized_slot, slot)) {
                         can_target_finalize = false;
                         break;
                     }


### PR DESCRIPTION
Bug: IsJustifiableSlot was called with self.latest_finalized.slot which gets mutated mid-loop when finalization occurs, causing subsequent attestations to be checked against the wrong finalized slot.

  Fix: Capture original_finalized_slot at the start of attestation processing and use it for all justifiability checks, matching the spec behavior where self.latest_finalized is never modified during the loop.

  Spec proof:

  File: leanSpec/src/lean_spec/subspecs/containers/state/state.py

  Lines 585 & 638-639 - Justifiability checks use self.latest_finalized.slot:
  if not target.slot.is_justifiable_after(self.latest_finalized.slot):  # Line 585

  if not any(
      Slot(slot).is_justifiable_after(self.latest_finalized.slot)  # Line 639

  Lines 642-644 - Only LOCAL variables are updated during the loop:
  old_finalized_slot = finalized_slot
  latest_finalized = source
  finalized_slot = latest_finalized.slot

  Line 688 - self is only updated AFTER the loop ends:
  "latest_finalized": latest_finalized,

  Lean spec never mutates self.latest_finalized during attestation processing it only updates local variables. we incorrectly mutating self.latest_finalized at line 506 while still referencing it for justifiability checks.