### PR TITLE
network: remove redundant discv5.poll call from pollLoop

### DIFF
--- a/pkgs/network/src/ethp2p_discovery.zig
+++ b/pkgs/network/src/ethp2p_discovery.zig
@@ -228,13 +228,15 @@ pub const EthP2PDiscovery = struct {
             const ql = @atomicLoad(?*eth_ec_quic.EthEcQuicListener, &self.quic_listener, .acquire);
             self.shared_socket.routePackets(&self.discv5, ql);
 
-            // Advance discv5 timers (inbound recv was already handled above).
-            _ = self.discv5.poll(now_ns);
-
             // Drive QUIC engine timers (PTO, idle-close, etc.).
             if (ql) |listener| eth_ec_quic.processEngineOnly(listener);
 
-            // Advance peer warmup scheduling and QUIC dial flushes.
+            // Advance discv5 timers + peer warmup scheduling + QUIC dial flushes.
+            // PeerManager.poll internally calls discv5.Node.poll, which runs
+            // expireRequests and refreshBuckets.  Calling discv5.poll separately
+            // here as well would double-drive expireRequests on the same pending
+            // list within one tick, causing an integer-overflow panic in swapRemove
+            // when the list length is corrupted mid-iteration.
             self.manager.poll(now_ns, peering_warmup_mod.phase_idle_start_ms);
 
             // Wait up to POLL_INTERVAL_MS for the next batch of datagrams.


### PR DESCRIPTION
## Root cause

\`pollLoop\` in \`EthP2PDiscovery\` calls \`discv5.poll\` twice per tick:

\`\`\`zig
_ = self.discv5.poll(now_ns);                           // ← run 1
// ...
self.manager.poll(now_ns, phase_idle_start_ms);         // ← run 2, via PeerManager.poll → node.poll
\`\`\`

\`PeerManager.poll\` already calls \`self.node.poll(now_ns)\` internally (see \`peer_manager.zig\`), so \`expireRequests\` runs twice on the same \`pending\` list within one tick.

The second invocation is the one that panics:

\`\`\`
thread NNNNN panic: integer overflow
std/array_list.zig:964: if (self.items.len - 1 == i) ...
discv5/node.zig:expireRequests: _ = self.pending.swapRemove(i);
peer_manager.zig:poll: _ = self.node.poll(now_ns);
ethp2p_discovery.zig:238: self.manager.poll(now_ns, ...)
\`\`\`

This is confirmed in the pinned zig-ethp2p version (\`a1a2a58\` / \`TcaWElzqBwDWpiQespATjyPpnVCrHM2oz192TDZ0opz1\`), and also in every subsequent zig-ethp2p commit — \`PeerManager.poll\` has always driven \`node.poll\` internally.

## Fix

Remove the direct \`discv5.poll\` call; \`manager.poll\` is the single owner of the discv5 drive loop for each tick.

## Test plan

- \`zig build test --summary all\` passes (all tests green)
- \`zig fmt --check\` clean