### PR TITLE
docker, build: use x86-64-v3 baseline for portable Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,10 +80,15 @@ COPY .git/refs .git/refs
 
 # Get git commit hash and build the project with optimizations
 # Use cache mount for Zig build cache as well
-# Set RUSTFLAGS for ARM64 to use generic CPU (QEMU-compatible)
+# CPU targeting per architecture:
+#   amd64: x86-64-v3 (AVX2, no AVX512) — portable across modern x86_64 servers
+#   arm64: generic CPU — QEMU-compatible when cross-building
 ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/zig \
-    if [ "$TARGETARCH" = "arm64" ]; then \
+    EXTRA_ZIG_FLAGS="" && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        EXTRA_ZIG_FLAGS="-Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
         export RUSTFLAGS="-C target-cpu=generic"; \
     fi && \
     GIT_VERSION=$(cat .git/HEAD | grep -o '[0-9a-f]\{40\}' || echo "unknown") && \
@@ -93,7 +98,7 @@ RUN --mount=type=cache,target=/root/.cache/zig \
     else \
         GIT_VERSION=$(echo "$GIT_VERSION" | head -c 7); \
     fi && \
-    zig build -Doptimize=ReleaseSafe -Dgit_version="$GIT_VERSION"
+    zig build -Doptimize=ReleaseSafe -Dgit_version="$GIT_VERSION" $EXTRA_ZIG_FLAGS
 
 # rec_aggregation's compilation.rs reads .py source files at runtime to verify
 # a bytecode fingerprint (via env!("CARGO_MANIFEST_DIR") baked at compile time).

--- a/build.zig
+++ b/build.zig
@@ -724,13 +724,17 @@ fn build_rust_project(b: *Builder, path: []const u8, prover: ProverChoice) *Buil
     };
 
     // leanMultisig's backend crate uses compile-time #[cfg(target_feature)] for SIMD
-    // (AVX2/AVX512 on x86_64, NEON on aarch64). On x86_64, we must set target-cpu=native
-    // so the compiler enables AVX2/AVX512 feature flags. We skip this on aarch64 because
-    // ring 0.17 fails its compile-time feature assertions when target-cpu=native is set
-    // on aarch64-apple-darwin. We use CARGO_ENCODED_RUSTFLAGS (with \x1f separator) so
-    // we don't clobber any RUSTFLAGS already set in the environment (e.g. CI's -D warnings).
+    // (AVX2/AVX512 on x86_64, NEON on aarch64). On x86_64, we set the Rust target-cpu
+    // so the compiler enables the appropriate feature flags. Defaults to "native" for
+    // local builds; Docker images should pass -Drust-target-cpu=x86-64-v3 (AVX2, no AVX512)
+    // to produce portable binaries. We skip this on aarch64 because ring 0.17 fails its
+    // compile-time feature assertions when target-cpu=native is set on aarch64-apple-darwin.
+    // We use CARGO_ENCODED_RUSTFLAGS (with \x1f separator) so we don't clobber any RUSTFLAGS
+    // already set in the environment (e.g. CI's -D warnings).
     if (builtin.cpu.arch == .x86_64) {
-        cargo_build.setEnvironmentVariable("CARGO_ENCODED_RUSTFLAGS", "-Ctarget-cpu=native\x1f-Dwarnings");
+        const rust_target_cpu = b.option([]const u8, "rust-target-cpu", "Target CPU for Rust libs (default: native, use x86-64-v3 for portable Docker images)") orelse "native";
+        const flags = b.fmt("-Ctarget-cpu={s}\x1f-Dwarnings", .{rust_target_cpu});
+        cargo_build.setEnvironmentVariable("CARGO_ENCODED_RUSTFLAGS", flags);
     }
 
     return cargo_build;


### PR DESCRIPTION
## Summary

- The Rust libs were compiled with `-Ctarget-cpu=native`, which enables AVX512 when the CI builder has it. Servers without AVX512 then crash with "illegal instruction".
- `build.zig`: add `-Drust-target-cpu` option (defaults to `native` for local builds). The Dockerfile passes `x86-64-v3` (AVX2, no AVX512).
- `Dockerfile`: for amd64, pass `-Dcpu=x86_64_v3` (Zig) and `-Drust-target-cpu=x86-64-v3` (Rust) so the image runs on any x86_64 server with AVX2 support (Haswell / 2013+).

## Root cause

`build_rust_project()` in `build.zig` hardcodes `CARGO_ENCODED_RUSTFLAGS="-Ctarget-cpu=native"` on x86_64. When CI builds on a machine with AVX512 (e.g. Xeon Scalable), the Rust libraries (leanMultisig, hashsig-glue, libp2p-glue) are compiled with AVX512 instructions. Zig code also defaults to native CPU features. Servers without AVX512 hit SIGILL ("illegal instruction") at runtime.

## Fix

**`build.zig`**: Replace the hardcoded `target-cpu=native` with a configurable build option:

```
-Drust-target-cpu=<value>   (default: native)
```

Local builds remain unchanged (native). Docker/CI builds pass `x86-64-v3`.

**`Dockerfile`**: For amd64, pass both Zig and Rust CPU targets:

```
zig build ... -Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3
```

`x86-64-v3` enables AVX2/FMA/BMI but not AVX512 — compatible with all x86_64 servers from ~2013 onwards.

## Test plan

- [ ] Docker image builds successfully for amd64
- [ ] Image runs without "illegal instruction" on servers without AVX512
- [ ] Local `zig build` still uses native CPU features (no regression)
- [ ] leanMultisig SIMD codepaths still activate (AVX2 enabled via x86-64-v3)