### PR TITLE
ci: add Hive integration workflow (daily + run-hive label)

### DIFF
--- a/.github/ISSUE_TEMPLATE/hive-scheduled-failure.md
+++ b/.github/ISSUE_TEMPLATE/hive-scheduled-failure.md
@@ -1,0 +1,25 @@
+---
+title: "Daily Hive run failed: {{ env.SIMULATOR }} / {{ env.DEVNET }}"
+labels: ci-failure, hive
+---
+
+The scheduled Hive CI run failed.
+
+| Field | Value |
+|---|---|
+| Simulator | `{{ env.SIMULATOR }}` |
+| Devnet profile | `{{ env.DEVNET }}` |
+| Hive source | `{{ env.HIVE_REPOSITORY }}@{{ env.HIVE_VERSION }}` |
+| Commit tested | [`{{ env.COMMIT_SHA }}`]({{ env.COMMIT_URL }}) |
+| Workflow run | [#{{ env.GITHUB_RUN_ID }}]({{ env.RUN_URL }}) |
+
+This issue is auto-opened by the `hive` workflow and updated in place by later scheduled failures; close it once the underlying cause is fixed and the next daily run goes green.
+
+### Notes
+
+- The upstream `clients/zeam` Dockerfile in `ethereum/hive` selects the devnet4
+  binary from the pre-published `blockblaz/zeam:devnet4` image (no tag build
+  arg), so a failure here may reflect the published image rather than HEAD of
+  `main`. Check the published image tag before assuming a regression in-tree.
+- Logs, per-test results, and the hiveview output are attached to the workflow
+  run as artifacts (`hive-zeam-{{ env.DEVNET }}-*`).

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run Hive
         id: hive
-        uses: ethpandaops/hive-github-action@v0.6.3
+        uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         with:
           client: zeam
           simulator: ${{ steps.cfg.outputs.simulator }}
@@ -128,9 +128,9 @@ jobs:
             const devnet = '${{ steps.cfg.outputs.devnet }}';
             const conclusion = '${{ steps.hive.outcome }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const icon = conclusion === 'success' ? 'success' : (conclusion === 'skipped' ? 'skipped' : 'failure');
+            const icon = conclusion === 'success' ? '✅' : (conclusion === 'skipped' ? '⏭️' : '❌');
             const body = [
-              `### Hive results: ${icon}`,
+              `### Hive results: ${icon} \`${conclusion}\``,
               ``,
               `| Field | Value |`,
               `|---|---|`,
@@ -156,7 +156,7 @@ jobs:
 
       - name: Open (or update) tracking issue on scheduled failure
         if: github.event_name == 'schedule' && failure()
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SIMULATOR: ${{ steps.cfg.outputs.simulator }}
@@ -166,7 +166,6 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
-          RUN_DATE: ${{ github.event.schedule }}
         with:
           filename: .github/ISSUE_TEMPLATE/hive-scheduled-failure.md
           update_existing: true

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -27,8 +27,8 @@ name: hive
 
 on:
   schedule:
-    # 10:00 UTC daily.
-    - cron: '0 10 * * *'
+    # 03:00 UTC daily.
+    - cron: '0 3 * * *'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
@@ -63,6 +63,7 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  issues: write
 
 jobs:
   hive:
@@ -152,3 +153,21 @@ jobs:
               issue_number: context.issue.number,
               body,
             });
+
+      - name: Open (or update) tracking issue on scheduled failure
+        if: github.event_name == 'schedule' && failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIMULATOR: ${{ steps.cfg.outputs.simulator }}
+          DEVNET: ${{ steps.cfg.outputs.devnet }}
+          HIVE_REPOSITORY: ${{ steps.cfg.outputs.hive_repository }}
+          HIVE_VERSION: ${{ steps.cfg.outputs.hive_version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          RUN_DATE: ${{ github.event.schedule }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/hive-scheduled-failure.md
+          update_existing: true
+          search_existing: open

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -5,20 +5,23 @@
 #     early without paying the cost on every PR.
 #   - pull_request (labeled): only runs when the `run-hive` label is applied to
 #     a PR. Mirrors the `stf` label pattern used by risc0.yml.
-#   - workflow_dispatch: manual trigger with overridable simulator / hive repo.
+#   - workflow_dispatch: manual trigger with overridable simulator / devnet /
+#     hive repo / hive version.
 #
-# Prerequisites (external, tracked in issue #740):
-#   1. A Hive fork that ships a `clients/zeam/Dockerfile` capable of building
-#      zeam from a `{github, tag}` source (matching hive's dockerfile:git
-#      convention). Default repo is `ethpandaops/hive`, overridable via the
-#      HIVE_REPOSITORY repository variable or workflow_dispatch input.
-#   2. A Lean-consensus simulator under the same Hive fork, default
-#      `leanconsensus/sync`, overridable via HIVE_SIMULATOR repository variable
-#      or workflow_dispatch input.
+# Hive side (upstream ethereum/hive):
+#   - Client definition:  clients/zeam/
+#   - Simulator:          simulators/lean
+#   - Client profiles:    simulators/lean/clients/{devnet3,devnet4}.yaml
 #
-# Until those land, scheduled and label-triggered runs will fail fast at the
-# hive build step — this is intentional so that the integration becomes usable
-# the moment the upstream pieces are in place, without a second zeam PR.
+# Known limitation (tracked for follow-up, not this PR):
+#   The upstream zeam Dockerfile in ethereum/hive selects the devnet3 binary
+#   from a pinned source revision (build arg `zeam_devnet3_revision`) and the
+#   devnet4 binary from the pre-published `blockblaz/zeam:devnet4` Docker Hub
+#   image (no tag build arg). As a result, PR-label-triggered runs currently
+#   exercise the published devnet4 image rather than the exact PR HEAD binary.
+#   To test an arbitrary PR commit, we will need an upstream hive change that
+#   exposes a `zeam_devnet4_tag` build arg (or equivalent) and a per-PR image
+#   push to Docker Hub/GHCR. Tracked separately.
 
 name: hive
 
@@ -31,17 +34,25 @@ on:
   workflow_dispatch:
     inputs:
       simulator:
-        description: 'Hive simulator to run (e.g. leanconsensus/sync)'
+        description: 'Hive simulator (upstream name, e.g. `lean`)'
         required: false
-        default: ''
+        default: 'lean'
+      devnet:
+        description: 'Lean devnet profile to select from simulators/lean/clients/'
+        required: false
+        type: choice
+        default: 'devnet4'
+        options:
+          - devnet3
+          - devnet4
       hive_repository:
-        description: 'Hive repo (owner/name) hosting the Lean simulator + zeam client definition'
+        description: 'Hive repo hosting the Lean simulator + zeam client definition'
         required: false
-        default: ''
+        default: 'ethereum/hive'
       hive_version:
         description: 'Hive branch or tag'
         required: false
-        default: ''
+        default: 'master'
 
 concurrency:
   # Cancel previous PR runs, but keep scheduled runs independent (run_id fallback).
@@ -55,7 +66,7 @@ permissions:
 
 jobs:
   hive:
-    name: hive (${{ github.event.inputs.simulator || vars.HIVE_SIMULATOR || 'leanconsensus/sync' }})
+    name: hive (lean / ${{ github.event.inputs.devnet || vars.HIVE_DEVNET || 'devnet4' }})
     runs-on: ubuntu-latest
     # Gate PR runs behind the `run-hive` label. Scheduled and manual runs always pass this check.
     if: >-
@@ -65,44 +76,30 @@ jobs:
     steps:
       - name: Checkout zeam
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
 
       - name: Resolve inputs
         id: cfg
         run: |
           SIMULATOR="${{ github.event.inputs.simulator }}"
           [ -z "$SIMULATOR" ] && SIMULATOR="${{ vars.HIVE_SIMULATOR }}"
-          [ -z "$SIMULATOR" ] && SIMULATOR="leanconsensus/sync"
+          [ -z "$SIMULATOR" ] && SIMULATOR="lean"
+
+          DEVNET="${{ github.event.inputs.devnet }}"
+          [ -z "$DEVNET" ] && DEVNET="${{ vars.HIVE_DEVNET }}"
+          [ -z "$DEVNET" ] && DEVNET="devnet4"
 
           HIVE_REPOSITORY="${{ github.event.inputs.hive_repository }}"
           [ -z "$HIVE_REPOSITORY" ] && HIVE_REPOSITORY="${{ vars.HIVE_REPOSITORY }}"
-          [ -z "$HIVE_REPOSITORY" ] && HIVE_REPOSITORY="ethpandaops/hive"
+          [ -z "$HIVE_REPOSITORY" ] && HIVE_REPOSITORY="ethereum/hive"
 
           HIVE_VERSION="${{ github.event.inputs.hive_version }}"
           [ -z "$HIVE_VERSION" ] && HIVE_VERSION="${{ vars.HIVE_VERSION }}"
           [ -z "$HIVE_VERSION" ] && HIVE_VERSION="master"
 
           echo "simulator=$SIMULATOR" >> "$GITHUB_OUTPUT"
+          echo "devnet=$DEVNET" >> "$GITHUB_OUTPUT"
           echo "hive_repository=$HIVE_REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "hive_version=$HIVE_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve client source
-        id: src
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SHA="${{ github.event.pull_request.head.sha }}"
-            REPO="${{ github.event.pull_request.head.repo.full_name }}"
-            NAMETAG="pr-${{ github.event.pull_request.number }}-$(echo $SHA | cut -c1-7)"
-          else
-            SHA="${{ github.sha }}"
-            REPO="${{ github.repository }}"
-            NAMETAG="$(echo ${{ github.ref_name }} | tr '/' '-')-$(echo ${{ github.sha }} | cut -c1-7)"
-          fi
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
-          echo "nametag=$NAMETAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Hive
         id: hive
@@ -112,15 +109,14 @@ jobs:
           simulator: ${{ steps.cfg.outputs.simulator }}
           hive_repository: ${{ steps.cfg.outputs.hive_repository }}
           hive_version: ${{ steps.cfg.outputs.hive_version }}
-          client_config: |
-            - client: zeam
-              nametag: ${{ steps.src.outputs.nametag }}
-              dockerfile: git
-              build_args:
-                github: ${{ steps.src.outputs.repo }}
-                tag: ${{ steps.src.outputs.sha }}
+          # Point hive at the committed lean client profile for the chosen devnet.
+          # Kept as extra_flags rather than inlining via `client_config` so the
+          # profile stays in sync with upstream without this workflow having to
+          # mirror every change to simulators/lean/clients/<devnet>.yaml.
+          extra_flags: >-
+            --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml
           workflow_artifact_upload: 'true'
-          workflow_artifact_prefix: hive-zeam-${{ steps.src.outputs.nametag }}
+          workflow_artifact_prefix: hive-zeam-${{ steps.cfg.outputs.devnet }}
 
       - name: Post summary comment on PR
         if: github.event_name == 'pull_request' && always()
@@ -128,7 +124,7 @@ jobs:
         with:
           script: |
             const simulator = '${{ steps.cfg.outputs.simulator }}';
-            const nametag = '${{ steps.src.outputs.nametag }}';
+            const devnet = '${{ steps.cfg.outputs.devnet }}';
             const conclusion = '${{ steps.hive.outcome }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const icon = conclusion === 'success' ? 'success' : (conclusion === 'skipped' ? 'skipped' : 'failure');
@@ -138,11 +134,17 @@ jobs:
               `| Field | Value |`,
               `|---|---|`,
               `| Simulator | \`${simulator}\` |`,
-              `| Client tag | \`${nametag}\` |`,
+              `| Devnet profile | \`${devnet}\` |`,
               `| Outcome | \`${conclusion}\` |`,
               `| Run | [#${context.runId}](${runUrl}) |`,
               ``,
               `Artifacts (logs, test results) are attached to the workflow run.`,
+              ``,
+              `> **Note:** the upstream \`clients/zeam\` Dockerfile pulls the devnet4 binary`,
+              `> from the pre-published \`blockblaz/zeam:devnet4\` image and the devnet3`,
+              `> binary from a pinned source revision, so this run does not exercise the`,
+              `> exact PR HEAD binary. Per-PR binary coverage requires an upstream hive change`,
+              `> (see the note at the top of the workflow file).`,
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -27,8 +27,8 @@ name: hive
 
 on:
   schedule:
-    # 03:17 UTC daily — off-peak, avoids clashing with other nightly jobs.
-    - cron: '17 3 * * *'
+    # 10:00 UTC daily.
+    - cron: '0 10 * * *'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -1,0 +1,152 @@
+# Hive integration tests for zeam.
+#
+# Triggers:
+#   - schedule: daily run against the default branch (main) to catch regressions
+#     early without paying the cost on every PR.
+#   - pull_request (labeled): only runs when the `run-hive` label is applied to
+#     a PR. Mirrors the `stf` label pattern used by risc0.yml.
+#   - workflow_dispatch: manual trigger with overridable simulator / hive repo.
+#
+# Prerequisites (external, tracked in issue #740):
+#   1. A Hive fork that ships a `clients/zeam/Dockerfile` capable of building
+#      zeam from a `{github, tag}` source (matching hive's dockerfile:git
+#      convention). Default repo is `ethpandaops/hive`, overridable via the
+#      HIVE_REPOSITORY repository variable or workflow_dispatch input.
+#   2. A Lean-consensus simulator under the same Hive fork, default
+#      `leanconsensus/sync`, overridable via HIVE_SIMULATOR repository variable
+#      or workflow_dispatch input.
+#
+# Until those land, scheduled and label-triggered runs will fail fast at the
+# hive build step — this is intentional so that the integration becomes usable
+# the moment the upstream pieces are in place, without a second zeam PR.
+
+name: hive
+
+on:
+  schedule:
+    # 03:17 UTC daily — off-peak, avoids clashing with other nightly jobs.
+    - cron: '17 3 * * *'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      simulator:
+        description: 'Hive simulator to run (e.g. leanconsensus/sync)'
+        required: false
+        default: ''
+      hive_repository:
+        description: 'Hive repo (owner/name) hosting the Lean simulator + zeam client definition'
+        required: false
+        default: ''
+      hive_version:
+        description: 'Hive branch or tag'
+        required: false
+        default: ''
+
+concurrency:
+  # Cancel previous PR runs, but keep scheduled runs independent (run_id fallback).
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  hive:
+    name: hive (${{ github.event.inputs.simulator || vars.HIVE_SIMULATOR || 'leanconsensus/sync' }})
+    runs-on: ubuntu-latest
+    # Gate PR runs behind the `run-hive` label. Scheduled and manual runs always pass this check.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-hive')
+
+    steps:
+      - name: Checkout zeam
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Resolve inputs
+        id: cfg
+        run: |
+          SIMULATOR="${{ github.event.inputs.simulator }}"
+          [ -z "$SIMULATOR" ] && SIMULATOR="${{ vars.HIVE_SIMULATOR }}"
+          [ -z "$SIMULATOR" ] && SIMULATOR="leanconsensus/sync"
+
+          HIVE_REPOSITORY="${{ github.event.inputs.hive_repository }}"
+          [ -z "$HIVE_REPOSITORY" ] && HIVE_REPOSITORY="${{ vars.HIVE_REPOSITORY }}"
+          [ -z "$HIVE_REPOSITORY" ] && HIVE_REPOSITORY="ethpandaops/hive"
+
+          HIVE_VERSION="${{ github.event.inputs.hive_version }}"
+          [ -z "$HIVE_VERSION" ] && HIVE_VERSION="${{ vars.HIVE_VERSION }}"
+          [ -z "$HIVE_VERSION" ] && HIVE_VERSION="master"
+
+          echo "simulator=$SIMULATOR" >> "$GITHUB_OUTPUT"
+          echo "hive_repository=$HIVE_REPOSITORY" >> "$GITHUB_OUTPUT"
+          echo "hive_version=$HIVE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve client source
+        id: src
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SHA="${{ github.event.pull_request.head.sha }}"
+            REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            NAMETAG="pr-${{ github.event.pull_request.number }}-$(echo $SHA | cut -c1-7)"
+          else
+            SHA="${{ github.sha }}"
+            REPO="${{ github.repository }}"
+            NAMETAG="$(echo ${{ github.ref_name }} | tr '/' '-')-$(echo ${{ github.sha }} | cut -c1-7)"
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+          echo "nametag=$NAMETAG" >> "$GITHUB_OUTPUT"
+
+      - name: Run Hive
+        id: hive
+        uses: ethpandaops/hive-github-action@v0.6.3
+        with:
+          client: zeam
+          simulator: ${{ steps.cfg.outputs.simulator }}
+          hive_repository: ${{ steps.cfg.outputs.hive_repository }}
+          hive_version: ${{ steps.cfg.outputs.hive_version }}
+          client_config: |
+            - client: zeam
+              nametag: ${{ steps.src.outputs.nametag }}
+              dockerfile: git
+              build_args:
+                github: ${{ steps.src.outputs.repo }}
+                tag: ${{ steps.src.outputs.sha }}
+          workflow_artifact_upload: 'true'
+          workflow_artifact_prefix: hive-zeam-${{ steps.src.outputs.nametag }}
+
+      - name: Post summary comment on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const simulator = '${{ steps.cfg.outputs.simulator }}';
+            const nametag = '${{ steps.src.outputs.nametag }}';
+            const conclusion = '${{ steps.hive.outcome }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const icon = conclusion === 'success' ? 'success' : (conclusion === 'skipped' ? 'skipped' : 'failure');
+            const body = [
+              `### Hive results: ${icon}`,
+              ``,
+              `| Field | Value |`,
+              `|---|---|`,
+              `| Simulator | \`${simulator}\` |`,
+              `| Client tag | \`${nametag}\` |`,
+              `| Outcome | \`${conclusion}\` |`,
+              `| Run | [#${context.runId}](${runUrl}) |`,
+              ``,
+              `Artifacts (logs, test results) are attached to the workflow run.`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## Summary

Implements Hive CI integration per issue #740.

- **Daily scheduled run** at `03:00 UTC` against `main`.
- **Label-triggered PR run**: only executes when the `run-hive` label is applied to a PR, mirroring the existing `stf` label pattern used by `risc0.yml`.
- **Manual trigger** via `workflow_dispatch` with overridable simulator, devnet profile, hive_repository, hive_version inputs.

## Where failures surface

| Trigger | Report | Location |
|---|---|---|
| `schedule` | Auto-opened GitHub issue (labels: `ci-failure`, `hive`), updated in place across consecutive failing days | [issues](https://github.com/blockblaz/zeam/issues?q=is%3Aissue+is%3Aopen+label%3Aci-failure+label%3Ahive) |
| `pull_request` (label) | Comment posted on the PR with run status + artifact reference | The PR itself |
| `workflow_dispatch` | Artifacts on the workflow run | Actions tab |

The scheduled-failure issue is opened/updated by `JasonEtco/create-an-issue@v2` using the template at `.github/ISSUE_TEMPLATE/hive-scheduled-failure.md`. Close the issue once a subsequent daily run goes green.

## Upstream integration

The required upstream pieces already exist in `ethereum/hive` on `master`:

- `clients/zeam/` — Dockerfile, `hive.yaml`, entrypoint
- `simulators/lean/` — Rust-based Lean Hive simulator
- `simulators/lean/clients/{devnet3,devnet4}.yaml` — committed client profiles

The workflow points hive at the committed profile via `--client-file simulators/lean/clients/<devnet>.yaml` rather than inlining `client_config`, so upstream profile changes propagate without this workflow needing updates.

## Configuration

Defaults are sensible and can be overridden without a code change:

| Knob | Precedence | Default |
|---|---|---|
| Simulator | `workflow_dispatch.simulator` → `vars.HIVE_SIMULATOR` → fallback | `lean` |
| Devnet profile | `workflow_dispatch.devnet` → `vars.HIVE_DEVNET` → fallback | `devnet4` |
| Hive repo | `workflow_dispatch.hive_repository` → `vars.HIVE_REPOSITORY` → fallback | `ethereum/hive` |
| Hive version | `workflow_dispatch.hive_version` → `vars.HIVE_VERSION` → fallback | `master` |

## Files changed

- `.github/workflows/hive.yml` — new workflow (schedule + PR label + manual dispatch, hive invocation, PR comment, scheduled-failure issue)
- `.github/ISSUE_TEMPLATE/hive-scheduled-failure.md` — template used when a scheduled run fails

## Known limitation (follow-up, not this PR)

The upstream `clients/zeam/Dockerfile` in `ethereum/hive` selects:

- **devnet3** binary from a pinned source revision via `zeam_devnet3_revision` build arg
- **devnet4** binary from the pre-published `blockblaz/zeam:devnet4` Docker Hub image (no tag build arg)

So PR-label-triggered runs currently exercise the published devnet4 image, not the exact PR HEAD binary. Per-PR binary coverage requires an upstream hive change that exposes a `zeam_devnet4_tag` build arg (or equivalent), plus a per-PR image push to Docker Hub/GHCR from this workflow. Tracking as follow-up — not scoped into this PR to keep the CI infrastructure change isolated.

## Test plan

- [ ] Apply `run-hive` label to this draft PR and verify the job runs the `lean/devnet4` suite successfully and posts a summary comment on the PR.
- [ ] Trigger the workflow manually via `workflow_dispatch` with `devnet=devnet3` and verify the committed `devnet3.yaml` profile is picked up and a `hive-zeam-devnet3-*` artifact is uploaded.
- [ ] Confirm the 03:00 UTC cron shows up in the Actions UI after merge.
- [ ] Simulate a scheduled failure (e.g. transient override with a bad simulator name) and confirm the tracking issue is opened with the expected labels.
- [ ] After a second transient failure, confirm the existing issue is updated rather than duplicated (`update_existing: true`).

Closes #740.