### PR TITLE
build: document opt-level=z + CGU=1 miscompile and CGU>=2 alternative

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,14 +21,18 @@ codegen-units = 16  # Multiple units keep risc0 and openvm code separate
 [profile.openvm-release]
 inherits = "release"
 lto = "off"          # Disable LTO on macOS due to linker issues, keeps symbols separate
-# opt-level = "z" triggers a codegen interaction with leanMultisig's prover
-# (rec_aggregation / lean_prover / backend) that produces a runtime General
-# Protection Exception inside xmss_aggregate on x86_64 Linux. Bisected against
-# `zig build run -Dprover=risc0 -- prove -z risc0`: "z" crashes deterministically,
-# "s" and numeric levels are clean. Using "s" keeps the size-optimization focus
-# without the aggressive inlining/outlining passes that expose the issue.
-# Tracked in #734. risc0-release mirrors this setting.
-opt-level = "s"      # "s" rather than "z": see comment above and #734
+# The `{opt-level = "z", codegen-units = 1}` combination miscompiles
+# leanMultisig's prover on x86_64 Linux (rustc >= 1.95), producing a
+# deterministic General Protection Exception inside xmss_aggregate ->
+# prove_execution -> eval_virtual_bus_column's inlined SIMD fold. Bisected
+# against `zig build run -Dprover=risc0 -- prove -z risc0`:
+#   - opt-level = "z" + codegen-units = 1  -> crash
+#   - opt-level = "s" + codegen-units = 1  -> clean
+#   - opt-level = "z" + codegen-units >= 2 -> clean
+# We pick `s` + CGU=1 because it keeps the single-CGU size benefit without
+# the aggressive -Oz inlining heuristics that expose the bug. Tracked in
+# zeam#734 and leanEthereum/leanMultisig#198.
+opt-level = "s"      # "s" rather than "z": see comment above
 codegen-units = 1    # Better optimization (slower compilation)
 panic = "abort"      # Remove unwinding code for smaller binary
 
@@ -36,7 +40,8 @@ panic = "abort"      # Remove unwinding code for smaller binary
 [profile.risc0-release]
 inherits = "release"
 lto = "off"          # Disable LTO on macOS due to linker issues, keeps symbols separate
-# See openvm-release above for why opt-level is "s" and not "z" (#734).
+# See openvm-release above for why opt-level is "s" and not "z"
+# (zeam#734, leanEthereum/leanMultisig#198).
 opt-level = "s"
 codegen-units = 1    # Better optimization (slower compilation)
 panic = "abort"      # Remove unwinding code for smaller binary


### PR DESCRIPTION
## Summary

Docs-only follow-up to #759. Expand the `[profile.openvm-release]` / `[profile.risc0-release]` comments in `rust/Cargo.toml` with the narrowed root cause from a bisection session on x86_64 Linux (rustc 1.95, AMD EPYC-Genoa + GitHub runners) and cross-reference the upstream issue.

**Key findings now captured in-file:**

- The miscompile requires the combination `opt-level = "z"` **AND** `codegen-units = 1`. Either change alone clears it.
- Faulting code is `lean_vm::tables::utils::eval_virtual_bus_column` once inlined into `lean_prover::prove_execution` — a stack reload of a spilled AVX2 lane inside a 16-YMM-register-live basic block.
- The comment now lists the three bisected combinations so a future reader can immediately see the alternative (`opt-level = "z"` + `codegen-units >= 2`) if they ever want to revisit `z` for binary-size reasons.
- Added a cross-reference to the upstream issue [leanEthereum/leanMultisig#198](https://github.com/leanEthereum/leanMultisig/issues/198) alongside the existing #734 reference.

**No code/config values changed** — profile keys and values are byte-identical to `main`. Diff is 14 lines of comment text.

## Test plan

- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` clean
- [x] `cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings` clean
- [x] `cargo metadata --manifest-path rust/Cargo.toml --no-deps` parses without error
- [x] Local `zig fmt --check pkgs build.zig` clean
- [ ] CI green (docs-only change; expect no regression from #759's shipped workaround)