### PR TITLE
build, auto-release: fix RUSTFLAGS precedence silently dropping target-cpu

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -184,7 +184,7 @@ jobs:
     - name: Build zeam natively
       run: |
         if [ "${{ matrix.arch }}" = "amd64" ]; then
-          zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-gnu -Dcpu=baseline -Dgit_version="$(git rev-parse --short HEAD)"
+          zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-gnu -Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3 -Dgit_version="$(git rev-parse --short HEAD)"
         else
           zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-linux-gnu -Dcpu=baseline -Dgit_version="$(git rev-parse --short HEAD)"
         fi

--- a/build.zig
+++ b/build.zig
@@ -729,12 +729,14 @@ fn build_rust_project(b: *Builder, path: []const u8, prover: ProverChoice) *Buil
     // local builds; Docker images should pass -Drust-target-cpu=x86-64-v3 (AVX2, no AVX512)
     // to produce portable binaries. We skip this on aarch64 because ring 0.17 fails its
     // compile-time feature assertions when target-cpu=native is set on aarch64-apple-darwin.
-    // We use CARGO_ENCODED_RUSTFLAGS (with \x1f separator) so we don't clobber any RUSTFLAGS
-    // already set in the environment (e.g. CI's -D warnings).
+    //
+    // We set RUSTFLAGS directly (not CARGO_ENCODED_RUSTFLAGS) because Cargo ignores
+    // CARGO_ENCODED_RUSTFLAGS when RUSTFLAGS is already set in the environment — which
+    // happens in CI via actions-rust-lang/setup-rust-toolchain setting RUSTFLAGS=-Dwarnings.
     if (builtin.cpu.arch == .x86_64) {
         const rust_target_cpu = b.option([]const u8, "rust-target-cpu", "Target CPU for Rust libs (default: native, use x86-64-v3 for portable Docker images)") orelse "native";
-        const flags = b.fmt("-Ctarget-cpu={s}\x1f-Dwarnings", .{rust_target_cpu});
-        cargo_build.setEnvironmentVariable("CARGO_ENCODED_RUSTFLAGS", flags);
+        const flags = b.fmt("-Ctarget-cpu={s} -Dwarnings", .{rust_target_cpu});
+        cargo_build.setEnvironmentVariable("RUSTFLAGS", flags);
     }
 
     return cargo_build;


### PR DESCRIPTION
## Summary

Fixes the root cause of "Illegal instruction" errors in released AMD64 Docker images. PR #729 added `-Drust-target-cpu=x86-64-v3` support, but the flag was silently ignored in CI and release builds.

**Root cause**: `build.zig` set `CARGO_ENCODED_RUSTFLAGS` to pass `-Ctarget-cpu` to Cargo. Per [Cargo docs](https://doc.rust-lang.org/cargo/reference/environment-variables.html), `CARGO_ENCODED_RUSTFLAGS` is **completely ignored when `RUSTFLAGS` is set**. The `actions-rust-lang/setup-rust-toolchain` GitHub Action sets `RUSTFLAGS=-D warnings` in every CI/release job, silently dropping the target-cpu flag.

**Changes:**

- **`build.zig`**: Switch from `CARGO_ENCODED_RUSTFLAGS` to `RUSTFLAGS` directly so the target-cpu flag overrides any inherited environment value
- **`auto-release.yml`**: Add `-Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3` to the amd64 native build step (was using `-Dcpu=baseline` with no Rust target-cpu)

## What was broken

| Build path | Before this PR | After |
|---|---|---|
| `Dockerfile` direct | Works (no RUSTFLAGS in Docker env) | Works |
| `auto-release.yml` → published images | **Broken** (RUSTFLAGS override + missing flag) | Fixed |
| CI `docker-build` native step | **Broken** (RUSTFLAGS override) | Fixed |

## Test plan

- [ ] CI builds pass on both ubuntu and macos runners
- [ ] Verify with `objdump` that released amd64 binary contains AVX2 but no AVX-512 instructions