### PR TITLE
multisig-glue: wrap xmss_aggregate and xmss_verify in catch_unwind

### DIFF
--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -182,16 +182,22 @@ pub unsafe extern "C" fn xmss_aggregate(
         .map(|(pks, proof)| (pks.as_slice(), proof))
         .collect();
 
-    // Call rec_aggregation
-    let (_pub_keys, agg_sig) = rec_xmss_aggregate(
-        &children_with_keys,
-        raw_xmss,
-        message_hash,
-        slot,
-        log_inv_rate,
-    );
+    // Wrap rec_xmss_aggregate in catch_unwind — a panic through extern "C" is UB and
+    // causes GPE/abort (same class of bug as #722 for the setup functions).
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        rec_xmss_aggregate(
+            &children_with_keys,
+            raw_xmss,
+            message_hash,
+            slot,
+            log_inv_rate,
+        )
+    }));
 
-    Box::into_raw(Box::new(agg_sig))
+    match result {
+        Ok((_pub_keys, agg_sig)) => Box::into_raw(Box::new(agg_sig)),
+        Err(_) => std::ptr::null(),
+    }
 }
 
 /// Verify aggregated signatures.
@@ -236,7 +242,10 @@ pub unsafe extern "C" fn xmss_verify_aggregated(
         pub_keys.push((*pk_ptr).inner.clone());
     }
 
-    xmss_verify_aggregation(pub_keys, &agg_sig, message_hash, slot).is_ok()
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        xmss_verify_aggregation(pub_keys, &agg_sig, message_hash, slot).is_ok()
+    }))
+    .unwrap_or(false)
 }
 
 /// Serialize an AggregatedXMSS to bytes (postcard + lz4).


### PR DESCRIPTION
## Summary

- `rec_xmss_aggregate` and `xmss_verify_aggregation` can panic inside the `rec_aggregation` SIMD backend. A Rust panic through an `extern "C"` boundary is UB — on Linux it manifests as a **General Protection Exception** with no address, crashing the process.
- Wraps both FFI entry points in `catch_unwind` (same pattern as #724 for the setup functions). On panic, `xmss_aggregate` returns null and `xmss_verify_aggregated` returns false, letting the Zig caller handle the failure gracefully.

**Observed in CI:** risc0 prover test crashes with GPE at `aggregation.zig:139` during `genMockChain`.

Note: This is a defensive fix that prevents the crash from being UB. The root cause of the panic inside `rec_xmss_aggregate` still needs investigation — it could be an assertion failure in the SIMD arithmetic backend, missing/invalid prover state, or a target-cpu mismatch causing illegal instructions.

## Test plan

- [ ] CI risc0 prover test should no longer crash with GPE (will get `AggregationFailed` error instead)
- [ ] Existing aggregation tests pass
- [ ] Investigate root cause of panic in `rec_xmss_aggregate`