### PR TITLE
ci(hive): retry on transient docker-build failures

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -102,8 +102,17 @@ jobs:
           echo "hive_repository=$HIVE_REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "hive_version=$HIVE_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Run Hive
-        id: hive
+      # The upstream `clients/zeam` Dockerfile in ethereum/hive does an
+      # `apt-get update && apt-get install` over the public Ubuntu mirrors and
+      # a `docker pull blockblaz/zeam:devnet4` before any zeam-specific code
+      # runs. Both are transient-failure prone on shared GitHub runners and
+      # produce a build-time failure (exit 100) that does not indicate a
+      # regression in-tree. We retry the full Hive invocation once with a
+      # small backoff so those transients do not spuriously fail the
+      # scheduled run and auto-open a tracking issue.
+      - name: Run Hive (primary attempt)
+        id: hive_primary
+        continue-on-error: true
         uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         with:
           client: zeam
@@ -118,6 +127,45 @@ jobs:
             --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml
           workflow_artifact_upload: 'true'
           workflow_artifact_prefix: hive-zeam-${{ steps.cfg.outputs.devnet }}
+
+      - name: Back off before retry
+        if: steps.hive_primary.outcome == 'failure'
+        run: sleep 30
+
+      - name: Run Hive (retry)
+        if: steps.hive_primary.outcome == 'failure'
+        id: hive_retry
+        continue-on-error: true
+        uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          client: zeam
+          simulator: ${{ steps.cfg.outputs.simulator }}
+          hive_repository: ${{ steps.cfg.outputs.hive_repository }}
+          hive_version: ${{ steps.cfg.outputs.hive_version }}
+          extra_flags: >-
+            --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml
+          workflow_artifact_upload: 'true'
+          workflow_artifact_prefix: hive-zeam-${{ steps.cfg.outputs.devnet }}-retry
+
+      # Single authoritative outcome used by every downstream step (PR comment,
+      # scheduled-failure issue creator, job status). Exits 0 iff either attempt
+      # succeeded; otherwise fails the job.
+      - name: Consolidate Hive outcome
+        id: hive
+        if: always()
+        run: |
+          primary='${{ steps.hive_primary.outcome }}'
+          retry='${{ steps.hive_retry.outcome }}'
+          if [ "$primary" = "success" ]; then
+            echo "Hive succeeded on primary attempt"
+            exit 0
+          fi
+          if [ "$retry" = "success" ]; then
+            echo "Hive succeeded on retry (primary: $primary)"
+            exit 0
+          fi
+          echo "Hive failed on both attempts (primary: $primary, retry: $retry)"
+          exit 1
 
       - name: Post summary comment on PR
         if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
## Context

The first scheduled Hive run after #745 was merged ([run 24549174433](https://github.com/blockblaz/zeam/actions/runs/24549174433/job/71771155497#step:4:391)) failed and auto-opened #747. The failure had nothing to do with zeam:

```
Apr 17 05:27:03.041 ERR image build failed image=hive/clients/zeam_devnet4:latest
  err="The command '/bin/bash -o pipefail -c rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
       && apt-get update -o Acquire::Retries=3 -o Acquire::By-Hash=force
       && apt-get install -y --no-install-recommends
          build-essential ca-certificates curl git libssl-dev pkg-config python3 xz-utils
       && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100"
all clients failed to build
```

This aborts in the upstream `ethereum/hive` `clients/zeam/Dockerfile` at the very first `apt-get install` in the `build-base` stage, well before any zeam-specific code runs. Exit code 100 on stock Ubuntu packages with `Acquire::Retries=3` already set is a textbook transient Ubuntu-mirror flake on the shared GitHub runner. We can't fix the upstream Dockerfile from here, and even if we could, apt/docker-pull hiccups on public infra will always happen.

## Change

Wrap the `Run Hive` step with one automatic retry (30s backoff). A single consolidation step reports `steps.hive.outcome`, preserving the contract used by the PR-summary comment and the scheduled-failure issue creator.

- Primary attempt runs with `continue-on-error: true`.
- On failure, wait 30s, then run the same Hive invocation again (artifacts get a `-retry` suffix so they don't collide).
- Final `Consolidate Hive outcome` step (`id: hive`) exits 0 iff either attempt succeeded; otherwise fails the job.
- Net effect: the PR comment and the scheduled-failure tracking issue now fire only when **both** attempts fail, which is what we want from a real-regression detector.

Total extra cost when the primary attempt succeeds: zero (retry step is gated on `steps.hive_primary.outcome == 'failure'`).

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/hive.yml'))\"` parses cleanly.
- [ ] Merge, then verify the next scheduled run (03:00 UTC) either passes, or — if it fails again — that the second attempt's artifacts appear under `hive-zeam-devnet4-retry-*` and the tracking issue is only (re)opened after both attempts fail.
- [ ] Optionally trigger a manual `workflow_dispatch` to sanity-check the two-step flow end-to-end.

## Followups (not in this PR)

- Close #747 once this lands; the triggering event was the transient documented above, not a regression.
- An upstream hive change that accepts a `zeam_devnet4_tag` build arg is still needed to actually exercise per-PR binaries (tracked in the note at the top of `hive.yml`).