### PR TITLE
Fix git branch existence check

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -365,14 +365,17 @@ jobs:
         DEVNET_BRANCH="$DOCKER_TAG"  # branch = devnetX
 
         echo "✅ GitHub tag: $GITHUB_TAG, Docker tag/branch: $DOCKER_TAG"
-        if git ls-remote --heads origin "$DEVNET_BRANCH" | grep -q "$DEVNET_BRANCH"; then
+        # Fetch all remotes first - ensures origin/main and all branches are available
+        git fetch origin
+
+        if git ls-remote --heads origin | grep -q "refs/heads/$DEVNET_BRANCH$"; then
           echo "✅ $DEVNET_BRANCH branch exists, updating it"
-          git fetch origin "$DEVNET_BRANCH"
+
           git checkout "$DEVNET_BRANCH"
-          git merge main --no-edit
+          git merge origin/main --no-edit
         else
           echo "✅ $DEVNET_BRANCH branch doesn't exist, creating it from main"
-          git checkout -b "$DEVNET_BRANCH"
+          git checkout -b "$DEVNET_BRANCH" origin/main
         fi
 
         git push origin "$DEVNET_BRANCH"


### PR DESCRIPTION
Use exact ref match refs/heads/$DEVNET_BRANCH$ in grep to prevent partial matches (e.g. gr/devnet4 falsely matching devnet4).