### PR TITLE
fix race condition leading to seg faults

### DIFF
--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -56,6 +56,9 @@ pub const BeamNode = struct {
     node_registry: *const NodeNameRegistry,
     /// Explicitly configured subnet ids for attestation import (adds to validator-derived subnets).
     aggregation_subnet_ids: ?[]const u32 = null,
+    /// Serializes BeamNode work between the libxev main thread (onInterval) and
+    /// the libp2p worker thread (onGossip / onReqRespResponse / onReqRespRequest).
+    mutex: std.Thread.Mutex = .{},
 
     const Self = @This();
 
@@ -129,6 +132,9 @@ pub const BeamNode = struct {
     pub fn onGossip(ptr: *anyopaque, data: *const networks.GossipMessage, sender_peer_id: []const u8) anyerror!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
 
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
         switch (data.*) {
             .block => |signed_block| {
                 const block = signed_block.block;
@@ -151,6 +157,7 @@ pub const BeamNode = struct {
                     self.logger.warn("failed to compute block root for incoming gossip block: {any}", .{err});
                     return;
                 };
+
                 _ = self.network.removePendingBlockRoot(block_root);
 
                 if (!hasParentBlock) {
@@ -864,6 +871,8 @@ pub const BeamNode = struct {
 
     pub fn onReqRespResponse(ptr: *anyopaque, event: *const networks.ReqRespResponseEvent) anyerror!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
+        self.mutex.lock();
+        defer self.mutex.unlock();
         try self.handleReqRespResponse(event);
     }
 
@@ -879,6 +888,9 @@ pub const BeamNode = struct {
 
         switch (data.*) {
             .blocks_by_root => |request| {
+                self.mutex.lock();
+                defer self.mutex.unlock();
+
                 const roots = request.roots.constSlice();
 
                 self.logger.debug(
@@ -1087,30 +1099,37 @@ pub const BeamNode = struct {
         var current_interval: isize = start_interval;
         while (current_interval <= itime_intervals) : (current_interval += 1) {
             const interval: usize = @intCast(current_interval);
-            self.chain.onInterval(interval) catch |e| {
-                self.logger.err("error ticking chain to time(intervals)={d} err={any}", .{ interval, e });
-                // no point going further if chain is not ticked properly
-                return e;
-            };
+            const slot: types.Slot = @intCast(@divFloor(interval, constants.INTERVALS_PER_SLOT));
 
-            // Replay blocks that were queued waiting for the forkchoice clock to advance,
-            // then fetch any attestation head roots that were missing during replay.
-            const pending_missing_roots = self.chain.processPendingBlocks();
-            defer self.allocator.free(pending_missing_roots);
-            if (pending_missing_roots.len > 0) {
-                self.fetchBlockByRoots(pending_missing_roots, 0) catch |err| {
-                    self.logger.warn(
-                        "failed to fetch {d} missing block(s) from pending blocks: {any}",
-                        .{ pending_missing_roots.len, err },
-                    );
+            {
+                self.mutex.lock();
+                defer self.mutex.unlock();
+
+                self.chain.onInterval(interval) catch |e| {
+                    self.logger.err("error ticking chain to time(intervals)={d} err={any}", .{ interval, e });
+                    // no point going further if chain is not ticked properly
+                    return e;
                 };
+
+                // Replay blocks that were queued waiting for the forkchoice clock to advance,
+                // then fetch any attestation head roots that were missing during replay.
+                const pending_missing_roots = self.chain.processPendingBlocks();
+                defer self.allocator.free(pending_missing_roots);
+                if (pending_missing_roots.len > 0) {
+                    self.fetchBlockByRoots(pending_missing_roots, 0) catch |err| {
+                        self.logger.warn(
+                            "failed to fetch {d} missing block(s) from pending blocks: {any}",
+                            .{ pending_missing_roots.len, err },
+                        );
+                    };
+                }
+
+                // Sweep timed-out RPC requests to prevent sync stalls from non-responsive peers.
+                self.sweepTimedOutRequests();
+
+                self.processReadyCachedBlocks(slot);
             }
 
-            // Sweep timed-out RPC requests to prevent sync stalls from non-responsive peers.
-            self.sweepTimedOutRequests();
-
-            const slot: types.Slot = @intCast(@divFloor(interval, constants.INTERVALS_PER_SLOT));
-            self.processReadyCachedBlocks(slot);
             if (self.validator) |*validator| {
                 // we also tick validator per interval in case it would
                 // need to sync its future duties when its an independent validator


### PR DESCRIPTION
~~The fetched_blocks map in the network layer is accessed by both the main thread and the libp2p thread. The main thread was using a shallow copy of the blocks, which caused segmentation faults during long chain syncs. This happened because blocks could be pruned after finalization while still being referenced by the main thread.~~

~~This issue doesn’t appear when the chain remains fully synced, since pruning and access don’t overlap in the same way.~~

The issue happens because the hashmap resizes when new blocks are inserted on the network thread. This causes rehashing, which moves keys to different positions. Meanwhile, the main thread still relies on the old positions based on the previous size, so those references become invalid and lead to a panic.

To fix this, don’t share internal hashmap positions across threads. Either lock the hashmap while it’s being accessed or pass a full copy of the data instead of references.