### PR TITLE
fix: avoid FFI panic on bad input; plug test-registry leak

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -508,8 +508,9 @@ fn mainInner() !void {
                 errdefer allocator.free(fork_digest1);
                 // Create empty registry for test network
                 const test_registry1 = try allocator.create(node_lib.NodeNameRegistry);
-                test_registry1.* = node_lib.NodeNameRegistry.init(allocator);
                 errdefer allocator.destroy(test_registry1);
+                test_registry1.* = node_lib.NodeNameRegistry.init(allocator);
+                errdefer test_registry1.deinit();
 
                 network1.* = try networks.EthLibp2p.init(allocator, loop, .{
                     .networkId = 0,
@@ -532,8 +533,9 @@ fn mainInner() !void {
                 errdefer allocator.free(fork_digest2);
                 // Create empty registry for test network
                 const test_registry2 = try allocator.create(node_lib.NodeNameRegistry);
-                test_registry2.* = node_lib.NodeNameRegistry.init(allocator);
                 errdefer allocator.destroy(test_registry2);
+                test_registry2.* = node_lib.NodeNameRegistry.init(allocator);
+                errdefer test_registry2.deinit();
 
                 network2.* = try networks.EthLibp2p.init(allocator, loop, .{
                     .networkId = 1,
@@ -555,8 +557,9 @@ fn mainInner() !void {
                 const fork_digest3 = try allocator.dupe(u8, chain_config.spec.fork_digest);
                 errdefer allocator.free(fork_digest3);
                 const test_registry3 = try allocator.create(node_lib.NodeNameRegistry);
-                test_registry3.* = node_lib.NodeNameRegistry.init(allocator);
                 errdefer allocator.destroy(test_registry3);
+                test_registry3.* = node_lib.NodeNameRegistry.init(allocator);
+                errdefer test_registry3.deinit();
 
                 network3.* = try networks.EthLibp2p.init(allocator, loop, .{
                     .networkId = 2,

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -186,18 +186,59 @@ pub unsafe fn create_and_run_network(
     connect_addresses: *const c_char,
     topics_str: *const c_char,
 ) {
-    let listen_multiaddrs = CStr::from_ptr(listen_addresses)
-        .to_string_lossy()
-        .split(",")
-        .map(|addr| addr.parse::<Multiaddr>().expect("Invalid multiaddress"))
-        .collect::<Vec<_>>();
+    // Register the handler early so any logs emitted from the parse/validation
+    // path below are routed through the Zig logger.
+    set_zig_handler(network_id, zig_handler);
 
-    let connect_multiaddrs = CStr::from_ptr(connect_addresses)
-        .to_string_lossy()
+    // Release the Zig-allocated parameter strings on every exit path from here on,
+    // including parse failures, so the Zig side never leaks the buffers it handed us.
+    let release_params = || {
+        releaseStartNetworkParams(
+            zig_handler,
+            local_private_key,
+            listen_addresses,
+            connect_addresses,
+            topics_str,
+        );
+    };
+
+    let listen_str = CStr::from_ptr(listen_addresses).to_string_lossy();
+    let listen_multiaddrs: Vec<Multiaddr> = match listen_str
         .split(",")
-        .filter(|s| !s.trim().is_empty()) // filter out empty strings because connect_addresses can be empty
-        .map(|addr| addr.parse::<Multiaddr>().expect("Invalid multiaddress"))
-        .collect::<Vec<_>>();
+        .map(|addr| addr.parse::<Multiaddr>())
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(v) => v,
+        Err(e) => {
+            logger::rustLogger.error(
+                network_id,
+                &format!("invalid listen multiaddress in \"{}\": {}", listen_str, e),
+            );
+            release_params();
+            return;
+        }
+    };
+
+    let connect_str = CStr::from_ptr(connect_addresses).to_string_lossy();
+    let connect_multiaddrs: Vec<Multiaddr> = match connect_str
+        .split(",")
+        .filter(|s| !s.trim().is_empty()) // connect_addresses can be empty
+        .map(|addr| addr.parse::<Multiaddr>())
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(v) => v,
+        Err(e) => {
+            logger::rustLogger.error(
+                network_id,
+                &format!(
+                    "invalid connect multiaddress in \"{}\": {}",
+                    connect_str, e
+                ),
+            );
+            release_params();
+            return;
+        }
+    };
 
     let topics = CStr::from_ptr(topics_str)
         .to_string_lossy()
@@ -214,24 +255,32 @@ pub unsafe fn create_and_run_network(
         .strip_prefix("0x")
         .unwrap_or(&local_private_key_hex);
 
-    let mut private_key_bytes =
-        hex::decode(private_key_hex).expect("Invalid hex string for private key");
+    let mut private_key_bytes = match hex::decode(private_key_hex) {
+        Ok(b) => b,
+        Err(e) => {
+            logger::rustLogger.error(
+                network_id,
+                &format!("invalid hex string for private key: {}", e),
+            );
+            release_params();
+            return;
+        }
+    };
 
-    let local_key_pair = Keypair::from(secp256k1::Keypair::from(
-        secp256k1::SecretKey::try_from_bytes(&mut private_key_bytes)
-            .expect("Invalid private key bytes"),
-    ));
+    let secret_key = match secp256k1::SecretKey::try_from_bytes(&mut private_key_bytes) {
+        Ok(k) => k,
+        Err(e) => {
+            logger::rustLogger.error(
+                network_id,
+                &format!("invalid secp256k1 private key bytes: {}", e),
+            );
+            release_params();
+            return;
+        }
+    };
+    let local_key_pair = Keypair::from(secp256k1::Keypair::from(secret_key));
 
-    // Store zig_handler for this network id for use by free functions
-    set_zig_handler(network_id, zig_handler);
-
-    releaseStartNetworkParams(
-        zig_handler,
-        local_private_key,
-        listen_addresses,
-        connect_addresses,
-        topics_str,
-    );
+    release_params();
 
     let rt = Builder::new_current_thread().enable_all().build().unwrap();
 

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -230,10 +230,7 @@ pub unsafe fn create_and_run_network(
         Err(e) => {
             logger::rustLogger.error(
                 network_id,
-                &format!(
-                    "invalid connect multiaddress in \"{}\": {}",
-                    connect_str, e
-                ),
+                &format!("invalid connect multiaddress in \"{}\": {}", connect_str, e),
             );
             release_params();
             return;


### PR DESCRIPTION
## Summary

Two small memory-safety fixes from the ongoing adversarial review.

### `libp2p-glue::create_and_run_network` panicking across FFI (CRITICAL)

[rust/libp2p-glue/src/lib.rs](rust/libp2p-glue/src/lib.rs) had four `.expect()` calls inside the FFI entrypoint started on a Rust thread from Zig:

- `addr.parse::<Multiaddr>().expect("Invalid multiaddress")` (listen addrs)
- `addr.parse::<Multiaddr>().expect("Invalid multiaddress")` (connect addrs)
- `hex::decode(...).expect("Invalid hex string for private key")`
- `secp256k1::SecretKey::try_from_bytes(...).expect("Invalid private key bytes")`

The default release profile uses `panic = "unwind"` with `lto = false` (see `rust/Cargo.toml`). A panic on this thread unwinds across the FFI boundary into the Zig caller — undefined behavior per the Rustonomicon. Malformed input from a config file or Zig-side bug (e.g. a bad `local_private_key` hex) crashes the entire node process via UB rather than a recoverable error.

**Fix:** replace each `.expect()` with `match` that:
1. Logs the error through `logger::rustLogger.error` (handler registered earlier in the function so logs still route through Zig).
2. Calls `releaseStartNetworkParams` so the Zig-allocated C strings don't leak.
3. Returns — the Zig side's existing `wait_for_network_ready(..., timeout_ms)` at [pkgs/network/src/ethlibp2p.zig:1087](pkgs/network/src/ethlibp2p.zig:1087) surfaces this as `error.NetworkInitializationTimeout` to the caller.

`set_zig_handler` is now called before parsing so error logs have somewhere to go.

### CLI `.beam` command: `test_registry1/2/3` leaked internal hashmaps on error

[pkgs/cli/src/main.zig](pkgs/cli/src/main.zig) created three per-network `NodeNameRegistry` instances with the wrong errdefer ordering:

```zig
const test_registry1 = try allocator.create(node_lib.NodeNameRegistry);
test_registry1.* = node_lib.NodeNameRegistry.init(allocator);   // allocates inner hashmaps
errdefer allocator.destroy(test_registry1);                     // frees only outer; inner maps leak
```

If `EthLibp2p.init` or any subsequent allocation failed, the registry's `peer_id_to_name` and `validator_index_to_name` hashmaps leaked. The process exits on this path so it's not a long-lived leak, but it's still wrong and it's the same pattern `shared_registry` already got right at [pkgs/cli/src/main.zig:482-485](pkgs/cli/src/main.zig:482).

**Fix:** match the `shared_registry` pattern — register `destroy` before `init`, register `deinit` after:

```zig
const test_registry1 = try allocator.create(node_lib.NodeNameRegistry);
errdefer allocator.destroy(test_registry1);
test_registry1.* = node_lib.NodeNameRegistry.init(allocator);
errdefer test_registry1.deinit();
```

Applied identically to `test_registry1/2/3`. `EthLibp2p.init` borrows (doesn't own) the registry pointer, so the errdefers are safe on a later-stage error — `network1` is never run on the error path.

## Test plan
- [x] `zig fmt --check .` clean
- [x] `zig build` succeeds
- [x] `zig build test` passes (all tests, no panics/regressions)
- [x] `cargo check -p libp2p-glue` clean

## Scope

Two of the MEDIUM/HIGH items from the adversarial review. Keeping this change minimal — other items (e.g. the `SWARM_STATE` `static mut` refactor) are deferred since they require architectural work.