### PR TITLE
fix: IsJustifiableSlot should use the original_finalized_slot

### DIFF
--- a/pkgs/types/src/state.zig
+++ b/pkgs/types/src/state.zig
@@ -376,6 +376,8 @@ pub const BeamState = struct {
 
         var finalized_slot: Slot = self.latest_finalized.slot;
 
+        const original_finalized_slot: Slot = self.latest_finalized.slot;
+
         // Use the global cache directly if provided, otherwise build a local cache.
         var owned_cache: ?utils.RootToSlotCache = if (cache == null) utils.RootToSlotCache.init(allocator) else null;
         defer if (owned_cache) |*oc| oc.deinit();
@@ -430,7 +432,7 @@ pub const BeamState = struct {
             const has_known_root = has_correct_source_root and has_correct_target_root;
 
             const target_not_ahead = target_slot <= source_slot;
-            const is_target_justifiable = try utils.IsJustifiableSlot(self.latest_finalized.slot, target_slot);
+            const is_target_justifiable = try utils.IsJustifiableSlot(original_finalized_slot, target_slot);
 
             if (!is_source_justified or
                 // not present in 3sf mini but once a target is justified no need to run loop
@@ -495,7 +497,7 @@ pub const BeamState = struct {
                 const end_slot_usize: usize = @intCast(target_slot);
                 for (start_slot_usize..end_slot_usize) |slot_usize| {
                     const slot: Slot = @intCast(slot_usize);
-                    if (try utils.IsJustifiableSlot(self.latest_finalized.slot, slot)) {
+                    if (try utils.IsJustifiableSlot(original_finalized_slot, slot)) {
                         can_target_finalize = false;
                         break;
                     }


### PR DESCRIPTION
In leanSpec, self is immutable throughout process_attestations. 

The is_justifiable_after checks use self.latest_finalized.slot (the pre-state value).

LeanSpec `base.py`:

```
class StrictBaseModel(CamelModel):
    """A strict, immutable pydantic base model."""

    model_config = CamelModel.model_config | {
        "extra": "forbid",
        "frozen": True,
        "strict": True,
    }
```

Using self.latest_finalized.slot for the is justifiable checks leads to a deviation from spec as self.latest_finalized is changed in-place on like 508 in state.zig:

`self.latest_finalized = attestation_data.source;
`

This lead to the error in todays devnet where a block from gossip was rejected and then lead to UnknownHeadBlock errors. 

```zig
Mar-06 19:02:33.241 [s=2467 i=1] [info] (zeam): [node] received gossip block for slot=2467 parent_root=0x333fea4ab8b33c8056aa0ce6e8f64829496860a596778d1e9accaa83deded0f2 proposer=1 hasParentBlock=true from peer=unknown_peer
Mar-06 19:02:33.427 [s=2467 i=1] [error] (zeam): [chain] error processing block for slot=2467 root=0xb42df1ab428bf5f10e62639dba50d21067fc0a523fcc53097d241160c9c921f8: error.InvalidJustifiableSlot
Mar-06 19:02:33.427 [s=2467 i=1] [error] (zeam): [network] network-0:: onGossip handler error=error.InvalidJustifiableSlot
Mar-06 19:02:33.485 [s=2467 i=1] [info] (zeam): [network] rust-bridge: [reqresp] Received request from 16Uiu2HAmPQhkD6Zg5Co2ee8ShshkiY4tDePKFARPpCS2oKSLj1E1 for protocol /leanconsensus/req/status/1/ssz_snappy (99 bytes)
Mar-06 19:02:33.485 [s=2467 i=1] [info] (zeam): [network] rust-bridge: [reqresp] Sent response payload on channel 1454 (peer: 16Uiu2HAmPQhkD6Zg5Co2ee8ShshkiY4tDePKFARPpCS2oKSLj1E1)
Mar-06 19:02:33.485 [s=2467 i=1] [info] (zeam): [network] rust-bridge: [reqresp] Sent end-of-stream on channel 1454 (peer: 16Uiu2HAmPQhkD6Zg5Co2ee8ShshkiY4tDePKFARPpCS2oKSLj1E1)
Mar-06 19:02:34.141 [s=2467 i=2] [info] (zeam): [node] received gossip attestation for slot=2467 validator=1 from peer=unknown_peer
Mar-06 19:02:34.141 [s=2467 i=2] [warning] (zeam): [node] gossip attestation validation failed slot=2467 validator=1 error=error.UnknownHeadBlock
Mar-06 19:02:34.709 [s=2467 i=3] [info] (zeam): [node] received gossip aggregation for slot=2467 from peer=unknown_peer.{ .name = null }
Mar-06 19:02:34.822 [s=2467 i=3] [info] (zeam): [node] received gossip aggregation for slot=2467 from peer=unknown_peer.{ .name = null }
Mar-06 19:02:36.057 [s=2468 i=0] [info] (zeam): [node] received gossip block for slot=2468 parent_root=0xb42df1ab428bf5f10e62639dba50d21067fc0a523fcc53097d241160c9c921f8 proposer=2 hasParentBlock=false from peer=unknown_peer
Mar-06 19:02:36.059 [s=2468 i=0] [info] (zeam): [network] rust-bridge: [reqresp] Sent BlocksByRootV1 request to 16Uiu2HAmPQhkD6Zg5Co2ee8ShshkiY4tDePKFARPpCS2oKSLj1E1 (id: 10)
Mar-06 19:02:36.735 [s=2468 i=0] [info] (zeam): [network] rust-bridge: [reqresp] Received response from 16Uiu2HAmPQhkD6Zg5Co2ee8ShshkiY4tDePKFARPpCS2oKSLj1E1 for request id 10 (667081 bytes)
Mar-06 19:02:36.756 [s=2468 i=0] [info] (zeam): [node] received blocks-by-root chunk from peer 16Uiu2HAmPQhkD6Zg5Co2ee8ShshkiY4tDePKFARPpCS2oKSLj1E1(ream_0)
Mar-06 19:02:36.800 [s=2468 i=1] [info] (zeam): [chain] 
+=================
```