### PR TITLE
fix: handle and fetch missing roots in gossip attestation and aggregated attestation

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -739,10 +739,21 @@ pub const BeamChain = struct {
                 // Validate attestation before processing (gossip = not from block)
                 self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-                    // Propagate unknown block errors to node.zig for context-aware logging
-                    // (downgrade to debug when the missing block is already being fetched)
                     switch (err) {
-                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
+                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
+                            // Add the missing root to the result so node's onGossip can enqueue it for fetching
+                            const att_data = signed_attestation.message.message;
+                            const missing_root = if (err == error.UnknownHeadBlock)
+                                att_data.head.root
+                            else if (err == error.UnknownSourceBlock)
+                                att_data.source.root
+                            else
+                                att_data.target.root;
+                            var roots: std.ArrayListUnmanaged(types.Root) = .empty;
+                            errdefer roots.deinit(self.allocator);
+                            try roots.append(self.allocator, missing_root);
+                            return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
+                        },
                         else => {
                             self.logger.warn("gossip attestation validation failed: {any}", .{err});
                             return .{};
@@ -775,7 +786,20 @@ pub const BeamChain = struct {
                 self.validateAttestationData(signed_aggregation.data, false) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
                     switch (err) {
-                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
+                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
+                            // Add the missing root to the result so node's onGossip can enqueue it for fetching
+                            const att_data = signed_aggregation.data;
+                            const missing_root = if (err == error.UnknownHeadBlock)
+                                att_data.head.root
+                            else if (err == error.UnknownSourceBlock)
+                                att_data.source.root
+                            else
+                                att_data.target.root;
+                            var roots: std.ArrayListUnmanaged(types.Root) = .empty;
+                            errdefer roots.deinit(self.allocator);
+                            try roots.append(self.allocator, missing_root);
+                            return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
+                        },
                         else => {
                             self.logger.warn("gossip aggregation validation failed: {any}", .{err});
                             return .{};
@@ -785,14 +809,8 @@ pub const BeamChain = struct {
 
                 self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
-                    switch (err) {
-                        // Propagate unknown block errors to node.zig for context-aware logging
-                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
-                        else => {
-                            self.logger.warn("gossip aggregation processing error: {any}", .{err});
-                            return .{};
-                        },
-                    }
+                    self.logger.warn("gossip aggregation processing error: {any}", .{err});
+                    return .{};
                 };
                 zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "aggregation" }) catch {};
                 return .{};

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -321,16 +321,15 @@ pub const BeamNode = struct {
             self.processCachedDescendants(processed_root);
         }
 
-        // Fetch any attestation head roots that were missing while processing the block.
-        // We only own the slice when the block was actually processed (onBlock allocates it).
+        // Fetch any block roots that were missing while processing a block or validating attestation/aggregation gossip.
+        // We own the slice whenever it's non-empty (onBlock and onGossip both allocate it).
         const missing_roots = result.missing_attestation_roots;
-        const owns_missing_roots = result.processed_block_root != null;
-        defer if (owns_missing_roots) self.allocator.free(missing_roots);
+        defer if (missing_roots.len > 0) self.allocator.free(missing_roots);
 
-        if (missing_roots.len > 0 and owns_missing_roots) {
+        if (missing_roots.len > 0) {
             self.fetchBlockByRoots(missing_roots, 0) catch |err| {
                 self.logger.warn(
-                    "failed to fetch {d} missing attestation head block(s) from gossip: {any}",
+                    "failed to fetch {d} missing block root(s) from gossip: {any}",
                     .{ missing_roots.len, err },
                 );
             };


### PR DESCRIPTION
Closes #657

## Summary

When `validateAttestationData` throws `UnknownHeadBlock`, `UnknownSourceBlock`, or `UnknownTargetBlock` during gossip attestation or aggregated attestation handling, instead of propagating the error (which was caught and silently discarded in node.zig), we now:

1. Extract the specific missing root (head, source, or target) from the attestation data
2. Return it via `missing_attestation_roots` in the gossip result
3. `node.onGossip` then enqueues it for fetching via `fetchBlockByRoots`

This mirrors what already happens for block gossip unknown attestation roots, ensuring peers can provide the missing blocks instead of silently dropping the attestation.

**Changes:**
- `chain.zig`: In both `onGossipAttestation` and `onGossipAggregatedAttestation`, replace `return err` for unknown-root errors with returning `.{ .missing_attestation_roots = ... }`
- `node.zig`: Remove the `owns_missing_roots` guard — any non-empty `missing_roots` slice is owned and should be freed/fetched

## Testing
- [ ] `zig build test` passes