### PR TITLE
fix(network): align gossipsub max_transmit_size with consensus spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,13 @@ RUN --mount=type=cache,target=/root/.cache/zig \
     fi && \
     zig build -Doptimize=ReleaseSafe -Dgit_version="$GIT_VERSION"
 
+# rec_aggregation's compilation.rs reads .py source files at runtime to verify
+# a bytecode fingerprint (via env!("CARGO_MANIFEST_DIR") baked at compile time).
+# Stage the crate source so we can recreate the path in the runtime image.
+RUN REC_AGG_DIR=$(find /root/.cargo/git/checkouts -path "*/rec_aggregation" -type d | head -1) \
+    && cp -r "$REC_AGG_DIR" /tmp/rec_aggregation_src \
+    && echo "$REC_AGG_DIR" > /tmp/rec_aggregation_path
+
 # Intermediate stage to prepare runtime libraries
 FROM ubuntu:24.04 AS runtime-prep
 ARG TARGETARCH
@@ -103,6 +110,13 @@ ARG TARGETARCH
 COPY --from=builder /app/zig-out/ /app/zig-out/
 COPY --from=builder /app/resources/ /app/resources/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Recreate rec_aggregation .py files at the baked-in CARGO_MANIFEST_DIR path
+COPY --from=builder /tmp/rec_aggregation_src /tmp/rec_aggregation_src
+COPY --from=builder /tmp/rec_aggregation_path /tmp/rec_aggregation_path
+RUN mkdir -p "$(cat /tmp/rec_aggregation_path)" \
+    && cp -r /tmp/rec_aggregation_src/* "$(cat /tmp/rec_aggregation_path)/" \
+    && rm -rf /tmp/rec_aggregation_src /tmp/rec_aggregation_path
 
 # Create a script to copy the right libraries based on architecture
 RUN mkdir -p /runtime-libs && \
@@ -162,6 +176,9 @@ COPY --from=builder /app/zig-out/ /app/zig-out/
 
 # Copy runtime resources
 COPY --from=builder /app/resources/ /app/resources/
+
+# Copy rec_aggregation .py files at baked-in CARGO_MANIFEST_DIR path
+COPY --from=runtime-prep /root/.cargo/ /root/.cargo/
 
 # Set the zeam binary as the entrypoint with beam parameter by default
 ENTRYPOINT ["/app/zig-out/bin/zeam"]

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -1439,7 +1439,7 @@ impl Behaviour {
             .validation_mode(gossipsub::ValidationMode::Anonymous)
             .history_length(6)
             .duplicate_cache_time(Duration::from_secs(3 * 4 * 2))
-            .max_transmit_size(2 * 1024 * 1024) // 2 MiB for blocks/ aggregated payloads
+            .max_transmit_size(crate::req_resp::configurations::max_message_size())
             .message_id_fn(message_id_fn) // content-address messages. No two messages of the same content will be propagated.
             .build()
             .unwrap();

--- a/rust/libp2p-glue/src/req_resp/configurations.rs
+++ b/rust/libp2p-glue/src/req_resp/configurations.rs
@@ -2,15 +2,23 @@
 /// as we still need rust-libp2p until we fully migrate to zig-libp2p. It needs the custom RPC protocol implementation.
 use std::time::Duration;
 
-/// Maximum allowed size for a single RPC payload (compressed).
-pub const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+/// Maximum uncompressed payload size (10 MiB), per Ethereum consensus spec.
+pub const MAX_PAYLOAD_SIZE: usize = 10 * 1024 * 1024;
+
+/// Snappy worst-case compressed length for a payload of size `n`.
+pub const fn max_compressed_len(n: usize) -> usize {
+    32 + n + n / 6
+}
+
+/// Spec-derived maximum message size: snappy worst-case of MAX_PAYLOAD_SIZE + 1024 bytes
+/// framing overhead, with a floor of 1 MiB.
+/// Matches ream / grandine / lighthouse: `max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1 MiB)`.
+pub fn max_message_size() -> usize {
+    std::cmp::max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1024 * 1024)
+}
 
 /// Timeout applied to reading requests and responses from a substream.
 pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Idle timeout for server-side response streams.
 pub const RESPONSE_CHANNEL_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
-
-pub fn max_message_size() -> usize {
-    MAX_MESSAGE_SIZE
-}


### PR DESCRIPTION
## Summary
- Replace hardcoded 2 MiB gossipsub `max_transmit_size` and 4 MiB RPC `MAX_MESSAGE_SIZE` with the spec-derived formula used by ream, grandine, and lighthouse: `max(max_compressed_len(MAX_PAYLOAD_SIZE) + 1024, 1 MiB)` → ~11.67 MiB
- Fix Dockerfile to stage `rec_aggregation` .py source files at the baked-in `CARGO_MANIFEST_DIR` path so the runtime image can verify the bytecode fingerprint

## Context
Hash-sig blocks carry multiple XMSS multi-sig proofs (up to 1 MiB each of high-entropy crypto data). With 3-4 attestation proofs per block, the snappy-compressed gossip payload exceeds the old 2 MiB limit, causing `MessageTooLarge` errors in cross-client devnets.