### PR TITLE
docs: add proxy troubleshooting note for EndOfStream build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ docker build -f Dockerfile.prebuilt \
   -t blockblaz/zeam:latest .
 ```
 
+### Troubleshooting
+
+**Build fails with `EndOfStream` error**
+
+If you encounter errors like:
+```
+error: invalid HTTP response: EndOfStream
+```
+
+This may be caused by proxy environment variables interfering with Zig's HTTP client (related to the [Zig HTTP connection pool bug](https://github.com/ziglang/zig/issues/21316) mentioned above).
+
+Try building without proxy settings:
+```bash
+env -u https_proxy -u HTTPS_PROXY -u http_proxy -u HTTP_PROXY \
+    -u all_proxy -u ALL_PROXY -u no_proxy -u NO_PROXY \
+    zig build -Doptimize=ReleaseFast
+```
+
 ---
 
 ## Running a Local Devnet


### PR DESCRIPTION
Picks up the change from #454 (by @lilhammerfun), rebased onto current main to resolve the merge conflict.

Adds a troubleshooting section under Build Instructions explaining that `EndOfStream` errors during build may be caused by proxy env vars, with the fix.

Closes #454

Co-authored-by: lilhammerfun <lilhammerfun@users.noreply.github.com>