### PR TITLE
refactor: use idiomatic iterators and avoid manual index loops

### DIFF
--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -792,13 +792,11 @@ fn validatorAssignmentsFromYAML(allocator: std.mem.Allocator, node_key: []const 
 //```
 
 fn nodeKeyIndexFromYaml(node_key: []const u8, validator_config: Yaml) !usize {
-    var index: usize = 0;
-    for (validator_config.docs.items[0].map.get("validators").?.list) |entry| {
+    for (validator_config.docs.items[0].map.get("validators").?.list, 0..) |entry, index| {
         const name_value = entry.map.get("name").?;
         if (name_value == .scalar and std.mem.eql(u8, name_value.scalar, node_key)) {
             return index;
         }
-        index += 1;
     }
     return error.InvalidNodeKey;
 }

--- a/pkgs/network/src/mock.zig
+++ b/pkgs/network/src/mock.zig
@@ -886,9 +886,8 @@ test "Mock status RPC between peers" {
 
         fn onPeerDisconnected(ptr: *anyopaque, peer_id: []const u8, _: interface.PeerDirection, _: interface.DisconnectionReason) !void {
             const self: *Self = @ptrCast(@alignCast(ptr));
-            var idx: usize = 0;
-            while (idx < self.connections.items.len) : (idx += 1) {
-                if (std.mem.eql(u8, self.connections.items[idx], peer_id)) {
+            for (self.connections.items, 0..) |conn, idx| {
+                if (std.mem.eql(u8, conn, peer_id)) {
                     const removed = self.connections.swapRemove(idx);
                     self.allocator.free(removed);
                     break;

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1231,13 +1231,9 @@ pub const BeamNode = struct {
     }
 
     fn publishProducedAggregations(self: *Self, aggregations: []types.SignedAggregatedAttestation) !void {
-        var i: usize = 0;
-        while (i < aggregations.len) : (i += 1) {
+        for (aggregations, 0..) |_, i| {
             self.publishAggregation(aggregations[i]) catch |err| {
-                var j: usize = i;
-                while (j < aggregations.len) : (j += 1) {
-                    aggregations[j].deinit();
-                }
+                for (aggregations[i..]) |*a| a.deinit();
                 return err;
             };
             aggregations[i].deinit();


### PR DESCRIPTION
## Summary

Refactored manual index-based loops to use idiomatic Zig patterns.

### Changes

**`pkgs/cli/src/node.zig`**
- `nodeKeyIndexFromYaml`: replaced `var index: usize = 0` + `for` + `index += 1` with `for (list, 0..) |entry, index|`

**`pkgs/network/src/mock.zig`**
- `onPeerDisconnected`: replaced `var idx: usize = 0; while (idx < len) : (idx += 1)` with `for (items, 0..) |conn, idx|`

**`pkgs/node/src/node.zig`**
- `publishProducedAggregations`: replaced outer `while (i < len) : (i += 1)` with `for (aggregations, 0..) |_, i|` and inner cleanup `while (j < len) : (j += 1)` with `for (aggregations[i..]) |*a| a.deinit()`

All changes verified with `zig build`.