### PR TITLE
fix: catch xmss_setup_prover panic and return error code instead of aborting (#722)

### DIFF
--- a/pkgs/xmss/src/aggregation.zig
+++ b/pkgs/xmss/src/aggregation.zig
@@ -13,8 +13,11 @@ pub const ByteListMiB = ssz.utils.List(u8, MAX_AGGREGATE_SIGNATURE_SIZE);
 pub const AggregatedXMSS = opaque {};
 
 // External C functions from multisig-glue (uses leanMultisig devnet4 with recursive aggregation)
-extern fn xmss_setup_prover() void;
-extern fn xmss_setup_verifier() void;
+/// Returns 0 on success, -1 if the prover bytecode file is missing or initialisation failed.
+/// Never panics — the Rust side wraps the body in catch_unwind (fix for #722).
+extern fn xmss_setup_prover() c_int;
+/// Returns 0 on success, -1 on failure.
+extern fn xmss_setup_verifier() c_int;
 
 extern fn xmss_aggregate(
     // Raw XMSS signatures
@@ -56,12 +59,17 @@ extern fn xmss_aggregate_signature_from_bytes(
     bytes_len: usize,
 ) ?*AggregatedXMSS;
 
-pub fn setupProver() void {
-    xmss_setup_prover();
+/// Initialize the XMSS prover (idempotent — only runs once).
+/// Returns error.ProverSetupFailed when the prover bytecode file is missing or the
+/// underlying Rust initialisation failed. Callers should log a warning and skip
+/// aggregation rather than propagating the error as a fatal failure.
+pub fn setupProver() error{ProverSetupFailed}!void {
+    if (xmss_setup_prover() != 0) return error.ProverSetupFailed;
 }
 
-pub fn setupVerifier() void {
-    xmss_setup_verifier();
+/// Initialize the XMSS verifier (idempotent — only runs once).
+pub fn setupVerifier() error{VerifierSetupFailed}!void {
+    if (xmss_setup_verifier() != 0) return error.VerifierSetupFailed;
 }
 
 /// Aggregate raw XMSS signatures with optional recursive children.
@@ -87,7 +95,7 @@ pub fn aggregateSignatures(
         return AggregationError.AggregationFailed;
     }
 
-    setupProver();
+    try setupProver();
 
     const num_children = children_pub_keys.len;
     const allocator = std.heap.c_allocator;
@@ -163,7 +171,7 @@ pub fn verifyAggregatedPayload(public_keys: []*const hashsig.HashSigPublicKey, m
     // Get bytes from aggregated signature
     const sig_bytes = agg_sig.constSlice();
 
-    setupVerifier();
+    try setupVerifier();
 
     // Verify directly from bytes (Rust deserializes internally)
     const result = xmss_verify_aggregated(
@@ -205,7 +213,7 @@ test "aggregateSignatures and verifyAggregatedPayload with valid and invalid pub
     var signature = try keypair.sign(&message_hash, epoch);
     defer signature.deinit();
 
-    setupProver();
+    try setupProver();
 
     var public_keys = [_]*const hashsig.HashSigPublicKey{keypair.public_key};
     var signatures = [_]*const hashsig.HashSigSignature{signature.handle};

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -4,7 +4,7 @@ use rec_aggregation::{
     AggregatedXMSS,
 };
 use std::slice;
-use std::sync::Once;
+
 
 // Mirror hashsig-glue's struct layout with #[repr(C)]
 // These must match hashsig-glue/src/lib.rs exactly
@@ -18,28 +18,48 @@ pub struct Signature {
     pub inner: XmssSignature,
 }
 
-// Static Once guards for idempotent initialization
-// Avoids redundant heavy computation on repeated calls
-static PROVER_INIT: Once = Once::new();
-static VERIFIER_INIT: Once = Once::new();
+// Cached init results: true = succeeded, false = failed.
+// Using OnceLock<bool> instead of Once so we can distinguish "succeeded" from "panicked"
+// without poisoning the guard. The closure is called exactly once; subsequent calls return
+// the cached result without any computation.
+static PROVER_READY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+static VERIFIER_READY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
-/// Initialize the prover (idempotent - only runs once)
-/// This is safe to call multiple times; heavy computation only happens on first call.
+/// Initialize the prover (idempotent - only runs once).
+///
+/// Returns 0 on success, -1 on failure.
+///
+/// Previously used `Once::call_once` which allowed `init_aggregation_bytecode()` to panic
+/// (e.g. when the compiled prover bytecode file is missing — ENOENT). A Rust panic through
+/// an `extern "C"` boundary is undefined behaviour and aborted the process.
+///
+/// Fix: wrap the init body in `catch_unwind` and cache the boolean result in a `OnceLock`.
+/// The caller (Zig) checks the return code and skips aggregation gracefully instead of crashing.
 #[no_mangle]
-pub extern "C" fn xmss_setup_prover() {
-    PROVER_INIT.call_once(|| {
-        init_aggregation_bytecode();
-        backend::precompute_dft_twiddles::<backend::KoalaBear>(1 << 24);
+pub extern "C" fn xmss_setup_prover() -> i32 {
+    let ready = PROVER_READY.get_or_init(|| {
+        std::panic::catch_unwind(|| {
+            init_aggregation_bytecode();
+            backend::precompute_dft_twiddles::<backend::KoalaBear>(1 << 24);
+        })
+        .is_ok()
     });
+    if *ready { 0 } else { -1 }
 }
 
-/// Initialize the verifier (idempotent - only runs once)
-/// This is safe to call multiple times; setup only happens on first call.
+/// Initialize the verifier (idempotent - only runs once).
+///
+/// Returns 0 on success, -1 on failure.
+/// Same panic-safety rationale as `xmss_setup_prover`.
 #[no_mangle]
-pub extern "C" fn xmss_setup_verifier() {
-    VERIFIER_INIT.call_once(|| {
-        init_aggregation_bytecode();
+pub extern "C" fn xmss_setup_verifier() -> i32 {
+    let ready = VERIFIER_READY.get_or_init(|| {
+        std::panic::catch_unwind(|| {
+            init_aggregation_bytecode();
+        })
+        .is_ok()
     });
+    if *ready { 0 } else { -1 }
 }
 
 /// Aggregate signatures with recursive child proof support.

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -5,7 +5,6 @@ use rec_aggregation::{
 };
 use std::slice;
 
-
 // Mirror hashsig-glue's struct layout with #[repr(C)]
 // These must match hashsig-glue/src/lib.rs exactly
 #[repr(C)]
@@ -44,7 +43,11 @@ pub extern "C" fn xmss_setup_prover() -> i32 {
         })
         .is_ok()
     });
-    if *ready { 0 } else { -1 }
+    if *ready {
+        0
+    } else {
+        -1
+    }
 }
 
 /// Initialize the verifier (idempotent - only runs once).
@@ -59,7 +62,11 @@ pub extern "C" fn xmss_setup_verifier() -> i32 {
         })
         .is_ok()
     });
-    if *ready { 0 } else { -1 }
+    if *ready {
+        0
+    } else {
+        -1
+    }
 }
 
 /// Aggregate signatures with recursive child proof support.


### PR DESCRIPTION
Closes #722

## Root cause

`init_aggregation_bytecode()` in `rec_aggregation/compilation.rs:52` calls `.unwrap()` on a file-open. When the prover bytecode file is missing (ENOENT — e.g. on a fresh aggregator node), it panics inside `xmss_setup_prover()`. A Rust panic propagating through an `extern "C"` boundary is UB and triggers `panic_cannot_unwind`, aborting the process.

This fires on every `maybeAggregateOnInterval` tick, so the aggregator crashes repeatedly during devnet4 multi-subnet testing.

## Fix

### `rust/multisig-glue/src/lib.rs`
- Remove `static Once` guards (replaced by `OnceLock<bool>`)
- Wrap init body in `std::panic::catch_unwind`; cache the `bool` result
- Change `xmss_setup_prover` / `xmss_setup_verifier` return type from `void` → `i32` (`0` = success, `-1` = failure)
- Subsequent calls return the cached result with no work

### `pkgs/xmss/src/aggregation.zig`
- Update `extern fn` declarations to `c_int` return type
- `setupProver()` / `setupVerifier()` now return `!void` and surface `error.ProverSetupFailed` / `error.VerifierSetupFailed`
- All three callsites changed to `try setupProver()` / `try setupVerifier()`
- `aggregateSignatures()` already returns `!void`, so the error propagates through `computeAggregatedSignatures` → `aggregateUnlocked` → `aggregate` → `maybeAggregateOnInterval`, which **already** catches and logs a warning — so no crash, just a skip

## Behaviour after fix

```
[warn] failed to aggregate attestation signatures for slot=64: error.ProverSetupFailed
```

Aggregation is skipped for that interval; the node keeps running.

## Testing
- `zig build` passes ✅