### PR TITLE
fix: skip STF re-processing for blocks already known to fork choice

### DIFF
--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -391,6 +391,17 @@ pub const BeamNode = struct {
         // Try to process each descendant
         for (descendants_to_process.items) |descendant_root| {
             if (self.network.getFetchedBlock(descendant_root)) |cached_block| {
+                // Skip if already known to fork choice — same guard as processBlockByRootChunk
+                if (self.chain.forkChoice.hasBlock(descendant_root)) {
+                    self.logger.debug(
+                        "cached block 0x{x} is already known to fork choice, skipping re-processing",
+                        .{&descendant_root},
+                    );
+                    _ = self.network.removeFetchedBlock(descendant_root);
+                    self.processCachedDescendants(descendant_root);
+                    continue;
+                }
+
                 self.logger.debug(
                     "Attempting to process cached block 0x{x}",
                     .{&descendant_root},


### PR DESCRIPTION
Closes #669

## Summary

`processBlockByRootChunk` was unconditionally passing every fetched block through `chain.onBlock()` (the full state transition function), even when the block is already known to fork choice (the checkpoint sync anchor). The anchor block does not need STF re-processing — it is already the trust root.

This caused an infinite fetch loop: `onBlock` would fail with a missing pre-state error for the already-finalized anchor block, which would re-enqueue the parent for fetching, looping indefinitely.

### Fix

Before calling `chain.onBlock()`, check `forkChoice.hasBlock(block_root)`. If the block is already known, skip STF processing, call `processCachedDescendants` to unblock any cached children, and return early.

## Testing
- [ ] `zig build test` passes
