### PR TITLE
add bound checks before decoding

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.0",
     .dependencies = .{
         .ssz = .{
-            .url = "git+https://github.com/blockblaz/ssz.zig#c5394395dd7d0f8eda685c4723ad25ebbf550570",
-            .hash = "ssz-0.0.9-Lfwd693UAgBn89Sl4ljI4p3jW6ioLgonPWIdhIeIUDMN",
+            .url = "git+https://github.com/blockblaz/ssz.zig#50ddfa98d3b6485ae4e445a61a3b5392be3e9a62",
+            .hash = "ssz-0.0.9-Lfwd6zf0AgAYs-N72OTKqQGZEe6tF-YfpHn41ykIlDiH",
         },
         .zigcli = .{
             .url = "git+https://github.com/jiacai2050/zigcli#67a06e34cbe25a39bb86e35796cc5a0ca45a31f7",

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -48,6 +48,17 @@ fn decodeVarint(bytes: []const u8) uvarint.VarintParseError!struct { value: usiz
     };
 }
 
+fn validateGossipSnappyHeader(message_bytes: []const u8) (uvarint.VarintParseError || error{PayloadTooLarge})!struct { value: usize, length: usize } {
+    const decoded = try decodeVarint(message_bytes);
+    if (decoded.value > MAX_RPC_MESSAGE_SIZE) {
+        return error.PayloadTooLarge;
+    }
+    return .{
+        .value = decoded.value,
+        .length = decoded.length,
+    };
+}
+
 /// Build a request frame with varint-encoded uncompressed size followed by snappy-framed payload.
 fn buildRequestFrame(allocator: Allocator, uncompressed_size: usize, snappy_payload: []const u8) ![]u8 {
     if (uncompressed_size > MAX_RPC_MESSAGE_SIZE) {
@@ -87,11 +98,7 @@ fn parseRequestFrame(bytes: []const u8) FrameDecodeError!struct {
         return error.EmptyFrame;
     }
 
-    const decoded = try decodeVarint(bytes);
-
-    if (decoded.value > MAX_RPC_MESSAGE_SIZE) {
-        return error.PayloadTooLarge;
-    }
+    const decoded = try validateGossipSnappyHeader(bytes);
 
     return .{
         .declared_len = decoded.value,
@@ -111,11 +118,7 @@ fn parseResponseFrame(bytes: []const u8) FrameDecodeError!struct {
         return error.Incomplete;
     }
 
-    const decoded = try decodeVarint(bytes[1..]);
-
-    if (decoded.value > MAX_RPC_MESSAGE_SIZE) {
-        return error.PayloadTooLarge;
-    }
+    const decoded = try validateGossipSnappyHeader(bytes[1..]);
 
     return .{
         .code = bytes[0],
@@ -316,6 +319,15 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
         return;
     };
     defer zigHandler.allocator.free(uncompressed_message);
+
+    if (uncompressed_message.len > MAX_RPC_MESSAGE_SIZE) {
+        zigHandler.logger.err(
+            "Gossip message decompressed size {d} exceeds limit {d} for topic={s}",
+            .{ uncompressed_message.len, MAX_RPC_MESSAGE_SIZE, std.mem.span(topic_str) },
+        );
+        return;
+    }
+
     var message: interface.GossipMessage = switch (topic.gossip_topic.kind) {
         .block => .{ .block = deserializeGossipMessage(
             types.SignedBlockWithAttestation,
@@ -1283,3 +1295,9 @@ pub const EthLibp2p = struct {
         return result;
     }
 };
+
+test "validateGossipSnappyHeader rejects oversized declared size" {
+    var scratch: [MAX_VARINT_BYTES]u8 = undefined;
+    const encoded = uvarint.encode(usize, MAX_RPC_MESSAGE_SIZE + 1, &scratch);
+    try std.testing.expectError(error.PayloadTooLarge, validateGossipSnappyHeader(encoded));
+}


### PR DESCRIPTION
Updates ssz lib which performs max, min length checks before decoding to avoid crashes due to arbitrarily big memory allocation 