### PR TITLE
build, multisig-glue: bump prover profile opt-level from z to s (#734)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,18 +17,26 @@ lto = false  # Set to true for single-prover builds to reduce binary size from 1
 strip = "symbols"
 codegen-units = 16  # Multiple units keep risc0 and openvm code separate
 
-# Optimized profile for OpenVM-only builds (maximum size reduction)
+# Optimized profile for OpenVM-only builds (size reduction, but see opt-level note).
 [profile.openvm-release]
 inherits = "release"
 lto = "off"          # Disable LTO on macOS due to linker issues, keeps symbols separate
-opt-level = "z"      # Optimize for size instead of speed
+# opt-level = "z" triggers a codegen interaction with leanMultisig's prover
+# (rec_aggregation / lean_prover / backend) that produces a runtime General
+# Protection Exception inside xmss_aggregate on x86_64 Linux. Bisected against
+# `zig build run -Dprover=risc0 -- prove -z risc0`: "z" crashes deterministically,
+# "s" and numeric levels are clean. Using "s" keeps the size-optimization focus
+# without the aggressive inlining/outlining passes that expose the issue.
+# Tracked in #734. risc0-release mirrors this setting.
+opt-level = "s"      # "s" rather than "z": see comment above and #734
 codegen-units = 1    # Better optimization (slower compilation)
 panic = "abort"      # Remove unwinding code for smaller binary
 
-# Optimized profile for RISC0-only builds (maximum size reduction)
+# Optimized profile for RISC0-only builds (size reduction, but see opt-level note).
 [profile.risc0-release]
 inherits = "release"
 lto = "off"          # Disable LTO on macOS due to linker issues, keeps symbols separate
-opt-level = "z"      # Optimize for size instead of speed
+# See openvm-release above for why opt-level is "s" and not "z" (#734).
+opt-level = "s"
 codegen-units = 1    # Better optimization (slower compilation)
 panic = "abort"      # Remove unwinding code for smaller binary


### PR DESCRIPTION
## Summary

Fixes the long-standing risc0 CI failure tracked in #734.

- `risc0-release` and `openvm-release` used `opt-level = "z"` for size reduction.
- On x86_64 Linux this triggers a codegen interaction in leanMultisig's prover (`rec_aggregation` / `lean_prover` / `backend`) that produces a runtime **General Protection Exception** inside `xmss_aggregate` on the first aggregation call.
- Bumping to `opt-level = "s"` keeps the size-optimization focus and eliminates the crash.

## Bisection

On an AMD EPYC Genoa KVM guest (Linux 6.x, x86-64-v3 rustflags, fresh rebuild of `rust/target`):

| Profile config | Result |
| --- | --- |
| Stock (`opt-level = "z"`) | Crash at ``pkgs/xmss/src/aggregation.zig:139`` on first ``xmss_aggregate`` call |
| + ``ulimit -s unlimited`` | Still crashes — not stack overflow |
| ``opt-level = "s"`` | Pass — all 5 mock blocks ``state transition completed`` |
| ``opt-level = 1`` | Pass |

Ruled out: stack overflow, AVX-512 (reproduces with ``-Ctarget-cpu=x86-64-v3``), stale ``rust-cache``, CPU vendor (same crash on both Intel GH runners and AMD Zen 4 locally). Also unrelated to #756: that's already merged and present in the failing builds.

## Why ``s`` and not ``1`` or ``2``

``s`` remains size-focused like ``z``. It just doesn't enable the aggressive inlining / machine-outliner passes that expose the issue. The resulting ``libmultisig_glue.a`` is 63 MB in this config, which is acceptable.

## Follow-up

The real fix is upstream in leanMultisig. This PR is a workaround; #734 remains open.

## Test plan

- [ ] ``risc0`` workflow passes on this branch (the authoritative test; it has failed on every push to main since Apr 9).
- [ ] ``ci`` and ``hive`` workflows continue to pass.