### PR TITLE
feat(metrics): add Devnet-4 metrics (leanMetrics#29)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -314,6 +314,7 @@ pub fn build(b: *Builder) !void {
     zeam_network.addImport("multiaddr", multiaddr_mod);
     zeam_network.addImport("snappyframesz", snappyframesz);
     zeam_network.addImport("snappyz", snappyz);
+    zeam_network.addImport("@zeam/metrics", zeam_metrics);
 
     // add beam node
     const zeam_beam_node = b.addModule("@zeam/node", .{

--- a/pkgs/api/README.md
+++ b/pkgs/api/README.md
@@ -304,7 +304,7 @@ docker-compose up -d
 **Example query** (95th percentile block processing):
 
 ```promql
-histogram_quantile(0.95, sum(rate(chain_onblock_duration_seconds_bucket[5m])) by (le))
+histogram_quantile(0.95, sum(rate(zeam_chain_onblock_duration_seconds_bucket[5m])) by (le))
 ```
 
 ## Package Dependencies

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -304,6 +304,7 @@ pub const Node = struct {
         // metrics instead of being discarded by noop metrics.
         if (options.metrics_enable) {
             try api.init(allocator);
+            zeam_metrics.metrics.lean_node_start_time_seconds.set(@intCast(std.time.timestamp()));
         }
 
         try self.beam_node.init(allocator, .{
@@ -364,7 +365,6 @@ pub const Node = struct {
 
             // Set node lifecycle metrics
             zeam_metrics.metrics.lean_node_info.set(.{ .name = "zeam", .version = build_options.version }, 1) catch {};
-            zeam_metrics.metrics.lean_node_start_time_seconds.set(@intCast(std.time.timestamp()));
         }
 
         self.logger = options.logger_config.logger(.node);

--- a/pkgs/cli/test/integration.zig
+++ b/pkgs/cli/test/integration.zig
@@ -565,8 +565,7 @@ test "CLI beam command with mock network - complete integration test" {
     try std.testing.expect(std.mem.indexOf(u8, response, "HTTP/1.1 200") != null or std.mem.indexOf(u8, response, "HTTP/1.0 200") != null);
 
     // Verify response contains actual metric names from the metrics system
-    try std.testing.expect(std.mem.indexOf(u8, response, "chain_onblock_duration_seconds") != null or
-        std.mem.indexOf(u8, response, "block_processing_duration_seconds") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "zeam_chain_onblock_duration_seconds") != null);
 
     // Verify response is not empty
     try std.testing.expect(response.len > 100);

--- a/pkgs/metrics/README.md
+++ b/pkgs/metrics/README.md
@@ -262,7 +262,7 @@ The recommended way to measure durations is using the Timer API:
 
 ```zig
 // Start a timer
-const timer = zeam_metrics.chain_onblock_duration_seconds.start();
+const timer = zeam_metrics.zeam_chain_onblock_duration_seconds.start();
 defer _ = timer.observe(); // Automatically records when scope exits
 
 // ... do work ...
@@ -317,7 +317,7 @@ zeam_metrics.metrics.lean_peer_connection_events_total.incr(.{ .direction = "inb
 If you need to record a pre-calculated value without starting a timer:
 
 ```zig
-zeam_metrics.block_processing_duration_seconds.record(duration_seconds);
+zeam_metrics.lean_gossip_block_size_bytes.record(@floatFromInt(block_size_bytes));
 ```
 
 ## Adding New Metrics

--- a/pkgs/metrics/README.md
+++ b/pkgs/metrics/README.md
@@ -215,7 +215,7 @@ All metrics are defined in the `Metrics` struct in `pkgs/metrics/src/lib.zig`. T
 
 ### compactAttestations Metrics
 
-#### `lean_compact_attestations_time_seconds` (Histogram)
+#### `zeam_compact_attestations_time_seconds` (Histogram)
 - **Description**: Time taken by `compactAttestations` to merge payloads sharing the same `AttestationData`.
 - **Type**: Histogram
 - **Unit**: Seconds
@@ -223,14 +223,14 @@ All metrics are defined in the `Metrics` struct in `pkgs/metrics/src/lib.zig`. T
 - **Labels**: None
 - **Sample Collection Event**: On each invocation of `compactAttestations` during payload aggregation
 
-#### `lean_compact_attestations_input_total` (Counter)
+#### `zeam_compact_attestations_input_total` (Counter)
 - **Description**: Total number of attestations fed into `compactAttestations` before merging.
 - **Type**: Counter
 - **Unit**: Count (u64)
 - **Labels**: None
 - **Sample Collection Event**: On each invocation of `compactAttestations`
 
-#### `lean_compact_attestations_output_total` (Counter)
+#### `zeam_compact_attestations_output_total` (Counter)
 - **Description**: Total number of attestations produced by `compactAttestations` after merging.
 - **Type**: Counter
 - **Unit**: Count (u64)

--- a/pkgs/metrics/README.md
+++ b/pkgs/metrics/README.md
@@ -4,8 +4,9 @@
 
 The `@zeam/metrics` package provides the core metrics infrastructure for the Zeam node. It defines all application metrics (Histograms, Gauges, Counters) and provides a Timer API for time-based measurements.
 
+Zeam follows the [Lean Ethereum metrics specification](https://github.com/leanEthereum/leanMetrics). All metrics prefixed with `lean_` are defined in that spec. Any Zeam-specific metrics that are not part of the spec use the `zeam_` prefix instead.
+
 **Key Features:**
-- Comprehensive metrics definitions for monitoring node performance
 - Timer API for convenient time-based measurements
 - Automatic ZKVM/freestanding target detection with no-op behavior
 - Compile-time checks to avoid compiling unsupported code for freestanding targets
@@ -57,129 +58,6 @@ For freestanding targets (ZKVM):
 - Zero runtime overhead
 - Metrics are initialized as no-op by default
 
-## Metrics Definitions
-
-All metrics are defined in the `Metrics` struct in `pkgs/metrics/src/lib.zig`. The following metrics are available:
-
-### Chain Metrics
-
-#### `chain_onblock_duration_seconds` (Histogram)
-- **Description**: Measures the time taken to process a block within the `chain.onBlock` function (end-to-end block processing).
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
-- **Labels**: None
-- **Sample Collection Event**: On every block processed by the chain
-
-#### `block_processing_duration_seconds` (Histogram)
-- **Description**: Measures the time taken to process a block in the state transition function.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
-- **Labels**: None
-- **Sample Collection Event**: During state transition block processing
-
-### Fork Choice Metrics
-
-#### `lean_head_slot` (Gauge)
-- **Description**: Latest slot of the lean chain (canonical chain head as determined by fork choice).
-- **Type**: Gauge
-- **Unit**: Slot number (u64)
-- **Labels**: None
-- **Sample Collection Event**: Updated on every fork choice head update
-
-#### `lean_latest_justified_slot` (Gauge)
-- **Description**: Latest justified slot.
-- **Type**: Gauge
-- **Unit**: Slot number (u64)
-- **Labels**: None
-- **Sample Collection Event**: Updated on state transition completion
-
-#### `lean_latest_finalized_slot` (Gauge)
-- **Description**: Latest finalized slot.
-- **Type**: Gauge
-- **Unit**: Slot number (u64)
-- **Labels**: None
-- **Sample Collection Event**: Updated on state transition completion
-
-#### `lean_fork_choice_block_processing_time_seconds` (Histogram)
-- **Description**: Time taken to process block in fork choice.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
-- **Labels**: None
-- **Sample Collection Event**: On fork choice block processing
-
-#### `lean_attestations_valid_total` (Counter)
-- **Description**: Total number of valid attestations processed by fork choice.
-- **Type**: Counter
-- **Unit**: Count (u64)
-- **Labels**: source ("gossip", "block")
-- **Sample Collection Event**: On successful attestation validation and processing
-
-#### `lean_attestations_invalid_total` (Counter)
-- **Description**: Total number of invalid attestations rejected by fork choice.
-- **Type**: Counter
-- **Unit**: Count (u64)
-- **Labels**: source ("gossip", "block")
-- **Sample Collection Event**: On attestation validation failure
-
-#### `lean_attestation_validation_time_seconds` (Histogram)
-- **Description**: Time taken to validate attestations in fork choice.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
-- **Labels**: None
-- **Sample Collection Event**: On attestation validation and processing
-
-### State Transition Metrics
-
-#### `lean_state_transition_time_seconds` (Histogram)
-- **Description**: Time to process state transition.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4
-- **Labels**: None
-- **Sample Collection Event**: On state transition
-
-#### `lean_state_transition_slots_processed_total` (Counter)
-- **Description**: Total number of processed slots (including empty slots).
-- **Type**: Counter
-- **Unit**: Count (u64)
-- **Labels**: None
-- **Sample Collection Event**: On state transition process slots
-
-#### `lean_state_transition_slots_processing_time_seconds` (Histogram)
-- **Description**: Time taken to process slots.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
-- **Labels**: None
-- **Sample Collection Event**: On state transition process slots
-
-#### `lean_state_transition_block_processing_time_seconds` (Histogram)
-- **Description**: Time taken to process block.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
-- **Labels**: None
-- **Sample Collection Event**: On state transition process block
-
-#### `lean_state_transition_attestations_processed_total` (Counter)
-- **Description**: Total number of processed attestations.
-- **Type**: Counter
-- **Unit**: Count (u64)
-- **Labels**: None
-- **Sample Collection Event**: On state transition process attestations
-
-#### `lean_state_transition_attestations_processing_time_seconds` (Histogram)
-- **Description**: Time taken to process attestations.
-- **Type**: Histogram
-- **Unit**: Seconds
-- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
-- **Labels**: None
-- **Sample Collection Event**: On state transition process attestations
-
 ## Usage
 
 ### Importing the Package
@@ -224,6 +102,20 @@ For point-in-time measurements:
 zeam_metrics.metrics.lean_head_slot.set(slot_number);
 ```
 
+### Using GaugeVec
+
+For labeled gauges, pass a label struct to `set`. Labels represent fixed dimensions — the set of possible label values is known upfront and should always be present (with value 0 when nothing is active):
+
+```zig
+zeam_metrics.metrics.lean_connected_peers.set(.{ .client = "zeam_1", .client_type = "zeam" }, 1) catch {};
+```
+
+GaugeVec and CounterVec must be initialized with an allocator:
+
+```zig
+.my_gauge_vec = try Metrics.MyGaugeVec.init(allocator, "my_gauge_vec", .{ .help = "..." }, .{}),
+```
+
 ### Using Counters
 
 For cumulative counts:
@@ -232,12 +124,20 @@ For cumulative counts:
 zeam_metrics.metrics.lean_state_transition_slots_processed_total.incrBy(slots_processed);
 ```
 
-### Direct Histogram Observations
+### Using CounterVec
 
-If you need to record a pre-calculated duration:
+For labeled counters, pass a label struct to `incr`:
 
 ```zig
-zeam_metrics.metrics.block_processing_duration_seconds.observe(duration_seconds);
+zeam_metrics.metrics.lean_peer_connection_events_total.incr(.{ .direction = "inbound", .result = "success" }) catch {};
+```
+
+### Direct Histogram Observations
+
+If you need to record a pre-calculated value without starting a timer:
+
+```zig
+zeam_metrics.block_processing_duration_seconds.record(duration_seconds);
 ```
 
 ## Adding New Metrics
@@ -267,8 +167,14 @@ my_histogram: metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.1, 1.0 }),
 // Gauge (for point-in-time values)
 my_gauge: metrics_lib.Gauge(u64),
 
+// GaugeVec (gauge with labels — requires allocator in init)
+my_gauge_vec: metrics_lib.GaugeVec(u64, struct { status: []const u8 }),
+
 // Counter (for cumulative counts)
 my_counter: metrics_lib.Counter(u64),
+
+// CounterVec (counter with labels — requires allocator in init)
+my_counter_vec: metrics_lib.CounterVec(u64, struct { direction: []const u8, result: []const u8 }),
 ```
 
 ### Step 2: Initialize the Metric
@@ -276,28 +182,15 @@ my_counter: metrics_lib.Counter(u64),
 In the `init()` function in `pkgs/metrics/src/lib.zig`, add initialization:
 
 ```zig
-pub fn init(allocator: std.mem.Allocator) !void {
-    _ = allocator;
-    if (g_initialized) return;
-
-    if (isZKVM()) {
-        std.log.info("Using no-op metrics for ZKVM target", .{});
-        g_initialized = true;
-        return;
-    }
-
-    metrics = .{
-        // ... existing metrics ...
-        
-        .my_new_metric = Metrics.MyNewMetricHistogram.init(
-            "my_new_metric",
-            .{ .help = "Description of what this metric measures." },
-            .{}
-        ),
-    };
+metrics = .{
+    // ... existing metrics ...
     
-    // ... existing context assignments ...
-}
+    .my_new_metric = Metrics.MyNewMetricHistogram.init(
+        "my_new_metric",
+        .{ .help = "Description of what this metric measures." },
+        .{}
+    ),
+};
 ```
 
 ### Step 3: Create Wrapper for Timer API (Histograms Only)
@@ -343,17 +236,6 @@ zeam_metrics.metrics.my_gauge.set(42);
 zeam_metrics.metrics.my_counter.incrBy(1);
 ```
 
-### Step 5: Document the Metric
-
-Add the metric to this README in the appropriate section with:
-- Name
-- Description
-- Type
-- Unit
-- Buckets (for histograms)
-- Labels (if any)
-- Sample collection event
-
 ## Best Practices
 
 ### 1. Always Use Timer API for Time Measurements
@@ -391,9 +273,10 @@ For histograms, choose buckets that capture the expected range of values:
 &[_]f32{ 0.5, 1, 2, 5, 10, 30, 60 }
 ```
 
-### 4. Use Descriptive Names
+### 4. Follow the Naming Convention
 
-Follow Prometheus naming conventions:
+- `lean_` prefix: metric is defined in the [Lean metrics specification](https://github.com/leanEthereum/leanMetrics) — name, labels, buckets, and help text must match the spec exactly
+- `zeam_` prefix: metric is Zeam-specific and not part of the shared spec
 - Use `_total` suffix for counters: `requests_total`
 - Use `_seconds` suffix for time measurements: `processing_time_seconds`
 - Use base units (seconds, bytes, not milliseconds or megabytes)
@@ -465,4 +348,3 @@ See `pkgs/api/README.md` for information about the HTTP API and metrics serving.
 ## Visualization
 
 For information about visualizing metrics with Prometheus and Grafana, see the [zeam-dashboards repository](https://github.com/blockblaz/zeam-dashboards) and the API package documentation.
-

--- a/pkgs/metrics/README.md
+++ b/pkgs/metrics/README.md
@@ -58,6 +58,186 @@ For freestanding targets (ZKVM):
 - Zero runtime overhead
 - Metrics are initialized as no-op by default
 
+## Metrics Definitions
+
+All metrics are defined in the `Metrics` struct in `pkgs/metrics/src/lib.zig`. The following metrics are available:
+
+### Chain Metrics
+
+#### `zeam_chain_onblock_duration_seconds` (Histogram)
+- **Description**: Measures the time taken to process a block within the `chain.onBlock` function (end-to-end block processing).
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
+- **Labels**: None
+- **Sample Collection Event**: On every block processed by the chain
+
+### Fork Choice Metrics
+
+#### `lean_head_slot` (Gauge)
+- **Description**: Latest slot of the lean chain (canonical chain head as determined by fork choice).
+- **Type**: Gauge
+- **Unit**: Slot number (u64)
+- **Labels**: None
+- **Sample Collection Event**: Updated on every fork choice head update
+
+#### `lean_latest_justified_slot` (Gauge)
+- **Description**: Latest justified slot.
+- **Type**: Gauge
+- **Unit**: Slot number (u64)
+- **Labels**: None
+- **Sample Collection Event**: Updated on state transition completion
+
+#### `lean_latest_finalized_slot` (Gauge)
+- **Description**: Latest finalized slot.
+- **Type**: Gauge
+- **Unit**: Slot number (u64)
+- **Labels**: None
+- **Sample Collection Event**: Updated on state transition completion
+
+#### `lean_fork_choice_block_processing_time_seconds` (Histogram)
+- **Description**: Time taken to process block in fork choice.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
+- **Labels**: None
+- **Sample Collection Event**: On fork choice block processing
+
+#### `lean_attestations_valid_total` (Counter)
+- **Description**: Total number of valid attestations processed by fork choice.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: source ("gossip", "aggregation", "block")
+- **Sample Collection Event**: On successful attestation validation and processing
+
+#### `lean_attestations_invalid_total` (Counter)
+- **Description**: Total number of invalid attestations rejected by fork choice.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: source ("gossip", "aggregation", "block")
+- **Sample Collection Event**: On attestation validation failure
+
+#### `lean_attestation_validation_time_seconds` (Histogram)
+- **Description**: Time taken to validate attestations in fork choice.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
+- **Labels**: None
+- **Sample Collection Event**: On attestation validation and processing
+
+### State Transition Metrics
+
+#### `lean_state_transition_time_seconds` (Histogram)
+- **Description**: Time to process state transition.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4
+- **Labels**: None
+- **Sample Collection Event**: On state transition
+
+#### `lean_state_transition_slots_processed_total` (Counter)
+- **Description**: Total number of processed slots (including empty slots).
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: On state transition process slots
+
+#### `lean_state_transition_slots_processing_time_seconds` (Histogram)
+- **Description**: Time taken to process slots.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
+- **Labels**: None
+- **Sample Collection Event**: On state transition process slots
+
+#### `lean_state_transition_block_processing_time_seconds` (Histogram)
+- **Description**: Time taken to process block.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
+- **Labels**: None
+- **Sample Collection Event**: On state transition process block
+
+#### `lean_state_transition_attestations_processed_total` (Counter)
+- **Description**: Total number of processed attestations.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: On state transition process attestations
+
+#### `lean_state_transition_attestations_processing_time_seconds` (Histogram)
+- **Description**: Time taken to process attestations.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.005, 0.01, 0.025, 0.05, 0.1, 1
+- **Labels**: None
+- **Sample Collection Event**: On state transition process attestations
+
+### Block Production Metrics
+
+#### `lean_block_building_time_seconds` (Histogram)
+- **Description**: Total time taken to build a block.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1
+- **Labels**: None
+- **Sample Collection Event**: On each block proposal attempt
+
+#### `lean_block_building_payload_aggregation_time_seconds` (Histogram)
+- **Description**: Time taken to aggregate attestation payloads during block building.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4
+- **Labels**: None
+- **Sample Collection Event**: On each block proposal attempt
+
+#### `lean_block_aggregated_payloads` (Histogram)
+- **Description**: Number of aggregated payloads included in a produced block.
+- **Type**: Histogram
+- **Unit**: Count
+- **Buckets**: 1, 2, 4, 8, 16, 32, 64, 128
+- **Labels**: None
+- **Sample Collection Event**: On each successful block proposal
+
+#### `lean_block_building_success_total` (Counter)
+- **Description**: Total number of successfully built blocks.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: On each successful block build
+
+#### `lean_block_building_failures_total` (Counter)
+- **Description**: Total number of failed block build attempts.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: On each failed block build
+
+### compactAttestations Metrics
+
+#### `lean_compact_attestations_time_seconds` (Histogram)
+- **Description**: Time taken by `compactAttestations` to merge payloads sharing the same `AttestationData`.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5
+- **Labels**: None
+- **Sample Collection Event**: On each invocation of `compactAttestations` during payload aggregation
+
+#### `lean_compact_attestations_input_total` (Counter)
+- **Description**: Total number of attestations fed into `compactAttestations` before merging.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: On each invocation of `compactAttestations`
+
+#### `lean_compact_attestations_output_total` (Counter)
+- **Description**: Total number of attestations produced by `compactAttestations` after merging.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: On each invocation of `compactAttestations`
+
+
 ## Usage
 
 ### Importing the Package
@@ -182,15 +362,27 @@ my_counter_vec: metrics_lib.CounterVec(u64, struct { direction: []const u8, resu
 In the `init()` function in `pkgs/metrics/src/lib.zig`, add initialization:
 
 ```zig
-metrics = .{
-    // ... existing metrics ...
-    
-    .my_new_metric = Metrics.MyNewMetricHistogram.init(
-        "my_new_metric",
-        .{ .help = "Description of what this metric measures." },
-        .{}
-    ),
-};
+pub fn init(allocator: std.mem.Allocator) !void {
+    if (g_initialized) return;
+
+    if (isZKVM()) {
+        std.log.info("Using no-op metrics for ZKVM target", .{});
+        g_initialized = true;
+        return;
+    }
+
+    metrics = .{
+        // ... existing metrics ...
+        
+        .my_new_metric = Metrics.MyNewMetricHistogram.init(
+            "my_new_metric",
+            .{ .help = "Description of what this metric measures." },
+            .{}
+        ),
+    };
+
+    // ... existing context assignments ...
+}
 ```
 
 ### Step 3: Create Wrapper for Timer API (Histograms Only)

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -95,9 +95,9 @@ const Metrics = struct {
     // Attestation production time histogram
     lean_attestations_production_time_seconds: AttestationProductionTimeHistogram,
     // compactAttestations metrics
-    lean_compact_attestations_time_seconds: CompactAttestationsTimeHistogram,
-    lean_compact_attestations_input_total: CompactAttestationsInputCounter,
-    lean_compact_attestations_output_total: CompactAttestationsOutputCounter,
+    zeam_compact_attestations_time_seconds: CompactAttestationsTimeHistogram,
+    zeam_compact_attestations_input_total: CompactAttestationsInputCounter,
+    zeam_compact_attestations_output_total: CompactAttestationsOutputCounter,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
@@ -411,7 +411,7 @@ pub var lean_attestations_production_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeAttestationProduction,
 };
-pub var lean_compact_attestations_time_seconds: Histogram = .{
+pub var zeam_compact_attestations_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeCompactAttestations,
 };
@@ -494,9 +494,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_gossip_aggregation_size_bytes = Metrics.GossipAggregationSizeBytesHistogram.init("lean_gossip_aggregation_size_bytes", .{ .help = "Bytes size of a gossip aggregated attestation message" }, .{}),
         .lean_attestations_production_time_seconds = Metrics.AttestationProductionTimeHistogram.init("lean_attestations_production_time_seconds", .{ .help = "Time taken to produce attestation" }, .{}),
         // compactAttestations metrics
-        .lean_compact_attestations_time_seconds = Metrics.CompactAttestationsTimeHistogram.init("lean_compact_attestations_time_seconds", .{ .help = "Time taken by compactAttestations to merge payloads sharing the same AttestationData" }, .{}),
-        .lean_compact_attestations_input_total = Metrics.CompactAttestationsInputCounter.init("lean_compact_attestations_input_total", .{ .help = "Total number of attestations input to compactAttestations" }, .{}),
-        .lean_compact_attestations_output_total = Metrics.CompactAttestationsOutputCounter.init("lean_compact_attestations_output_total", .{ .help = "Total number of attestations output from compactAttestations after compaction" }, .{}),
+        .zeam_compact_attestations_time_seconds = Metrics.CompactAttestationsTimeHistogram.init("zeam_compact_attestations_time_seconds", .{ .help = "Time taken by compactAttestations to merge payloads sharing the same AttestationData" }, .{}),
+        .zeam_compact_attestations_input_total = Metrics.CompactAttestationsInputCounter.init("zeam_compact_attestations_input_total", .{ .help = "Total number of attestations input to compactAttestations" }, .{}),
+        .zeam_compact_attestations_output_total = Metrics.CompactAttestationsOutputCounter.init("zeam_compact_attestations_output_total", .{ .help = "Total number of attestations output from compactAttestations after compaction" }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -532,7 +532,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_gossip_attestation_size_bytes.context = @ptrCast(&metrics.lean_gossip_attestation_size_bytes);
     lean_gossip_aggregation_size_bytes.context = @ptrCast(&metrics.lean_gossip_aggregation_size_bytes);
     lean_attestations_production_time_seconds.context = @ptrCast(&metrics.lean_attestations_production_time_seconds);
-    lean_compact_attestations_time_seconds.context = @ptrCast(&metrics.lean_compact_attestations_time_seconds);
+    zeam_compact_attestations_time_seconds.context = @ptrCast(&metrics.zeam_compact_attestations_time_seconds);
     // Initialize sync status to idle at startup
     try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);
     try metrics.lean_node_sync_status.set(.{ .status = "syncing" }, 0);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -157,7 +157,7 @@ const Metrics = struct {
     const GossipAttestationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 512, 1_024, 2_048, 4_096, 8_192, 16_384 });
     const GossipAggregationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1_024, 4_096, 16_384, 65_536, 131_072, 262_144, 524_288, 1_048_576 });
     // Attestation production time histogram type
-    const AttestationProductionTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
+    const AttestationProductionTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -94,6 +94,10 @@ const Metrics = struct {
     lean_gossip_aggregation_size_bytes: GossipAggregationSizeBytesHistogram,
     // Attestation production time histogram
     lean_attestations_production_time_seconds: AttestationProductionTimeHistogram,
+    // compactAttestations metrics
+    lean_compact_attestations_time_seconds: CompactAttestationsTimeHistogram,
+    lean_compact_attestations_input_total: CompactAttestationsInputCounter,
+    lean_compact_attestations_output_total: CompactAttestationsOutputCounter,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
@@ -109,8 +113,8 @@ const Metrics = struct {
     const AttestationsProcessedCounter = metrics_lib.Counter(u64);
     const LeanValidatorsCountGauge = metrics_lib.Gauge(u64);
     const ForkChoiceBlockProcessingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1, 1.25, 1.5, 2, 4 });
-    const ForkChoiceAttestationsValidLabeledCounter = metrics_lib.Counter(u64);
-    const ForkChoiceAttestationsInvalidLabeledCounter = metrics_lib.Counter(u64);
+    const ForkChoiceAttestationsValidLabeledCounter = metrics_lib.CounterVec(u64, struct { source: []const u8 });
+    const ForkChoiceAttestationsInvalidLabeledCounter = metrics_lib.CounterVec(u64, struct { source: []const u8 });
     const ForkChoiceAttestationValidationTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1 });
     // Individual attestation signature metric types
     const PQSigAttestationSignaturesTotalCounter = metrics_lib.Counter(u64);
@@ -158,6 +162,10 @@ const Metrics = struct {
     const GossipAggregationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1_024, 4_096, 16_384, 65_536, 131_072, 262_144, 524_288, 1_048_576 });
     // Attestation production time histogram type
     const AttestationProductionTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
+    // compactAttestations metric types
+    const CompactAttestationsTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5 });
+    const CompactAttestationsInputCounter = metrics_lib.Counter(u64);
+    const CompactAttestationsOutputCounter = metrics_lib.Counter(u64);
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -317,6 +325,12 @@ fn observeAttestationProduction(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeCompactAttestations(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.CompactAttestationsTimeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 /// The public variables the application interacts with.
 /// Calling `.start()` on these will start a new timer.
 pub var zeam_chain_onblock_duration_seconds: Histogram = .{
@@ -397,6 +411,10 @@ pub var lean_attestations_production_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeAttestationProduction,
 };
+pub var lean_compact_attestations_time_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeCompactAttestations,
+};
 
 /// Initializes the metrics system. Must be called once at startup.
 pub fn init(allocator: std.mem.Allocator) !void {
@@ -422,8 +440,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_state_transition_attestations_processing_time_seconds = Metrics.AttestationsProcessingHistogram.init("lean_state_transition_attestations_processing_time_seconds", .{ .help = "Time taken to process attestations" }, .{}),
         .lean_validators_count = Metrics.LeanValidatorsCountGauge.init("lean_validators_count", .{ .help = "Number of validators managed by a node" }, .{}),
         .lean_fork_choice_block_processing_time_seconds = Metrics.ForkChoiceBlockProcessingTimeHistogram.init("lean_fork_choice_block_processing_time_seconds", .{ .help = "Time taken to process block" }, .{}),
-        .lean_attestations_valid_total = Metrics.ForkChoiceAttestationsValidLabeledCounter.init("lean_attestations_valid_total", .{ .help = "Total number of valid attestations" }, .{}),
-        .lean_attestations_invalid_total = Metrics.ForkChoiceAttestationsInvalidLabeledCounter.init("lean_attestations_invalid_total", .{ .help = "Total number of invalid attestations" }, .{}),
+        .lean_attestations_valid_total = try Metrics.ForkChoiceAttestationsValidLabeledCounter.init(allocator, "lean_attestations_valid_total", .{ .help = "Total number of valid attestations" }, .{}),
+        .lean_attestations_invalid_total = try Metrics.ForkChoiceAttestationsInvalidLabeledCounter.init(allocator, "lean_attestations_invalid_total", .{ .help = "Total number of invalid attestations" }, .{}),
         .lean_attestation_validation_time_seconds = Metrics.ForkChoiceAttestationValidationTimeHistogram.init("lean_attestation_validation_time_seconds", .{ .help = "Time taken to validate attestation" }, .{}),
         // Individual attestation signature metrics
         .lean_pq_sig_attestation_signing_time_seconds = Metrics.PQSignatureSigningHistogram.init("lean_pq_sig_attestation_signing_time_seconds", .{ .help = "Time taken to sign an attestation" }, .{}),
@@ -475,6 +493,10 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_gossip_attestation_size_bytes = Metrics.GossipAttestationSizeBytesHistogram.init("lean_gossip_attestation_size_bytes", .{ .help = "Bytes size of a gossip attestation message" }, .{}),
         .lean_gossip_aggregation_size_bytes = Metrics.GossipAggregationSizeBytesHistogram.init("lean_gossip_aggregation_size_bytes", .{ .help = "Bytes size of a gossip aggregated attestation message" }, .{}),
         .lean_attestations_production_time_seconds = Metrics.AttestationProductionTimeHistogram.init("lean_attestations_production_time_seconds", .{ .help = "Time taken to produce attestation" }, .{}),
+        // compactAttestations metrics
+        .lean_compact_attestations_time_seconds = Metrics.CompactAttestationsTimeHistogram.init("lean_compact_attestations_time_seconds", .{ .help = "Time taken by compactAttestations to merge payloads sharing the same AttestationData" }, .{}),
+        .lean_compact_attestations_input_total = Metrics.CompactAttestationsInputCounter.init("lean_compact_attestations_input_total", .{ .help = "Total number of attestations input to compactAttestations" }, .{}),
+        .lean_compact_attestations_output_total = Metrics.CompactAttestationsOutputCounter.init("lean_compact_attestations_output_total", .{ .help = "Total number of attestations output from compactAttestations after compaction" }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -510,6 +532,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_gossip_attestation_size_bytes.context = @ptrCast(&metrics.lean_gossip_attestation_size_bytes);
     lean_gossip_aggregation_size_bytes.context = @ptrCast(&metrics.lean_gossip_aggregation_size_bytes);
     lean_attestations_production_time_seconds.context = @ptrCast(&metrics.lean_attestations_production_time_seconds);
+    lean_compact_attestations_time_seconds.context = @ptrCast(&metrics.lean_compact_attestations_time_seconds);
     // Initialize sync status to idle at startup
     try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);
     try metrics.lean_node_sync_status.set(.{ .status = "syncing" }, 0);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -28,8 +28,7 @@ pub var metrics = metrics_lib.initializeNoop(Metrics);
 var g_initialized: bool = false;
 
 const Metrics = struct {
-    chain_onblock_duration_seconds: ChainHistogram,
-    block_processing_duration_seconds: BlockProcessingHistogram,
+    zeam_chain_onblock_duration_seconds: ChainHistogram,
     lean_head_slot: LeanHeadSlotGauge,
     lean_latest_justified_slot: LeanLatestJustifiedSlotGauge,
     lean_latest_finalized_slot: LeanLatestFinalizedSlotGauge,
@@ -97,7 +96,6 @@ const Metrics = struct {
     lean_attestations_production_time_seconds: AttestationProductionTimeHistogram,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
-    const BlockProcessingHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
     const SlotsProcessingHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1 });
     const BlockProcessingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1 });
@@ -211,12 +209,6 @@ fn observeChainOnblock(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
-fn observeBlockProcessing(ctx: ?*anyopaque, value: f32) void {
-    const histogram_ptr = ctx orelse return; // No-op if not initialized
-    const histogram: *Metrics.BlockProcessingHistogram = @ptrCast(@alignCast(histogram_ptr));
-    histogram.observe(value);
-}
-
 fn observeStateTransition(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return; // No-op if not initialized
     const histogram: *Metrics.StateTransitionHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -327,13 +319,9 @@ fn observeAttestationProduction(ctx: ?*anyopaque, value: f32) void {
 
 /// The public variables the application interacts with.
 /// Calling `.start()` on these will start a new timer.
-pub var chain_onblock_duration_seconds: Histogram = .{
+pub var zeam_chain_onblock_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeChainOnblock,
-};
-pub var block_processing_duration_seconds: Histogram = .{
-    .context = null,
-    .observe = &observeBlockProcessing,
 };
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
@@ -422,8 +410,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     }
 
     metrics = .{
-        .chain_onblock_duration_seconds = Metrics.ChainHistogram.init("chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
-        .block_processing_duration_seconds = Metrics.BlockProcessingHistogram.init("block_processing_duration_seconds", .{ .help = "Time taken to process a block in the state transition function." }, .{}),
+        .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
         .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot" }, .{}),
         .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot" }, .{}),
@@ -502,8 +489,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics.lean_latest_known_aggregated_payloads.set(0);
 
     // Set context for histogram wrappers (observe functions already assigned at compile time)
-    chain_onblock_duration_seconds.context = @ptrCast(&metrics.chain_onblock_duration_seconds);
-    block_processing_duration_seconds.context = @ptrCast(&metrics.block_processing_duration_seconds);
+    zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -81,6 +81,18 @@ const Metrics = struct {
     lean_is_aggregator: LeanIsAggregatorGauge,
     lean_attestation_committee_subnet: LeanAttestationCommitteeSubnetGauge,
     lean_attestation_committee_count: LeanAttestationCommitteeCountGauge,
+    // Block production metrics (leanMetrics#29)
+    lean_block_building_time_seconds: BlockBuildingTimeHistogram,
+    lean_block_building_payload_aggregation_time_seconds: BlockPayloadAggregationTimeHistogram,
+    lean_block_aggregated_payloads: BlockAggregatedPayloadsHistogram,
+    lean_block_building_success_total: BlockBuildingSuccessCounter,
+    lean_block_building_failures_total: BlockBuildingFailuresCounter,
+    // Sync status gauge (leanMetrics#29)
+    lean_node_sync_status: LeanNodeSyncStatusGauge,
+    // Gossip message size histograms (leanMetrics#29)
+    lean_gossip_block_size_bytes: GossipBlockSizeBytesHistogram,
+    lean_gossip_attestation_size_bytes: GossipAttestationSizeBytesHistogram,
+    lean_gossip_aggregation_size_bytes: GossipAggregationSizeBytesHistogram,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const BlockProcessingHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
@@ -130,7 +142,20 @@ const Metrics = struct {
     const LeanLatestNewAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
     const LeanLatestKnownAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
     // Committee aggregation histogram type
-    const CommitteeSignaturesAggregationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
+    // Buckets widened for Devnet-4 (leanMetrics#29): was [0.005..1], now [0.05..4]
+    const CommitteeSignaturesAggregationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
+    // Block production metric types (leanMetrics#29)
+    const BlockBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
+    const BlockPayloadAggregationTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
+    const BlockAggregatedPayloadsHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 2, 4, 8, 16, 32, 64, 128 });
+    const BlockBuildingSuccessCounter = metrics_lib.Counter(u64);
+    const BlockBuildingFailuresCounter = metrics_lib.Counter(u64);
+    // Sync status gauge type (leanMetrics#29): 0=idle, 1=syncing, 2=synced
+    const LeanNodeSyncStatusGauge = metrics_lib.Gauge(u64);
+    // Gossip message size histogram types (leanMetrics#29)
+    const GossipBlockSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 10_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000 });
+    const GossipAttestationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 512, 1_024, 2_048, 4_096, 8_192, 16_384 });
+    const GossipAggregationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1_024, 4_096, 16_384, 65_536, 131_072, 262_144, 524_288, 1_048_576 });
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -168,6 +193,11 @@ pub const Histogram = struct {
             .context = self.context,
             .observe_impl = self.observe,
         };
+    }
+
+    /// Record a value directly without starting a timer.
+    pub fn record(self: *const Histogram, value: f32) void {
+        self.observe(self.context, value);
     }
 };
 
@@ -243,6 +273,42 @@ fn observePQSigAggregatedVerification(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeBlockBuildingTime(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.BlockBuildingTimeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeBlockPayloadAggregationTime(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.BlockPayloadAggregationTimeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeBlockAggregatedPayloads(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.BlockAggregatedPayloadsHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeGossipBlockSizeBytes(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.GossipBlockSizeBytesHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeGossipAttestationSizeBytes(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.GossipAttestationSizeBytesHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeGossipAggregationSizeBytes(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.GossipAggregationSizeBytesHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeCommitteeSignaturesAggregation(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return; // No-op if not initialized
     const histogram: *Metrics.CommitteeSignaturesAggregationHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -303,6 +369,31 @@ pub var lean_pq_sig_aggregated_signatures_verification_time_seconds: Histogram =
 pub var lean_committee_signatures_aggregation_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeCommitteeSignaturesAggregation,
+};
+
+pub var lean_block_building_time_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeBlockBuildingTime,
+};
+pub var lean_block_building_payload_aggregation_time_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeBlockPayloadAggregationTime,
+};
+pub var lean_block_aggregated_payloads: Histogram = .{
+    .context = null,
+    .observe = &observeBlockAggregatedPayloads,
+};
+pub var lean_gossip_block_size_bytes: Histogram = .{
+    .context = null,
+    .observe = &observeGossipBlockSizeBytes,
+};
+pub var lean_gossip_attestation_size_bytes: Histogram = .{
+    .context = null,
+    .observe = &observeGossipAttestationSizeBytes,
+};
+pub var lean_gossip_aggregation_size_bytes: Histogram = .{
+    .context = null,
+    .observe = &observeGossipAggregationSizeBytes,
 };
 
 /// Initializes the metrics system. Must be called once at startup.
@@ -370,6 +461,18 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_is_aggregator = Metrics.LeanIsAggregatorGauge.init("lean_is_aggregator", .{ .help = "Validator's is_aggregator status. True=1, False=0." }, .{}),
         .lean_attestation_committee_subnet = Metrics.LeanAttestationCommitteeSubnetGauge.init("lean_attestation_committee_subnet", .{ .help = "Node's attestation committee subnet." }, .{}),
         .lean_attestation_committee_count = Metrics.LeanAttestationCommitteeCountGauge.init("lean_attestation_committee_count", .{ .help = "Number of attestation committees." }, .{}),
+        // Block production metrics (leanMetrics#29)
+        .lean_block_building_time_seconds = Metrics.BlockBuildingTimeHistogram.init("lean_block_building_time_seconds", .{ .help = "Total time to build a block (propose_block)." }, .{}),
+        .lean_block_building_payload_aggregation_time_seconds = Metrics.BlockPayloadAggregationTimeHistogram.init("lean_block_building_payload_aggregation_time_seconds", .{ .help = "Time to aggregate attestation payloads during block building." }, .{}),
+        .lean_block_aggregated_payloads = Metrics.BlockAggregatedPayloadsHistogram.init("lean_block_aggregated_payloads", .{ .help = "Number of aggregated attestation payloads included in a block." }, .{}),
+        .lean_block_building_success_total = Metrics.BlockBuildingSuccessCounter.init("lean_block_building_success_total", .{ .help = "Total number of successfully produced blocks." }, .{}),
+        .lean_block_building_failures_total = Metrics.BlockBuildingFailuresCounter.init("lean_block_building_failures_total", .{ .help = "Total number of block production failures." }, .{}),
+        // Sync status (leanMetrics#29): 0=idle, 1=syncing, 2=synced
+        .lean_node_sync_status = Metrics.LeanNodeSyncStatusGauge.init("lean_node_sync_status", .{ .help = "Node sync status: 0=idle, 1=syncing (behind peers), 2=synced." }, .{}),
+        // Gossip message size histograms (leanMetrics#29)
+        .lean_gossip_block_size_bytes = Metrics.GossipBlockSizeBytesHistogram.init("lean_gossip_block_size_bytes", .{ .help = "Uncompressed size of received gossip block messages in bytes." }, .{}),
+        .lean_gossip_attestation_size_bytes = Metrics.GossipAttestationSizeBytesHistogram.init("lean_gossip_attestation_size_bytes", .{ .help = "Uncompressed size of received gossip attestation messages in bytes." }, .{}),
+        .lean_gossip_aggregation_size_bytes = Metrics.GossipAggregationSizeBytesHistogram.init("lean_gossip_aggregation_size_bytes", .{ .help = "Uncompressed size of received gossip aggregation messages in bytes." }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -397,6 +500,16 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_pq_sig_aggregated_signatures_building_time_seconds.context = @ptrCast(&metrics.lean_pq_sig_aggregated_signatures_building_time_seconds);
     lean_pq_sig_aggregated_signatures_verification_time_seconds.context = @ptrCast(&metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds);
     lean_committee_signatures_aggregation_time_seconds.context = @ptrCast(&metrics.lean_committee_signatures_aggregation_time_seconds);
+    // Block production histogram contexts (leanMetrics#29)
+    lean_block_building_time_seconds.context = @ptrCast(&metrics.lean_block_building_time_seconds);
+    lean_block_building_payload_aggregation_time_seconds.context = @ptrCast(&metrics.lean_block_building_payload_aggregation_time_seconds);
+    lean_block_aggregated_payloads.context = @ptrCast(&metrics.lean_block_aggregated_payloads);
+    // Gossip size histogram contexts (leanMetrics#29)
+    lean_gossip_block_size_bytes.context = @ptrCast(&metrics.lean_gossip_block_size_bytes);
+    lean_gossip_attestation_size_bytes.context = @ptrCast(&metrics.lean_gossip_attestation_size_bytes);
+    lean_gossip_aggregation_size_bytes.context = @ptrCast(&metrics.lean_gossip_aggregation_size_bytes);
+    // Initialize sync status to idle at startup (leanMetrics#29)
+    metrics.lean_node_sync_status.set(0);
 
     g_initialized = true;
 }

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -81,18 +81,20 @@ const Metrics = struct {
     lean_is_aggregator: LeanIsAggregatorGauge,
     lean_attestation_committee_subnet: LeanAttestationCommitteeSubnetGauge,
     lean_attestation_committee_count: LeanAttestationCommitteeCountGauge,
-    // Block production metrics (leanMetrics#29)
+    // Block production metrics
     lean_block_building_time_seconds: BlockBuildingTimeHistogram,
     lean_block_building_payload_aggregation_time_seconds: BlockPayloadAggregationTimeHistogram,
     lean_block_aggregated_payloads: BlockAggregatedPayloadsHistogram,
     lean_block_building_success_total: BlockBuildingSuccessCounter,
     lean_block_building_failures_total: BlockBuildingFailuresCounter,
-    // Sync status gauge (leanMetrics#29)
+    // Sync status gauge
     lean_node_sync_status: LeanNodeSyncStatusGauge,
-    // Gossip message size histograms (leanMetrics#29)
+    // Gossip message size histograms
     lean_gossip_block_size_bytes: GossipBlockSizeBytesHistogram,
     lean_gossip_attestation_size_bytes: GossipAttestationSizeBytesHistogram,
     lean_gossip_aggregation_size_bytes: GossipAggregationSizeBytesHistogram,
+    // Attestation production time histogram
+    lean_attestations_production_time_seconds: AttestationProductionTimeHistogram,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const BlockProcessingHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
@@ -109,8 +111,8 @@ const Metrics = struct {
     const AttestationsProcessedCounter = metrics_lib.Counter(u64);
     const LeanValidatorsCountGauge = metrics_lib.Gauge(u64);
     const ForkChoiceBlockProcessingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1, 1.25, 1.5, 2, 4 });
-    const ForkChoiceAttestationsValidLabeledCounter = metrics_lib.CounterVec(u64, struct { source: []const u8 });
-    const ForkChoiceAttestationsInvalidLabeledCounter = metrics_lib.CounterVec(u64, struct { source: []const u8 });
+    const ForkChoiceAttestationsValidLabeledCounter = metrics_lib.Counter(u64);
+    const ForkChoiceAttestationsInvalidLabeledCounter = metrics_lib.Counter(u64);
     const ForkChoiceAttestationValidationTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1 });
     // Individual attestation signature metric types
     const PQSigAttestationSignaturesTotalCounter = metrics_lib.Counter(u64);
@@ -124,7 +126,7 @@ const Metrics = struct {
     const PQSigAggregatedValidCounter = metrics_lib.Counter(u64);
     const PQSigAggregatedInvalidCounter = metrics_lib.Counter(u64);
     // Network peer metric types
-    const LeanConnectedPeersGauge = metrics_lib.Gauge(u64);
+    const LeanConnectedPeersGauge = metrics_lib.GaugeVec(u64, struct { client: []const u8, client_type: []const u8 });
     const PeerConnectionEventsCounter = metrics_lib.CounterVec(u64, struct { direction: []const u8, result: []const u8 });
     const PeerDisconnectionEventsCounter = metrics_lib.CounterVec(u64, struct { direction: []const u8, reason: []const u8 });
     // Node lifecycle metric types
@@ -142,20 +144,22 @@ const Metrics = struct {
     const LeanLatestNewAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
     const LeanLatestKnownAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
     // Committee aggregation histogram type
-    // Buckets widened for Devnet-4 (leanMetrics#29): was [0.005..1], now [0.05..4]
+    // Buckets widened for Devnet-4: was [0.005..1], now [0.05..4]
     const CommitteeSignaturesAggregationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
-    // Block production metric types (leanMetrics#29)
+    // Block production metric types
     const BlockBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
     const BlockPayloadAggregationTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
     const BlockAggregatedPayloadsHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 2, 4, 8, 16, 32, 64, 128 });
     const BlockBuildingSuccessCounter = metrics_lib.Counter(u64);
     const BlockBuildingFailuresCounter = metrics_lib.Counter(u64);
-    // Sync status gauge type (leanMetrics#29): 0=idle, 1=syncing, 2=synced
-    const LeanNodeSyncStatusGauge = metrics_lib.Gauge(u64);
-    // Gossip message size histogram types (leanMetrics#29)
+    // Sync status gauge type: 0=idle, 1=syncing, 2=synced
+    const LeanNodeSyncStatusGauge = metrics_lib.GaugeVec(u64, struct { status: []const u8 });
+    // Gossip message size histogram types
     const GossipBlockSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 10_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000 });
     const GossipAttestationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 512, 1_024, 2_048, 4_096, 8_192, 16_384 });
     const GossipAggregationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1_024, 4_096, 16_384, 65_536, 131_072, 262_144, 524_288, 1_048_576 });
+    // Attestation production time histogram type
+    const AttestationProductionTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -315,6 +319,12 @@ fn observeCommitteeSignaturesAggregation(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeAttestationProduction(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.AttestationProductionTimeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 /// The public variables the application interacts with.
 /// Calling `.start()` on these will start a new timer.
 pub var chain_onblock_duration_seconds: Histogram = .{
@@ -395,6 +405,10 @@ pub var lean_gossip_aggregation_size_bytes: Histogram = .{
     .context = null,
     .observe = &observeGossipAggregationSizeBytes,
 };
+pub var lean_attestations_production_time_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeAttestationProduction,
+};
 
 /// Initializes the metrics system. Must be called once at startup.
 pub fn init(allocator: std.mem.Allocator) !void {
@@ -410,69 +424,70 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .chain_onblock_duration_seconds = Metrics.ChainHistogram.init("chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .block_processing_duration_seconds = Metrics.BlockProcessingHistogram.init("block_processing_duration_seconds", .{ .help = "Time taken to process a block in the state transition function." }, .{}),
-        .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain." }, .{}),
-        .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot." }, .{}),
-        .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot." }, .{}),
-        .lean_state_transition_time_seconds = Metrics.StateTransitionHistogram.init("lean_state_transition_time_seconds", .{ .help = "Time to process state transition." }, .{}),
-        .lean_state_transition_slots_processed_total = Metrics.SlotsProcessedCounter.init("lean_state_transition_slots_processed_total", .{ .help = "Total number of processed slots." }, .{}),
-        .lean_state_transition_slots_processing_time_seconds = Metrics.SlotsProcessingHistogram.init("lean_state_transition_slots_processing_time_seconds", .{ .help = "Time taken to process slots." }, .{}),
-        .lean_state_transition_block_processing_time_seconds = Metrics.BlockProcessingTimeHistogram.init("lean_state_transition_block_processing_time_seconds", .{ .help = "Time taken to process block." }, .{}),
-        .lean_state_transition_attestations_processed_total = Metrics.AttestationsProcessedCounter.init("lean_state_transition_attestations_processed_total", .{ .help = "Total number of processed attestations." }, .{}),
-        .lean_state_transition_attestations_processing_time_seconds = Metrics.AttestationsProcessingHistogram.init("lean_state_transition_attestations_processing_time_seconds", .{ .help = "Time taken to process attestations." }, .{}),
-        .lean_validators_count = Metrics.LeanValidatorsCountGauge.init("lean_validators_count", .{ .help = "Number of connected validators." }, .{}),
-        .lean_fork_choice_block_processing_time_seconds = Metrics.ForkChoiceBlockProcessingTimeHistogram.init("lean_fork_choice_block_processing_time_seconds", .{ .help = "Time taken to process block in fork choice." }, .{}),
-        .lean_attestations_valid_total = try Metrics.ForkChoiceAttestationsValidLabeledCounter.init(allocator, "lean_attestations_valid_total", .{ .help = "Total number of valid attestations labeled by source (gossip or block)." }, .{}),
-        .lean_attestations_invalid_total = try Metrics.ForkChoiceAttestationsInvalidLabeledCounter.init(allocator, "lean_attestations_invalid_total", .{ .help = "Total number of invalid attestations labeled by source (gossip or block)." }, .{}),
-        .lean_attestation_validation_time_seconds = Metrics.ForkChoiceAttestationValidationTimeHistogram.init("lean_attestation_validation_time_seconds", .{ .help = "Time taken to validate attestation." }, .{}),
-        // Individual attestation signature metrics (renamed to match spec)
-        .lean_pq_sig_attestation_signing_time_seconds = Metrics.PQSignatureSigningHistogram.init("lean_pq_sig_attestation_signing_time_seconds", .{ .help = "Time taken to sign an attestation." }, .{}),
-        .lean_pq_sig_attestation_verification_time_seconds = Metrics.PQSignatureVerificationHistogram.init("lean_pq_sig_attestation_verification_time_seconds", .{ .help = "Time taken to verify an attestation signature." }, .{}),
-        .lean_pq_sig_attestation_signatures_total = Metrics.PQSigAttestationSignaturesTotalCounter.init("lean_pq_sig_attestation_signatures_total", .{ .help = "Total number of individual attestation signatures." }, .{}),
-        .lean_pq_sig_attestation_signatures_valid_total = Metrics.PQSigAttestationSignaturesValidCounter.init("lean_pq_sig_attestation_signatures_valid_total", .{ .help = "Total number of valid individual attestation signatures." }, .{}),
-        .lean_pq_sig_attestation_signatures_invalid_total = Metrics.PQSigAttestationSignaturesInvalidCounter.init("lean_pq_sig_attestation_signatures_invalid_total", .{ .help = "Total number of invalid individual attestation signatures." }, .{}),
+        .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
+        .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot" }, .{}),
+        .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot" }, .{}),
+        .lean_state_transition_time_seconds = Metrics.StateTransitionHistogram.init("lean_state_transition_time_seconds", .{ .help = "Time to process state transition" }, .{}),
+        .lean_state_transition_slots_processed_total = Metrics.SlotsProcessedCounter.init("lean_state_transition_slots_processed_total", .{ .help = "Total number of processed slots" }, .{}),
+        .lean_state_transition_slots_processing_time_seconds = Metrics.SlotsProcessingHistogram.init("lean_state_transition_slots_processing_time_seconds", .{ .help = "Time taken to process slots" }, .{}),
+        .lean_state_transition_block_processing_time_seconds = Metrics.BlockProcessingTimeHistogram.init("lean_state_transition_block_processing_time_seconds", .{ .help = "Time taken to process block" }, .{}),
+        .lean_state_transition_attestations_processed_total = Metrics.AttestationsProcessedCounter.init("lean_state_transition_attestations_processed_total", .{ .help = "Total number of processed attestations" }, .{}),
+        .lean_state_transition_attestations_processing_time_seconds = Metrics.AttestationsProcessingHistogram.init("lean_state_transition_attestations_processing_time_seconds", .{ .help = "Time taken to process attestations" }, .{}),
+        .lean_validators_count = Metrics.LeanValidatorsCountGauge.init("lean_validators_count", .{ .help = "Number of validators managed by a node" }, .{}),
+        .lean_fork_choice_block_processing_time_seconds = Metrics.ForkChoiceBlockProcessingTimeHistogram.init("lean_fork_choice_block_processing_time_seconds", .{ .help = "Time taken to process block" }, .{}),
+        .lean_attestations_valid_total = Metrics.ForkChoiceAttestationsValidLabeledCounter.init("lean_attestations_valid_total", .{ .help = "Total number of valid attestations" }, .{}),
+        .lean_attestations_invalid_total = Metrics.ForkChoiceAttestationsInvalidLabeledCounter.init("lean_attestations_invalid_total", .{ .help = "Total number of invalid attestations" }, .{}),
+        .lean_attestation_validation_time_seconds = Metrics.ForkChoiceAttestationValidationTimeHistogram.init("lean_attestation_validation_time_seconds", .{ .help = "Time taken to validate attestation" }, .{}),
+        // Individual attestation signature metrics
+        .lean_pq_sig_attestation_signing_time_seconds = Metrics.PQSignatureSigningHistogram.init("lean_pq_sig_attestation_signing_time_seconds", .{ .help = "Time taken to sign an attestation" }, .{}),
+        .lean_pq_sig_attestation_verification_time_seconds = Metrics.PQSignatureVerificationHistogram.init("lean_pq_sig_attestation_verification_time_seconds", .{ .help = "Time taken to verify an attestation signature" }, .{}),
+        .lean_pq_sig_attestation_signatures_total = Metrics.PQSigAttestationSignaturesTotalCounter.init("lean_pq_sig_attestation_signatures_total", .{ .help = "Total number of individual attestation signatures" }, .{}),
+        .lean_pq_sig_attestation_signatures_valid_total = Metrics.PQSigAttestationSignaturesValidCounter.init("lean_pq_sig_attestation_signatures_valid_total", .{ .help = "Total number of valid individual attestation signatures" }, .{}),
+        .lean_pq_sig_attestation_signatures_invalid_total = Metrics.PQSigAttestationSignaturesInvalidCounter.init("lean_pq_sig_attestation_signatures_invalid_total", .{ .help = "Total number of invalid individual attestation signatures" }, .{}),
         // Aggregated attestation signature metrics
-        .lean_pq_sig_aggregated_signatures_total = Metrics.PQSigAggregatedSignaturesTotalCounter.init("lean_pq_sig_aggregated_signatures_total", .{ .help = "Total number of aggregated signatures." }, .{}),
-        .lean_pq_sig_attestations_in_aggregated_signatures_total = Metrics.PQSigAttestationsInAggregatedTotalCounter.init("lean_pq_sig_attestations_in_aggregated_signatures_total", .{ .help = "Total number of attestations included into aggregated signatures." }, .{}),
-        .lean_pq_sig_aggregated_signatures_building_time_seconds = Metrics.PQSigBuildingTimeHistogram.init("lean_pq_sig_aggregated_signatures_building_time_seconds", .{ .help = "Time taken to build an aggregated attestation signature." }, .{}),
-        .lean_pq_sig_aggregated_signatures_verification_time_seconds = Metrics.PQSigAggregatedVerificationHistogram.init("lean_pq_sig_aggregated_signatures_verification_time_seconds", .{ .help = "Time taken to verify an aggregated attestation signature." }, .{}),
-        .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures." }, .{}),
-        .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures." }, .{}),
+        .lean_pq_sig_aggregated_signatures_total = Metrics.PQSigAggregatedSignaturesTotalCounter.init("lean_pq_sig_aggregated_signatures_total", .{ .help = "Total number of aggregated signatures" }, .{}),
+        .lean_pq_sig_attestations_in_aggregated_signatures_total = Metrics.PQSigAttestationsInAggregatedTotalCounter.init("lean_pq_sig_attestations_in_aggregated_signatures_total", .{ .help = "Total number of attestations included into aggregated signatures" }, .{}),
+        .lean_pq_sig_aggregated_signatures_building_time_seconds = Metrics.PQSigBuildingTimeHistogram.init("lean_pq_sig_aggregated_signatures_building_time_seconds", .{ .help = "Time taken to build an aggregated attestation signature" }, .{}),
+        .lean_pq_sig_aggregated_signatures_verification_time_seconds = Metrics.PQSigAggregatedVerificationHistogram.init("lean_pq_sig_aggregated_signatures_verification_time_seconds", .{ .help = "Time taken to verify an aggregated attestation signature" }, .{}),
+        .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures" }, .{}),
+        .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures" }, .{}),
         // Network peer metrics
-        .lean_connected_peers = Metrics.LeanConnectedPeersGauge.init("lean_connected_peers", .{ .help = "Number of currently connected peers." }, .{}),
-        .lean_peer_connection_events_total = try Metrics.PeerConnectionEventsCounter.init(allocator, "lean_peer_connection_events_total", .{ .help = "Total peer connection events by direction and result." }, .{}),
-        .lean_peer_disconnection_events_total = try Metrics.PeerDisconnectionEventsCounter.init(allocator, "lean_peer_disconnection_events_total", .{ .help = "Total peer disconnection events by direction and reason." }, .{}),
+        .lean_connected_peers = try Metrics.LeanConnectedPeersGauge.init(allocator, "lean_connected_peers", .{ .help = "Number of connected peers" }, .{}),
+        .lean_peer_connection_events_total = try Metrics.PeerConnectionEventsCounter.init(allocator, "lean_peer_connection_events_total", .{ .help = "Total number of peer connection events" }, .{}),
+        .lean_peer_disconnection_events_total = try Metrics.PeerDisconnectionEventsCounter.init(allocator, "lean_peer_disconnection_events_total", .{ .help = "Total number of peer disconnection events" }, .{}),
         // Node lifecycle metrics
-        .lean_node_info = try Metrics.LeanNodeInfoGauge.init(allocator, "lean_node_info", .{ .help = "Node information (always 1)." }, .{}),
-        .lean_node_start_time_seconds = Metrics.LeanNodeStartTimeGauge.init("lean_node_start_time_seconds", .{ .help = "Unix timestamp when the node started." }, .{}),
-        .lean_current_slot = Metrics.LeanCurrentSlotGauge.init("lean_current_slot", .{ .help = "Current slot of the lean chain based on wall clock." }, .{}),
-        .lean_safe_target_slot = Metrics.LeanSafeTargetSlotGauge.init("lean_safe_target_slot", .{ .help = "Safe target slot with 2/3 weight threshold." }, .{}),
+        .lean_node_info = try Metrics.LeanNodeInfoGauge.init(allocator, "lean_node_info", .{ .help = "Node information (always 1)" }, .{}),
+        .lean_node_start_time_seconds = Metrics.LeanNodeStartTimeGauge.init("lean_node_start_time_seconds", .{ .help = "Start timestamp" }, .{}),
+        .lean_current_slot = Metrics.LeanCurrentSlotGauge.init("lean_current_slot", .{ .help = "Current slot of the lean chain" }, .{}),
+        .lean_safe_target_slot = Metrics.LeanSafeTargetSlotGauge.init("lean_safe_target_slot", .{ .help = "Safe target slot" }, .{}),
         // Fork choice reorg metrics
-        .lean_fork_choice_reorgs_total = Metrics.LeanForkChoiceReorgsTotalCounter.init("lean_fork_choice_reorgs_total", .{ .help = "Total number of fork choice reorganizations." }, .{}),
-        .lean_fork_choice_reorg_depth = Metrics.LeanForkChoiceReorgDepthHistogram.init("lean_fork_choice_reorg_depth", .{ .help = "Depth of fork choice reorgs in blocks." }, .{}),
+        .lean_fork_choice_reorgs_total = Metrics.LeanForkChoiceReorgsTotalCounter.init("lean_fork_choice_reorgs_total", .{ .help = "Total number of fork choice reorgs" }, .{}),
+        .lean_fork_choice_reorg_depth = Metrics.LeanForkChoiceReorgDepthHistogram.init("lean_fork_choice_reorg_depth", .{ .help = "Depth of fork choice reorgs (in blocks)" }, .{}),
         // Finalization metrics
-        .lean_finalizations_total = try Metrics.LeanFinalizationsTotalCounter.init(allocator, "lean_finalizations_total", .{ .help = "Total finalization attempts by result." }, .{}),
+        .lean_finalizations_total = try Metrics.LeanFinalizationsTotalCounter.init(allocator, "lean_finalizations_total", .{ .help = "Total number of finalization attempts" }, .{}),
         // Fork-choice store gauges
-        .lean_gossip_signatures = Metrics.LeanGossipSignaturesGauge.init("lean_gossip_signatures", .{ .help = "Number of gossip signatures in fork-choice store." }, .{}),
-        .lean_latest_new_aggregated_payloads = Metrics.LeanLatestNewAggregatedPayloadsGauge.init("lean_latest_new_aggregated_payloads", .{ .help = "Number of new aggregated payload items." }, .{}),
-        .lean_latest_known_aggregated_payloads = Metrics.LeanLatestKnownAggregatedPayloadsGauge.init("lean_latest_known_aggregated_payloads", .{ .help = "Number of known aggregated payload items." }, .{}),
+        .lean_gossip_signatures = Metrics.LeanGossipSignaturesGauge.init("lean_gossip_signatures", .{ .help = "Number of gossip signatures in fork-choice store" }, .{}),
+        .lean_latest_new_aggregated_payloads = Metrics.LeanLatestNewAggregatedPayloadsGauge.init("lean_latest_new_aggregated_payloads", .{ .help = "Number of new aggregated payload items" }, .{}),
+        .lean_latest_known_aggregated_payloads = Metrics.LeanLatestKnownAggregatedPayloadsGauge.init("lean_latest_known_aggregated_payloads", .{ .help = "Number of known aggregated payload items" }, .{}),
         // Committee aggregation histogram
-        .lean_committee_signatures_aggregation_time_seconds = Metrics.CommitteeSignaturesAggregationHistogram.init("lean_committee_signatures_aggregation_time_seconds", .{ .help = "Time taken to aggregate committee signatures." }, .{}),
+        .lean_committee_signatures_aggregation_time_seconds = Metrics.CommitteeSignaturesAggregationHistogram.init("lean_committee_signatures_aggregation_time_seconds", .{ .help = "Time taken to aggregate committee signatures" }, .{}),
         // Validator status gauges
-        .lean_is_aggregator = Metrics.LeanIsAggregatorGauge.init("lean_is_aggregator", .{ .help = "Validator's is_aggregator status. True=1, False=0." }, .{}),
-        .lean_attestation_committee_subnet = Metrics.LeanAttestationCommitteeSubnetGauge.init("lean_attestation_committee_subnet", .{ .help = "Node's attestation committee subnet." }, .{}),
-        .lean_attestation_committee_count = Metrics.LeanAttestationCommitteeCountGauge.init("lean_attestation_committee_count", .{ .help = "Number of attestation committees." }, .{}),
-        // Block production metrics (leanMetrics#29)
-        .lean_block_building_time_seconds = Metrics.BlockBuildingTimeHistogram.init("lean_block_building_time_seconds", .{ .help = "Total time to build a block (propose_block)." }, .{}),
-        .lean_block_building_payload_aggregation_time_seconds = Metrics.BlockPayloadAggregationTimeHistogram.init("lean_block_building_payload_aggregation_time_seconds", .{ .help = "Time to aggregate attestation payloads during block building." }, .{}),
-        .lean_block_aggregated_payloads = Metrics.BlockAggregatedPayloadsHistogram.init("lean_block_aggregated_payloads", .{ .help = "Number of aggregated attestation payloads included in a block." }, .{}),
-        .lean_block_building_success_total = Metrics.BlockBuildingSuccessCounter.init("lean_block_building_success_total", .{ .help = "Total number of successfully produced blocks." }, .{}),
-        .lean_block_building_failures_total = Metrics.BlockBuildingFailuresCounter.init("lean_block_building_failures_total", .{ .help = "Total number of block production failures." }, .{}),
-        // Sync status (leanMetrics#29): 0=idle, 1=syncing, 2=synced
-        .lean_node_sync_status = Metrics.LeanNodeSyncStatusGauge.init("lean_node_sync_status", .{ .help = "Node sync status: 0=idle, 1=syncing (behind peers), 2=synced." }, .{}),
-        // Gossip message size histograms (leanMetrics#29)
-        .lean_gossip_block_size_bytes = Metrics.GossipBlockSizeBytesHistogram.init("lean_gossip_block_size_bytes", .{ .help = "Uncompressed size of received gossip block messages in bytes." }, .{}),
-        .lean_gossip_attestation_size_bytes = Metrics.GossipAttestationSizeBytesHistogram.init("lean_gossip_attestation_size_bytes", .{ .help = "Uncompressed size of received gossip attestation messages in bytes." }, .{}),
-        .lean_gossip_aggregation_size_bytes = Metrics.GossipAggregationSizeBytesHistogram.init("lean_gossip_aggregation_size_bytes", .{ .help = "Uncompressed size of received gossip aggregation messages in bytes." }, .{}),
+        .lean_is_aggregator = Metrics.LeanIsAggregatorGauge.init("lean_is_aggregator", .{ .help = "Validator's is_aggregator status. True=1, False=0" }, .{}),
+        .lean_attestation_committee_subnet = Metrics.LeanAttestationCommitteeSubnetGauge.init("lean_attestation_committee_subnet", .{ .help = "Node's attestation committee subnet" }, .{}),
+        .lean_attestation_committee_count = Metrics.LeanAttestationCommitteeCountGauge.init("lean_attestation_committee_count", .{ .help = "Number of attestation committees (ATTESTATION_COMMITTEE_COUNT)" }, .{}),
+        // Block production metrics
+        .lean_block_building_time_seconds = Metrics.BlockBuildingTimeHistogram.init("lean_block_building_time_seconds", .{ .help = "Time taken to build a block" }, .{}),
+        .lean_block_building_payload_aggregation_time_seconds = Metrics.BlockPayloadAggregationTimeHistogram.init("lean_block_building_payload_aggregation_time_seconds", .{ .help = "Time taken to build aggregated_payloads during block building" }, .{}),
+        .lean_block_aggregated_payloads = Metrics.BlockAggregatedPayloadsHistogram.init("lean_block_aggregated_payloads", .{ .help = "Number of aggregated_payloads in a block" }, .{}),
+        .lean_block_building_success_total = Metrics.BlockBuildingSuccessCounter.init("lean_block_building_success_total", .{ .help = "Successful block builds" }, .{}),
+        .lean_block_building_failures_total = Metrics.BlockBuildingFailuresCounter.init("lean_block_building_failures_total", .{ .help = "Failed block builds (exception in build_block)" }, .{}),
+        // Sync status: labeled gauge with status in {idle, syncing, synced}
+        .lean_node_sync_status = try Metrics.LeanNodeSyncStatusGauge.init(allocator, "lean_node_sync_status", .{ .help = "Node sync status" }, .{}),
+        // Gossip message size histograms
+        .lean_gossip_block_size_bytes = Metrics.GossipBlockSizeBytesHistogram.init("lean_gossip_block_size_bytes", .{ .help = "Bytes size of a gossip block message" }, .{}),
+        .lean_gossip_attestation_size_bytes = Metrics.GossipAttestationSizeBytesHistogram.init("lean_gossip_attestation_size_bytes", .{ .help = "Bytes size of a gossip attestation message" }, .{}),
+        .lean_gossip_aggregation_size_bytes = Metrics.GossipAggregationSizeBytesHistogram.init("lean_gossip_aggregation_size_bytes", .{ .help = "Bytes size of a gossip aggregated attestation message" }, .{}),
+        .lean_attestations_production_time_seconds = Metrics.AttestationProductionTimeHistogram.init("lean_attestations_production_time_seconds", .{ .help = "Time taken to produce attestation" }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -500,16 +515,19 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_pq_sig_aggregated_signatures_building_time_seconds.context = @ptrCast(&metrics.lean_pq_sig_aggregated_signatures_building_time_seconds);
     lean_pq_sig_aggregated_signatures_verification_time_seconds.context = @ptrCast(&metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds);
     lean_committee_signatures_aggregation_time_seconds.context = @ptrCast(&metrics.lean_committee_signatures_aggregation_time_seconds);
-    // Block production histogram contexts (leanMetrics#29)
+    // Block production histogram contexts
     lean_block_building_time_seconds.context = @ptrCast(&metrics.lean_block_building_time_seconds);
     lean_block_building_payload_aggregation_time_seconds.context = @ptrCast(&metrics.lean_block_building_payload_aggregation_time_seconds);
     lean_block_aggregated_payloads.context = @ptrCast(&metrics.lean_block_aggregated_payloads);
-    // Gossip size histogram contexts (leanMetrics#29)
+    // Gossip size histogram contexts
     lean_gossip_block_size_bytes.context = @ptrCast(&metrics.lean_gossip_block_size_bytes);
     lean_gossip_attestation_size_bytes.context = @ptrCast(&metrics.lean_gossip_attestation_size_bytes);
     lean_gossip_aggregation_size_bytes.context = @ptrCast(&metrics.lean_gossip_aggregation_size_bytes);
-    // Initialize sync status to idle at startup (leanMetrics#29)
-    metrics.lean_node_sync_status.set(0);
+    lean_attestations_production_time_seconds.context = @ptrCast(&metrics.lean_attestations_production_time_seconds);
+    // Initialize sync status to idle at startup
+    try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);
+    try metrics.lean_node_sync_status.set(.{ .status = "syncing" }, 0);
+    try metrics.lean_node_sync_status.set(.{ .status = "synced" }, 0);
 
     g_initialized = true;
 }

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -346,7 +346,7 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
     };
     defer zigHandler.allocator.free(uncompressed_message);
 
-    // Record gossip message size metrics (leanMetrics#29) — observed on uncompressed bytes
+    // Record gossip message size metrics — observed on uncompressed bytes
     switch (topic.gossip_topic.kind) {
         .block => zeam_metrics.lean_gossip_block_size_bytes.record(@floatFromInt(uncompressed_message.len)),
         .attestation => zeam_metrics.lean_gossip_attestation_size_bytes.record(@floatFromInt(uncompressed_message.len)),

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -10,6 +10,7 @@ const multiaddr_mod = @import("multiaddr");
 const Multiaddr = multiaddr_mod.Multiaddr;
 const uvarint = multiformats.uvarint;
 const zeam_utils = @import("@zeam/utils");
+const zeam_metrics = @import("@zeam/metrics");
 
 const interface = @import("./interface.zig");
 const NetworkInterface = interface.NetworkInterface;
@@ -344,6 +345,13 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
         return;
     };
     defer zigHandler.allocator.free(uncompressed_message);
+
+    // Record gossip message size metrics (leanMetrics#29) — observed on uncompressed bytes
+    switch (topic.gossip_topic.kind) {
+        .block => zeam_metrics.lean_gossip_block_size_bytes.record(@floatFromInt(uncompressed_message.len)),
+        .attestation => zeam_metrics.lean_gossip_attestation_size_bytes.record(@floatFromInt(uncompressed_message.len)),
+        .aggregation => zeam_metrics.lean_gossip_aggregation_size_bytes.record(@floatFromInt(uncompressed_message.len)),
+    }
 
     var message: interface.GossipMessage = switch (topic.gossip_topic.kind) {
         .block => .{ .block = deserializeGossipMessage(

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -273,6 +273,15 @@ pub const BeamChain = struct {
 
         // Update current slot metric (wall-clock time slot)
         zeam_metrics.metrics.lean_current_slot.set(slot);
+        // Update sync status metric (leanMetrics#29): 0=idle, 1=syncing, 2=synced
+        {
+            const sync_val: u64 = switch (self.getSyncStatus()) {
+                .synced => 2,
+                .no_peers, .fc_initing => 0,
+                .behind_peers => 1,
+            };
+            zeam_metrics.metrics.lean_node_sync_status.set(sync_val);
+        }
 
         var has_proposal = false;
         if (interval == 0) {
@@ -355,6 +364,12 @@ pub const BeamChain = struct {
     }
 
     pub fn produceBlock(self: *Self, opts: BlockProductionParams) !ProducedBlock {
+        // Block building total time timer (leanMetrics#29)
+        const block_building_timer = zeam_metrics.lean_block_building_time_seconds.start();
+        errdefer {
+            _ = block_building_timer.observe();
+            zeam_metrics.metrics.lean_block_building_failures_total.incr();
+        }
         // dump the vote tracker, letting this stay here commented for handy debugging activation
         // var iterator = self.forkChoice.attestations.iterator();
         // while (iterator.next()) |entry| {
@@ -386,9 +401,11 @@ pub const BeamChain = struct {
         const post_state = post_state_opt.?;
         try types.sszClone(self.allocator, types.BeamState, pre_state.*, post_state);
 
-        const building_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_building_time_seconds.start();
+        const payload_agg_timer = zeam_metrics.lean_block_building_payload_aggregation_time_seconds.start();
+        const pq_building_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_building_time_seconds.start();
         const proposal_atts = try self.forkChoice.getProposalAttestations(pre_state, opts.slot, opts.proposer_index, parent_root);
-        _ = building_timer.observe();
+        _ = pq_building_timer.observe();
+        _ = payload_agg_timer.observe();
 
         var agg_attestations = proposal_atts.attestations;
         var agg_att_cleanup = true;
@@ -489,6 +506,11 @@ pub const BeamChain = struct {
         });
         forkchoice_added = true;
         _ = try self.forkChoice.updateHead();
+
+        // Record block production success metrics (leanMetrics#29)
+        _ = block_building_timer.observe();
+        zeam_metrics.metrics.lean_block_building_success_total.incr();
+        zeam_metrics.lean_block_aggregated_payloads.record(@floatFromInt(attestation_signatures.len()));
 
         return .{
             .block = block,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -778,7 +778,7 @@ pub const BeamChain = struct {
 
                 // Validate attestation before processing (gossip = not from block)
                 self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
                     switch (err) {
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
                             // Add the missing root to the result so node's onGossip can enqueue it for fetching
@@ -804,7 +804,7 @@ pub const BeamChain = struct {
                 if (self.is_aggregator_enabled.load(.acquire)) {
                     // Process validated attestation
                     self.onGossipAttestation(signed_attestation) catch |err| {
-                        zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                        zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
                         self.logger.err("attestation processing error: {any}", .{err});
                         return err;
                     };
@@ -820,7 +820,7 @@ pub const BeamChain = struct {
                         validator_id,
                     });
                 }
-                zeam_metrics.metrics.lean_attestations_valid_total.incr();
+                zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "gossip" }) catch {};
                 return .{};
             },
             .aggregation => |signed_aggregation| {
@@ -832,7 +832,7 @@ pub const BeamChain = struct {
 
                 // Validate attestation data before processing (same rules as individual gossip attestations)
                 self.validateAttestationData(signed_aggregation.data, false) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
                     switch (err) {
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
                             // Add the missing root to the result so node's onGossip can enqueue it for fetching
@@ -856,7 +856,7 @@ pub const BeamChain = struct {
                 };
 
                 self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
                     switch (err) {
                         // Propagate unknown block errors to node.zig for context-aware logging
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
@@ -866,7 +866,7 @@ pub const BeamChain = struct {
                         },
                     }
                 };
-                zeam_metrics.metrics.lean_attestations_valid_total.incr();
+                zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "aggregation" }) catch {};
                 return .{};
             },
         }
@@ -1010,7 +1010,7 @@ pub const BeamChain = struct {
                 defer participant_indices.deinit(self.allocator);
 
                 if (validator_indices.items.len != participant_indices.items.len) {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
                     self.logger.err(
                         "attestation signature mismatch index={d} validators={d} participants={d}",
                         .{ index, validator_indices.items.len, participant_indices.items.len },
@@ -1020,7 +1020,7 @@ pub const BeamChain = struct {
 
                 // Validate aggregated attestation data once before processing individual validators
                 self.validateAttestationData(aggregated_attestation.data, true) catch |e| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
                     if (e == AttestationValidationError.UnknownHeadBlock) {
                         try missing_roots.append(self.allocator, aggregated_attestation.data.head.root);
                     }
@@ -1036,7 +1036,7 @@ pub const BeamChain = struct {
                     };
 
                     self.forkChoice.onAttestation(attestation, true) catch |e| {
-                        zeam_metrics.metrics.lean_attestations_invalid_total.incr();
+                        zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
                         self.logger.err(
                             "failed to apply block attestation to forkchoice tracker: validator={d} slot={d} error={any}",
                             .{ validator_index, attestation.data.slot, e },
@@ -1044,7 +1044,7 @@ pub const BeamChain = struct {
                         continue;
                     };
 
-                    zeam_metrics.metrics.lean_attestations_valid_total.incr();
+                    zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "block" }) catch {};
                 }
 
                 // store the aggregated payloads in known

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -273,14 +273,12 @@ pub const BeamChain = struct {
 
         // Update current slot metric (wall-clock time slot)
         zeam_metrics.metrics.lean_current_slot.set(slot);
-        // Update sync status metric (leanMetrics#29): 0=idle, 1=syncing, 2=synced
+        // Update sync status metric: labeled gauge, 1 for active state
         {
-            const sync_val: u64 = switch (self.getSyncStatus()) {
-                .synced => 2,
-                .no_peers, .fc_initing => 0,
-                .behind_peers => 1,
-            };
-            zeam_metrics.metrics.lean_node_sync_status.set(sync_val);
+            const sync_status = self.getSyncStatus();
+            zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "idle" }, if (sync_status == .no_peers or sync_status == .fc_initing) 1 else 0) catch {};
+            zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "syncing" }, if (sync_status == .behind_peers) 1 else 0) catch {};
+            zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "synced" }, if (sync_status == .synced) 1 else 0) catch {};
         }
 
         var has_proposal = false;
@@ -364,7 +362,7 @@ pub const BeamChain = struct {
     }
 
     pub fn produceBlock(self: *Self, opts: BlockProductionParams) !ProducedBlock {
-        // Block building total time timer (leanMetrics#29)
+        // Block building total time timer
         const block_building_timer = zeam_metrics.lean_block_building_time_seconds.start();
         errdefer {
             _ = block_building_timer.observe();
@@ -507,7 +505,7 @@ pub const BeamChain = struct {
         forkchoice_added = true;
         _ = try self.forkChoice.updateHead();
 
-        // Record block production success metrics (leanMetrics#29)
+        // Record block production success metrics
         _ = block_building_timer.observe();
         zeam_metrics.metrics.lean_block_building_success_total.incr();
         zeam_metrics.lean_block_aggregated_payloads.record(@floatFromInt(attestation_signatures.len()));
@@ -743,7 +741,7 @@ pub const BeamChain = struct {
 
                 // Validate attestation before processing (gossip = not from block)
                 self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                     switch (err) {
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
                             // Add the missing root to the result so node's onGossip can enqueue it for fetching
@@ -769,7 +767,7 @@ pub const BeamChain = struct {
                 if (self.is_aggregator_enabled) {
                     // Process validated attestation
                     self.onGossipAttestation(signed_attestation) catch |err| {
-                        zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                        zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                         self.logger.err("attestation processing error: {any}", .{err});
                         return err;
                     };
@@ -785,7 +783,7 @@ pub const BeamChain = struct {
                         validator_id,
                     });
                 }
-                zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "gossip" }) catch {};
+                zeam_metrics.metrics.lean_attestations_valid_total.incr();
                 return .{};
             },
             .aggregation => |signed_aggregation| {
@@ -797,7 +795,7 @@ pub const BeamChain = struct {
 
                 // Validate attestation data before processing (same rules as individual gossip attestations)
                 self.validateAttestationData(signed_aggregation.data, false) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                     switch (err) {
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
                             // Add the missing root to the result so node's onGossip can enqueue it for fetching
@@ -821,7 +819,7 @@ pub const BeamChain = struct {
                 };
 
                 self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                     switch (err) {
                         // Propagate unknown block errors to node.zig for context-aware logging
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
@@ -831,7 +829,7 @@ pub const BeamChain = struct {
                         },
                     }
                 };
-                zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "aggregation" }) catch {};
+                zeam_metrics.metrics.lean_attestations_valid_total.incr();
                 return .{};
             },
         }
@@ -951,7 +949,7 @@ pub const BeamChain = struct {
                 defer participant_indices.deinit(self.allocator);
 
                 if (validator_indices.items.len != participant_indices.items.len) {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                     self.logger.err(
                         "attestation signature mismatch index={d} validators={d} participants={d}",
                         .{ index, validator_indices.items.len, participant_indices.items.len },
@@ -961,7 +959,7 @@ pub const BeamChain = struct {
 
                 // Validate aggregated attestation data once before processing individual validators
                 self.validateAttestationData(aggregated_attestation.data, true) catch |e| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                     if (e == AttestationValidationError.UnknownHeadBlock) {
                         try missing_roots.append(self.allocator, aggregated_attestation.data.head.root);
                     }
@@ -977,7 +975,7 @@ pub const BeamChain = struct {
                     };
 
                     self.forkChoice.onAttestation(attestation, true) catch |e| {
-                        zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
+                        zeam_metrics.metrics.lean_attestations_invalid_total.incr();
                         self.logger.err(
                             "failed to apply block attestation to forkchoice tracker: validator={d} slot={d} error={any}",
                             .{ validator_index, attestation.data.slot, e },
@@ -985,7 +983,7 @@ pub const BeamChain = struct {
                         continue;
                     };
 
-                    zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "block" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_valid_total.incr();
                 }
 
                 // store the aggregated payloads in known

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -840,7 +840,7 @@ pub const BeamChain = struct {
     // our implemented forkchoice's onblock. this is to parallelize "apply transition" with other verifications
     // Returns a list of missing block roots that need to be fetched from the network
     pub fn onBlock(self: *Self, signedBlock: types.SignedBlock, blockInfo: CachedProcessedBlockInfo) ![]types.Root {
-        const onblock_timer = zeam_metrics.chain_onblock_duration_seconds.start();
+        const onblock_timer = zeam_metrics.zeam_chain_onblock_duration_seconds.start();
 
         const block = signedBlock.block;
 

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -437,9 +437,7 @@ pub const BeamChain = struct {
         try types.sszClone(self.allocator, types.BeamState, pre_state.*, post_state);
 
         const payload_agg_timer = zeam_metrics.lean_block_building_payload_aggregation_time_seconds.start();
-        const pq_building_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_building_time_seconds.start();
         const proposal_atts = try self.forkChoice.getProposalAttestations(pre_state, opts.slot, opts.proposer_index, parent_root);
-        _ = pq_building_timer.observe();
         _ = payload_agg_timer.observe();
 
         var agg_attestations = proposal_atts.attestations;

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1071,10 +1071,10 @@ pub const ForkChoice = struct {
                 &pre_state.validators,
             );
             _ = compact_timer.observe();
-            zeam_metrics.metrics.lean_compact_attestations_input_total.incrBy(@intCast(agg_attestations.len));
+            zeam_metrics.metrics.lean_compact_attestations_input_total.incrBy(@intCast(agg_attestations.constSlice().len));
             agg_attestations = compacted.attestations;
             attestation_signatures = compacted.signatures;
-            zeam_metrics.metrics.lean_compact_attestations_output_total.incrBy(@intCast(agg_attestations.len));
+            zeam_metrics.metrics.lean_compact_attestations_output_total.incrBy(@intCast(agg_attestations.constSlice().len));
 
             // Build candidate block with all accumulated attestations and apply STF
             // to check if justification changed.

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1530,6 +1530,8 @@ pub const ForkChoice = struct {
     }
 
     pub fn aggregate(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
+        const timer = zeam_metrics.lean_committee_signatures_aggregation_time_seconds.start();
+        defer _ = timer.observe();
         self.mutex.lock();
         defer self.mutex.unlock();
         return self.aggregateUnlocked(state_opt);

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1063,7 +1063,7 @@ pub const ForkChoice = struct {
             // Compact: merge proofs sharing the same AttestationData into one
             // using recursive children aggregation, so each AttestationData
             // appears at most once.
-            const compact_timer = zeam_metrics.lean_compact_attestations_time_seconds.start();
+            const compact_timer = zeam_metrics.zeam_compact_attestations_time_seconds.start();
             const compacted = try types.compactAttestations(
                 self.allocator,
                 &agg_attestations,
@@ -1071,10 +1071,10 @@ pub const ForkChoice = struct {
                 &pre_state.validators,
             );
             _ = compact_timer.observe();
-            zeam_metrics.metrics.lean_compact_attestations_input_total.incrBy(@intCast(agg_attestations.constSlice().len));
+            zeam_metrics.metrics.zeam_compact_attestations_input_total.incrBy(@intCast(agg_attestations.constSlice().len));
             agg_attestations = compacted.attestations;
             attestation_signatures = compacted.signatures;
-            zeam_metrics.metrics.lean_compact_attestations_output_total.incrBy(@intCast(agg_attestations.constSlice().len));
+            zeam_metrics.metrics.zeam_compact_attestations_output_total.incrBy(@intCast(agg_attestations.constSlice().len));
 
             // Build candidate block with all accumulated attestations and apply STF
             // to check if justification changed.

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1063,14 +1063,18 @@ pub const ForkChoice = struct {
             // Compact: merge proofs sharing the same AttestationData into one
             // using recursive children aggregation, so each AttestationData
             // appears at most once.
+            const compact_timer = zeam_metrics.lean_compact_attestations_time_seconds.start();
             const compacted = try types.compactAttestations(
                 self.allocator,
                 &agg_attestations,
                 &attestation_signatures,
                 &pre_state.validators,
             );
+            _ = compact_timer.observe();
+            zeam_metrics.metrics.lean_compact_attestations_input_total.incrBy(@intCast(agg_attestations.len));
             agg_attestations = compacted.attestations;
             attestation_signatures = compacted.signatures;
+            zeam_metrics.metrics.lean_compact_attestations_output_total.incrBy(@intCast(agg_attestations.len));
 
             // Build candidate block with all accumulated attestations and apply STF
             // to check if justification changed.
@@ -1416,6 +1420,8 @@ pub const ForkChoice = struct {
     /// via two-pass greedy selection. Replaces new_payloads with fresh results.
     fn aggregateUnlocked(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
         const state = state_opt orelse return try self.allocator.alloc(types.SignedAggregatedAttestation, 0);
+        const agg_timer = zeam_metrics.lean_committee_signatures_aggregation_time_seconds.start();
+        defer _ = agg_timer.observe();
 
         // Capture counts for metrics update outside lock scope
         var new_payloads_count: usize = 0;
@@ -1530,8 +1536,6 @@ pub const ForkChoice = struct {
     }
 
     pub fn aggregate(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
-        const timer = zeam_metrics.lean_committee_signatures_aggregation_time_seconds.start();
-        defer _ = timer.observe();
         self.mutex.lock();
         defer self.mutex.unlock();
         return self.aggregateUnlocked(state_opt);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -968,6 +968,15 @@ pub const BeamNode = struct {
         }
     }
 
+    /// Extract client type prefix from a node name like "zeam_0" -> "zeam", fallback "unknown".
+    fn clientTypeFromName(name: ?[]const u8) []const u8 {
+        const n = name orelse return "unknown";
+        if (std.mem.indexOfScalar(u8, n, '_')) |sep| {
+            if (sep > 0) return n[0..sep];
+        }
+        return if (n.len > 0) n else "unknown";
+    }
+
     pub fn onPeerConnected(ptr: *anyopaque, peer_id: []const u8, direction: networks.PeerDirection) !void {
         const self: *Self = @ptrCast(@alignCast(ptr));
 
@@ -982,7 +991,9 @@ pub const BeamNode = struct {
 
         // Record metrics
         zeam_metrics.metrics.lean_peer_connection_events_total.incr(.{ .direction = @tagName(direction), .result = "success" }) catch {};
-        zeam_metrics.metrics.lean_connected_peers.set(@intCast(self.network.getPeerCount()));
+        const client_name = node_name.name orelse "unknown";
+        const client_type = clientTypeFromName(node_name.name);
+        zeam_metrics.metrics.lean_connected_peers.set(.{ .client = client_name, .client_type = client_type }, 1) catch {};
 
         const handler = self.getReqRespResponseHandler();
         const status = self.chain.getStatus();
@@ -1008,10 +1019,12 @@ pub const BeamNode = struct {
     pub fn onPeerDisconnected(ptr: *anyopaque, peer_id: []const u8, direction: networks.PeerDirection, reason: networks.DisconnectionReason) !void {
         const self: *Self = @ptrCast(@alignCast(ptr));
 
+        const node_name = self.node_registry.getNodeNameFromPeerId(peer_id);
+
         if (self.network.disconnectPeer(peer_id)) {
             self.logger.info("peer disconnected: {s}{f}, direction={s}, reason={s}, total peers: {d}", .{
                 peer_id,
-                self.node_registry.getNodeNameFromPeerId(peer_id),
+                node_name,
                 @tagName(direction),
                 @tagName(reason),
                 self.network.getPeerCount(),
@@ -1019,7 +1032,9 @@ pub const BeamNode = struct {
 
             // Record metrics
             zeam_metrics.metrics.lean_peer_disconnection_events_total.incr(.{ .direction = @tagName(direction), .reason = @tagName(reason) }) catch {};
-            zeam_metrics.metrics.lean_connected_peers.set(@intCast(self.network.getPeerCount()));
+            const client_name = node_name.name orelse "unknown";
+            const client_type = clientTypeFromName(node_name.name);
+            zeam_metrics.metrics.lean_connected_peers.set(.{ .client = client_name, .client_type = client_type }, 0) catch {};
         }
     }
 

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -10,6 +10,7 @@ const key_manager_lib = @import("@zeam/key-manager");
 const chains = @import("./chain.zig");
 const networkFactory = @import("./network.zig");
 const networks = @import("@zeam/network");
+const zeam_metrics = @import("@zeam/metrics");
 
 const constants = @import("./constants.zig");
 
@@ -186,6 +187,8 @@ pub const ValidatorClient = struct {
             },
         }
 
+        const _attest_timer = zeam_metrics.lean_attestations_production_time_seconds.start();
+        defer _ = _attest_timer.observe();
         self.logger.info("constructing attestation message for slot={d}", .{slot});
         const attestation_data = try self.chain.constructAttestationData(.{ .slot = slot });
 

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const ssz = @import("ssz");
 
 const params = @import("@zeam/params");
+const zeam_metrics = @import("@zeam/metrics");
 const xmss = @import("@zeam/xmss");
 const zeam_utils = @import("@zeam/utils");
 
@@ -698,6 +699,7 @@ pub const AggregatedAttestationsResult = struct {
                 try child_pk_slices.append(allocator, cpks[0..cpk_idx]);
             }
 
+            const pq_sig_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_building_time_seconds.start();
             try aggregation.AggregatedSignatureProof.aggregate(
                 allocator,
                 xmss_participants,
@@ -709,6 +711,7 @@ pub const AggregatedAttestationsResult = struct {
                 epoch,
                 &proof,
             );
+            _ = pq_sig_timer.observe();
             if (xmss_participants) |*gp| gp.deinit();
             xmss_participants = null;
 


### PR DESCRIPTION
Implements the metrics defined in [leanEthereum/leanMetrics#29](https://github.com/leanEthereum/leanMetrics/pull/29) for Devnet-4 monitoring.

## Block production metrics (`pkgs/metrics/src/lib.zig` → instrumented in `chain.zig`)

| Metric | Type | Buckets |
|--------|------|---------|
| `lean_block_building_time_seconds` | Histogram | 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 |
| `lean_block_building_payload_aggregation_time_seconds` | Histogram | 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 |
| `lean_block_aggregated_payloads` | Histogram | 1, 2, 4, 8, 16, 32, 64, 128 |
| `lean_block_building_success_total` | Counter | — |
| `lean_block_building_failures_total` | Counter | — |

- `produceBlock()` is wrapped with a total-time timer; `errdefer` increments the failure counter and records the timer on any error path.
- `lean_block_building_payload_aggregation_time_seconds` wraps the `getProposalAttestations` call specifically.
- `lean_block_aggregated_payloads` records `attestation_signatures.len()` on success.

## Sync status (`chain.zig`)

| Metric | Type | Values |
|--------|------|--------|
| `lean_node_sync_status` | Gauge | 0=idle, 1=syncing, 2=synced |

- Updated every `onInterval` tick via `getSyncStatus()`.
- `no_peers` and `fc_initing` map to `idle (0)` since the node has not yet established sync state.

## Gossip message size metrics (`ethlibp2p.zig`)

| Metric | Type | Buckets |
|--------|------|---------|
| `lean_gossip_block_size_bytes` | Histogram | 10K, 50K, 100K, 250K, 500K, 1M, 2M, 5M |
| `lean_gossip_attestation_size_bytes` | Histogram | 512, 1K, 2K, 4K, 8K, 16K |
| `lean_gossip_aggregation_size_bytes` | Histogram | 1K, 4K, 16K, 64K, 128K, 256K, 512K, 1M |

- Observed on the **uncompressed** message after snappy decode, dispatched by topic kind.

## Modified existing metric

- `lean_committee_signatures_aggregation_time_seconds`: buckets updated from `[0.005..1]` to `[0.05..4]` to capture longer aggregation times in Devnet-4 (matches leanMetrics#29).

## Infrastructure changes

- `Histogram.record(value f32)` method added for direct observation without starting a timer.
- `@zeam/metrics` wired into `@zeam/network` module in `build.zig`.

## Testing

- `zig build` passes ✅
- `zig fmt` clean ✅