### PR TITLE
fix: drop global key cache on shutdown; fail RPCs on peer disconnect

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -411,6 +411,13 @@ fn mainInner() !void {
             // Nodes 1,2 start immediately; Node 3 starts after finalization to test sync
             const num_validators: usize = 3;
             var key_manager = try key_manager_lib.getTestKeyManager(allocator, num_validators, 1000);
+            // Defer order (LIFO): key_manager.deinit() runs first so it can drop its
+            // map entries while the cached XMSS handles are still valid, then the
+            // process-global cache itself is freed. key_manager.deinit() only
+            // deinits keys it owns (addKeypair), not borrowed ones (addCachedKeypair);
+            // the cache is the real owner of those handles and would otherwise
+            // leak until process exit since it uses the page allocator.
+            defer key_manager_lib.deinitGlobalKeyCache();
             defer key_manager.deinit();
 
             // Get validator pubkeys from keymanager

--- a/pkgs/key-manager/src/lib.zig
+++ b/pkgs/key-manager/src/lib.zig
@@ -28,6 +28,30 @@ const CachedKeyPair = struct {
 var global_test_key_pair_cache: ?std.AutoHashMap(usize, CachedKeyPair) = null;
 const cache_allocator = std.heap.page_allocator;
 
+/// Free every cached XMSS keypair and drop the backing hashmap.
+///
+/// The cache is intentionally long-lived — regenerating XMSS keypairs is
+/// expensive so callers of `getTestKeyManager` share the same set across
+/// invocations. That means on process exit the cache (and all secret key
+/// material it holds) otherwise leaks. Call this from a graceful shutdown
+/// path (e.g. CLI main after the KeyManager itself is deinit'd) so the OS
+/// doesn't have to reclaim it and, more importantly, so any future
+/// xmss-side zeroization of secret material actually runs.
+///
+/// Safe to call even if the cache was never populated. Not thread-safe;
+/// callers must ensure no other thread is touching the cache.
+pub fn deinitGlobalKeyCache() void {
+    if (global_test_key_pair_cache) |*cache| {
+        var it = cache.iterator();
+        while (it.next()) |entry| {
+            entry.value_ptr.attestation_keypair.deinit();
+            entry.value_ptr.proposal_keypair.deinit();
+        }
+        cache.deinit();
+        global_test_key_pair_cache = null;
+    }
+}
+
 fn getOrCreateCachedKeyPair(
     validator_id: usize,
     num_active_epochs: usize,

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -854,6 +854,13 @@ export fn handlePeerDisconnectedFromRustBridge(
         @tagName(rsn),
     });
 
+    zigHandler.failInflightRpcsForPeer(peer_id_slice) catch |e| {
+        zigHandler.logger.err(
+            "network-{d}:: Error failing in-flight RPCs for disconnected peer={s}{f}: {any}",
+            .{ zigHandler.params.networkId, peer_id_slice, node_name, e },
+        );
+    };
+
     zigHandler.peerEventHandler.onPeerDisconnected(peer_id_slice, dir, rsn) catch |e| {
         zigHandler.logger.err("network-{d}:: Error handling peer disconnected event: {any}", .{ zigHandler.params.networkId, e });
     };
@@ -1246,6 +1253,46 @@ pub const EthLibp2p = struct {
         };
 
         self.notifyRpcErrorWithOwnedMessage(request_id, method, code, owned_message);
+    }
+
+    /// Fail every in-flight RPC whose callback is waiting on the given peer.
+    ///
+    /// The Rust bridge already times requests out via REQUEST_TIMEOUT, but that
+    /// window is seconds-to-minutes. When a peer disconnects we know the
+    /// response will never arrive, so notify all matching callbacks with a
+    /// PeerDisconnected failure and drop them from the map immediately. This
+    /// gives callers fast feedback and prevents the callback entries (plus
+    /// their owned peer_id strings) from sitting around until the Rust-side
+    /// timeout fires. `ReqRespRequestCallback.deinit` frees the peer_id buffer.
+    fn failInflightRpcsForPeer(self: *Self, peer_id: []const u8) !void {
+        // Collect request_ids first so we can mutate the map without iterator
+        // invalidation while also holding a reference to each callback's peer_id.
+        var matching: std.ArrayList(u64) = .empty;
+        defer matching.deinit(self.allocator);
+
+        var it = self.rpcCallbacks.iterator();
+        while (it.next()) |entry| {
+            if (std.mem.eql(u8, entry.value_ptr.peer_id, peer_id)) {
+                try matching.append(self.allocator, entry.key_ptr.*);
+            }
+        }
+
+        // 499 = "Client Closed Request" (nginx-style); closest well-known code
+        // for "peer went away before responding". Distinct from 408 used by the
+        // Rust-side REQUEST_TIMEOUT so callers can tell them apart.
+        const PEER_DISCONNECTED_CODE: u32 = 499;
+
+        for (matching.items) |request_id| {
+            const callback_ptr = self.rpcCallbacks.getPtr(request_id) orelse continue;
+            const method = callback_ptr.method;
+            self.notifyRpcErrorFmt(
+                request_id,
+                method,
+                PEER_DISCONNECTED_CODE,
+                "peer disconnected before responding (peer={s})",
+                .{peer_id},
+            );
+        }
     }
 
     pub fn onRPCRequest(ptr: *anyopaque, data: *interface.ReqRespRequest, stream: interface.ReqRespServerStream) anyerror!void {


### PR DESCRIPTION
## Summary

Two memory-safety fixes from the adversarial review follow-up. 

### 1. `global_test_key_pair_cache` leaks until process exit — [pkgs/key-manager/src/lib.zig](pkgs/key-manager/src/lib.zig)

`getTestKeyManager` populates a module-level `AutoHashMap(usize, CachedKeyPair)` on the `page_allocator`. `KeyManager.deinit` only deinits handles it owns (those added via `addKeypair`); handles added via `addCachedKeypair` are borrowed from the global cache and are never freed anywhere. The cache survives until the OS reclaims the process.

Adds `pub fn deinitGlobalKeyCache()` that deinits each cached `xmss.KeyPair` and drops the map, and calls it from the CLI `.beam` command's cleanup path. Defer order is deliberate — `key_manager.deinit()` runs first (frees owned handles), then `deinitGlobalKeyCache()` (frees the underlying cached handles). The function is safe to call when the cache was never populated.

This also gives us somewhere to hang future xmss-side zeroization of secret key material — today `xmss.KeyPair.deinit` just calls the Rust `hashsig_keypair_free` and doesn't wipe memory. Out of scope for this PR.

### 2. RPC callbacks orphan on peer disconnect — [pkgs/network/src/ethlibp2p.zig](pkgs/network/src/ethlibp2p.zig)

`rpcCallbacks` entries are removed on response / end-of-stream / explicit error. The Rust bridge does have a `REQUEST_TIMEOUT` that eventually fires `handleRPCErrorFromRustBridge` with a 408, so they don't leak forever — but when a peer disconnects we already know the response will never come, and callers sit waiting until the Rust timeout expires seconds-to-minutes later.

Adds `EthLibp2p.failInflightRpcsForPeer(peer_id)`, invoked from `handlePeerDisconnectedFromRustBridge`, which iterates `rpcCallbacks`, notifies each matching callback with a 499 (Client Closed Request, nginx-style) failure, and removes the entry. Two-pass so we don't mutate the map during iteration. 499 is distinct from 408 so callers can tell disconnect-drop apart from true timeout.

## Test plan

- [x] `zig fmt --check .`
- [x] `zig build` (release, includes Rust workspace)
- [x] `zig build test --summary all` — 143/143 tests pass
- [ ] Manual devnet sanity: kill a peer mid-request and confirm the requester gets a 499 event (and metrics) instead of hanging until the Rust timeout
- [ ] Follow-up: xmss-side zeroization in `hashsig_keypair_free`
- [ ] Follow-up: design-level PR for `SWARM_STATE` FFI command-channel refactor