### PR TITLE
fix(validator): deduplicate validator indices from assignments

### DIFF
--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -107,11 +107,20 @@ pub const NodeOptions = struct {
     }
 
     pub fn getValidatorIndices(self: *const NodeOptions, allocator: std.mem.Allocator) ![]usize {
-        var indices = try allocator.alloc(usize, self.validator_assignments.len);
-        for (self.validator_assignments, 0..) |assignment, i| {
-            indices[i] = assignment.index;
+        // Deduplicate: each validator index may appear multiple times in
+        // assignments (e.g. once for the attester key, once for the proposer
+        // key). The validator only needs to attest/propose once per slot.
+        var seen = std.AutoHashMap(usize, void).init(allocator);
+        defer seen.deinit();
+        var unique: std.ArrayList(usize) = .empty;
+        errdefer unique.deinit(allocator);
+        for (self.validator_assignments) |assignment| {
+            const result = try seen.getOrPut(assignment.index);
+            if (!result.found_existing) {
+                try unique.append(allocator, assignment.index);
+            }
         }
-        return indices;
+        return try unique.toOwnedSlice(allocator);
     }
 };
 


### PR DESCRIPTION
## Summary
- `annotated_validators.yaml` contains two entries per validator (attester key + proposer key), both with the same `index`
- `getValidatorIndices()` returned duplicates (e.g. `[2, 2]`), causing `mayBeDoAttestation()` to construct and publish the same attestation twice per slot
- The second publish was rejected by gossipsub with `Publish error: Duplicate`
- Fix: deduplicate indices using a hash set

## Reproduction
Run 4-node local devnet (or 2 zeam + 2 nlean interop). Every slot at interval 1:
```
[error] [network] rust-bridge: Publish error: Duplicate
```

## Test plan
- [ ] Run 4-zeam local devnet, verify zero `Publish error: Duplicate` in logs
- [ ] Run 2 zeam + 2 nlean interop, verify zero duplicate errors