### PR TITLE
build: default rust-target-cpu to x86-64-v3 on x86_64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -725,16 +725,23 @@ fn build_rust_project(b: *Builder, path: []const u8, prover: ProverChoice) *Buil
 
     // leanMultisig's backend crate uses compile-time #[cfg(target_feature)] for SIMD
     // (AVX2/AVX512 on x86_64, NEON on aarch64). On x86_64, we set the Rust target-cpu
-    // so the compiler enables the appropriate feature flags. Defaults to "native" for
-    // local builds; Docker images should pass -Drust-target-cpu=x86-64-v3 (AVX2, no AVX512)
-    // to produce portable binaries. We skip this on aarch64 because ring 0.17 fails its
-    // compile-time feature assertions when target-cpu=native is set on aarch64-apple-darwin.
+    // so the compiler enables the appropriate feature flags.
+    //
+    // The default is x86-64-v3 (AVX2, no AVX-512) because enabling AVX-512 via
+    // target-cpu=native has triggered hard-to-diagnose runtime faults in the deeper
+    // Rust dependency graph on AVX-512-capable CPUs (LLVM codegen issues, clobber-list
+    // bugs, and kernel/microcode XSAVE quirks). Capping at AVX2 produces portable and
+    // reliable binaries across all x86_64 Linux hosts. Users who want machine-specific
+    // performance can opt in with -Drust-target-cpu=native (or x86-64-v4 for AVX-512).
+    //
+    // We skip this on aarch64 because ring 0.17 fails its compile-time feature
+    // assertions when target-cpu=native is set on aarch64-apple-darwin.
     //
     // We set RUSTFLAGS directly (not CARGO_ENCODED_RUSTFLAGS) because Cargo ignores
     // CARGO_ENCODED_RUSTFLAGS when RUSTFLAGS is already set in the environment — which
     // happens in CI via actions-rust-lang/setup-rust-toolchain setting RUSTFLAGS=-Dwarnings.
     if (builtin.cpu.arch == .x86_64) {
-        const rust_target_cpu = b.option([]const u8, "rust-target-cpu", "Target CPU for Rust libs (default: native, use x86-64-v3 for portable Docker images)") orelse "native";
+        const rust_target_cpu = b.option([]const u8, "rust-target-cpu", "Target CPU for Rust libs (default: x86-64-v3 for portable AVX2 builds; use 'native' or 'x86-64-v4' to opt into AVX-512)") orelse "x86-64-v3";
         const flags = b.fmt("-Ctarget-cpu={s} -Dwarnings", .{rust_target_cpu});
         cargo_build.setEnvironmentVariable("RUSTFLAGS", flags);
     }


### PR DESCRIPTION
## Summary

Cap the default Rust `target-cpu` at `x86-64-v3` (AVX2, no AVX-512) on x86_64 instead of `native`, so `zig build` produces portable binaries across all x86_64 Linux hosts by default. Users who want machine-specific codegen can still opt in via `-Drust-target-cpu=native` (or `x86-64-v4` for AVX-512).

## Why

`-Ctarget-cpu=native` on AVX-512-capable build hosts has been a persistent source of hard-to-diagnose failures:

- Runtime GPFs / SIGILLs for users whose CPU supports a *different* AVX-512 subset than the builder's (LLVM codegen bugs in deeper dependencies, inline-asm clobber-list issues, kernel/microcode XSAVE quirks).
- Specifically, today CI job \`test (ubuntu-latest)\` on PR #750 crashed \`rustc\` itself with \`SIGILL: illegal instruction\` inside the \`thiserror_impl\` proc-macro \`.so\`:

  ```
  could not compile hashsig-glue (lib)
  Caused by: rustc ... -Ctarget-cpu=native ... (signal: 4, SIGILL: illegal instruction)
  ```

  Root cause: \`Swatinem/rust-cache\` restored a proc-macro \`.so\` compiled with \`-Ctarget-cpu=native\` on a previous runner that had AVX-512, then today's runner lacked those opcodes. All 3 retry attempts hit the same poisoned cache.

Capping the default at AVX2 makes the output safe to share across any modern x86_64 machine and eliminates this entire class of flake. As a side effect, flipping the default in \`RUSTFLAGS\` bumps the \`rust-cache\` key (it hashes \`RUSTFLAGS\`), which also invalidates the currently-poisoned cache entry on first CI run.

## Scope

- aarch64 is unchanged (ring 0.17 fails compile-time feature assertions under \`target-cpu=native\` on aarch64-apple-darwin, so we were already not setting target-cpu there).
- Opt-in escape hatch preserved: \`-Drust-target-cpu=native\` restores the old behaviour per-build.
- This is a cherry-pick of commit 840bb36 from PR #743, extracted so it can merge independently of the broader libp2p-glue C-ABI work.

## Test plan

- [x] \`zig fmt --check build.zig\` passes locally.
- [ ] CI (\`test (ubuntu-latest)\` in particular) compiles Rust crates without SIGILL and is reproducible across runners.
- [ ] \`zig build\` local developer flow still works; \`-Drust-target-cpu=native\` still accepted.