### PR TITLE
fix: pass max-allocation-size to snappy decode to fail early on oversized payloads

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -37,8 +37,8 @@
             .hash = "rocksdb-9.7.4-z_CUTobHAABHAhOqlte1b6S27vx7qYDIbKMlg8opO6GJ",
         },
         .zig_snappy = .{
-            .url = "https://github.com/blockblaz/zig-snappy/archive/v0.0.3.tar.gz",
-            .hash = "zig_snappy-0.0.3-bDFzXnBgAAD9LL_x0g6M_1SPPwMGAA6RAT_rlxG6n06j",
+            .url = "https://github.com/blockblaz/zig-snappy/archive/v0.0.4.tar.gz",
+            .hash = "zig_snappy-0.0.3-bDFzXmBjAAA4DE0B9xYQt9jiKz1qBJrnailFrp9ShxvM",
         },
         .snappyframesz = .{
             .url = "https://github.com/blockblaz/snappyframesz/archive/v0.0.3.tar.gz",

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -309,7 +309,7 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
 
     const message_bytes: []const u8 = message_ptr[0..message_len];
 
-    const uncompressed_message = snappyz.decode(zigHandler.allocator, message_bytes) catch |e| {
+    const uncompressed_message = snappyz.decodeWithMax(zigHandler.allocator, message_bytes, MAX_RPC_MESSAGE_SIZE) catch |e| {
         zigHandler.logger.err("Error in snappyz decoding the message for topic={s}: {any}", .{ std.mem.span(topic_str), e });
         if (writeFailedBytes(message_bytes, "snappyz_decode", zigHandler.allocator, null, zigHandler.logger)) |filename| {
             zigHandler.logger.err("Snappyz decode failed - debug file created: {s}", .{filename});
@@ -319,14 +319,6 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
         return;
     };
     defer zigHandler.allocator.free(uncompressed_message);
-
-    if (uncompressed_message.len > MAX_RPC_MESSAGE_SIZE) {
-        zigHandler.logger.err(
-            "Gossip message decompressed size {d} exceeds limit {d} for topic={s}",
-            .{ uncompressed_message.len, MAX_RPC_MESSAGE_SIZE, std.mem.span(topic_str) },
-        );
-        return;
-    }
 
     var message: interface.GossipMessage = switch (topic.gossip_topic.kind) {
         .block => .{ .block = deserializeGossipMessage(


### PR DESCRIPTION
Closes #706

## Summary

A malicious peer could send a crafted snappy payload with a large declared decompressed size in the header, triggering a huge heap allocation before the post-decode bound check (added in PR #705) could catch it.

**Changes:**

- Bumped `zig-snappy` dependency to `v0.0.4` ([blockblaz/zig-snappy](https://github.com/blockblaz/zig-snappy)) which adds `decodeWithMax(allocator, src, max_size)` — this function reads the declared decompressed length from the snappy header varint and returns `error.TooLarge` **before allocating** if it exceeds `max_size`
- Replaced `snappyz.decode()` with `snappyz.decodeWithMax(allocator, src, MAX_RPC_MESSAGE_SIZE)` in gossip message handling (`handleMsgFromRustBridge`)
- Removed the now-redundant post-decode length check (the pre-allocation guard makes it unreachable)

**Attack path closed:**
```
Before: header varint → alloc(4GB) → OOM crash
After:  header varint → check > 4MB → error.TooLarge (no allocation)
```

## Testing
- `zig build test` passes
