### PR TITLE
fix: segfault during cached-block catch-up sync

### DIFF
--- a/pkgs/database/src/rocksdb.zig
+++ b/pkgs/database/src/rocksdb.zig
@@ -238,6 +238,26 @@ pub fn RocksDB(comptime column_namespaces: []const ColumnNamespace) type {
                 );
             }
 
+            /// Same as `putBlock` but stores already-serialized SSZ (must match `types.SignedBlock` encoding).
+            pub fn putBlockSerialized(
+                self: *WriteBatch,
+                comptime cn: ColumnNamespace,
+                block_root: types.Root,
+                serialized_block: []const u8,
+            ) void {
+                const key = interface.formatBlockKey(self.allocator, &block_root) catch |err| {
+                    self.logger.err("failed to format block key for putBlockSerialized: {any}", .{err});
+                    return;
+                };
+                defer self.allocator.free(key);
+
+                self.put(cn, key, serialized_block);
+                self.logger.debug("added pre-serialized block to batch: root=0x{x} len={d}", .{
+                    &block_root,
+                    serialized_block.len,
+                });
+            }
+
             /// Put a state to this write batch
             pub fn putState(
                 self: *WriteBatch,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -865,6 +865,13 @@ pub const BeamChain = struct {
         // Add current block's root to cache AFTER STF (ensures cache stays in sync with historical_block_hashes)
         try self.root_to_slot_cache.put(block_root, block.slot);
 
+        // Serialize for RocksDB now. Fork-choice follow-up (e.g. storeAggregatedPayload) clones signature
+        // proofs with sszClone; doing that after STF must not be assumed to leave the original
+        // SignedBlock's SSZ List interiors unchanged for a second serialize at persistence time.
+        var block_ssz_for_db: std.ArrayList(u8) = .empty;
+        defer block_ssz_for_db.deinit(self.allocator);
+        try ssz.serialize(types.SignedBlock, signedBlock, &block_ssz_for_db, self.allocator);
+
         var missing_roots: std.ArrayList(types.Root) = .empty;
         errdefer missing_roots.deinit(self.allocator);
 
@@ -987,7 +994,7 @@ pub const BeamChain = struct {
         const processing_time = onblock_timer.observe();
 
         // 6. Save block and state to database and confirm the block in forkchoice
-        self.updateBlockDb(signedBlock, fcBlock.blockRoot, post_state.*, block.slot) catch |err| {
+        self.updateBlockDb(block_ssz_for_db.items, fcBlock.blockRoot, post_state.*, block.slot) catch |err| {
             self.logger.err("failed to update block database for block root=0x{x}: {any}", .{
                 &fcBlock.blockRoot,
                 err,
@@ -1092,13 +1099,14 @@ pub const BeamChain = struct {
         zeam_metrics.metrics.lean_latest_finalized_slot.set(latest_finalized.slot);
     }
 
-    /// Update block database with block, state, and slot indices
-    fn updateBlockDb(self: *Self, signedBlock: types.SignedBlock, blockRoot: types.Root, postState: types.BeamState, slot: types.Slot) !void {
+    /// Update block database with block, state, and slot indices.
+    /// `signed_block_ssz` must be the SSZ encoding of `SignedBlock` (see onBlock).
+    fn updateBlockDb(self: *Self, signed_block_ssz: []const u8, blockRoot: types.Root, postState: types.BeamState, slot: types.Slot) !void {
         var batch = self.db.initWriteBatch();
         defer batch.deinit();
 
         // Store block and state
-        batch.putBlock(database.DbBlocksNamespace, blockRoot, signedBlock);
+        batch.putBlockSerialized(database.DbBlocksNamespace, blockRoot, signed_block_ssz);
         batch.putState(database.DbStatesNamespace, blockRoot, postState);
 
         // TODO: uncomment this code if there is a need of slot to unfinalized index

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -57,6 +57,10 @@ pub const CachedProcessedBlockInfo = struct {
     postState: ?*types.BeamState = null,
     blockRoot: ?types.Root = null,
     pruneForkchoice: bool = true,
+    // Pre-serialized SSZ bytes for the block.  When set, onBlock uses them directly
+    // for database persistence and skips re-serializing the live SignedBlock, which
+    // has been observed to corrupt in-memory List/Bitlist state on subsequent access.
+    sszBytes: ?[]const u8 = null,
 };
 
 pub const GossipProcessingResult = struct {
@@ -865,12 +869,29 @@ pub const BeamChain = struct {
         // Add current block's root to cache AFTER STF (ensures cache stays in sync with historical_block_hashes)
         try self.root_to_slot_cache.put(block_root, block.slot);
 
-        // Serialize for RocksDB now. Fork-choice follow-up (e.g. storeAggregatedPayload) clones signature
-        // proofs with sszClone; doing that after STF must not be assumed to leave the original
-        // SignedBlock's SSZ List interiors unchanged for a second serialize at persistence time.
-        var block_ssz_for_db: std.ArrayList(u8) = .empty;
-        defer block_ssz_for_db.deinit(self.allocator);
-        try ssz.serialize(types.SignedBlock, signedBlock, &block_ssz_for_db, self.allocator);
+        // Obtain SSZ bytes for RocksDB persistence.
+        //
+        // Prefer the pre-serialized bytes captured at cache time (blockInfo.sszBytes).
+        // Using those bytes avoids calling ssz.serialize on the live `signedBlock` here,
+        // which has been observed to corrupt in-memory List/Bitlist state (aggregation_bits,
+        // proof_data) and cause segfaults on the next cached block's processing.
+        //
+        // If no pre-serialized bytes are available (e.g. locally produced blocks), fall back
+        // to serializing a disposable deep clone so the live block is never passed to serialize.
+        var fallback_ssz: std.ArrayList(u8) = .empty;
+        defer fallback_ssz.deinit(self.allocator);
+
+        var fallback_clone: types.SignedBlock = undefined;
+        var fallback_clone_initialized = false;
+        defer if (fallback_clone_initialized) fallback_clone.deinit();
+
+        const block_ssz_for_db: []const u8 = if (blockInfo.sszBytes) |precomputed| precomputed else blk: {
+            // No pre-serialized bytes: clone the block and serialize the clone only.
+            try types.sszClone(self.allocator, types.SignedBlock, signedBlock, &fallback_clone);
+            fallback_clone_initialized = true;
+            try ssz.serialize(types.SignedBlock, fallback_clone, &fallback_ssz, self.allocator);
+            break :blk fallback_ssz.items;
+        };
 
         var missing_roots: std.ArrayList(types.Root) = .empty;
         errdefer missing_roots.deinit(self.allocator);
@@ -994,7 +1015,7 @@ pub const BeamChain = struct {
         const processing_time = onblock_timer.observe();
 
         // 6. Save block and state to database and confirm the block in forkchoice
-        self.updateBlockDb(block_ssz_for_db.items, fcBlock.blockRoot, post_state.*, block.slot) catch |err| {
+        self.updateBlockDb(block_ssz_for_db, fcBlock.blockRoot, post_state.*, block.slot) catch |err| {
             self.logger.err("failed to update block database for block root=0x{x}: {any}", .{
                 &fcBlock.blockRoot,
                 err,

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -57,6 +57,8 @@ pub const PendingRPCMap = std.AutoHashMap(u64, PendingRPCEntry);
 pub const PendingBlockRootMap = std.AutoHashMap(types.Root, u32);
 // key: block root, value: pointer to block
 pub const FetchedBlockMap = std.AutoHashMap(types.Root, *types.SignedBlock);
+// key: block root, value: pre-serialized SSZ bytes (captured at cache time)
+pub const FetchedBlockSszMap = std.AutoHashMap(types.Root, []u8);
 // key: parent root, value: list of child roots (for O(1) child lookup)
 pub const ChildrenMap = std.AutoHashMap(types.Root, std.ArrayList(types.Root));
 
@@ -72,6 +74,7 @@ pub const Network = struct {
     pending_rpc_requests: PendingRPCMap,
     pending_block_roots: PendingBlockRootMap,
     fetched_blocks: FetchedBlockMap,
+    fetched_block_ssz: FetchedBlockSszMap,
     fetched_block_children: ChildrenMap,
     timed_out_requests: std.ArrayList(u64),
 
@@ -93,6 +96,9 @@ pub const Network = struct {
         var fetched_blocks = FetchedBlockMap.init(allocator);
         errdefer fetched_blocks.deinit();
 
+        var fetched_block_ssz = FetchedBlockSszMap.init(allocator);
+        errdefer fetched_block_ssz.deinit();
+
         var fetched_block_children = ChildrenMap.init(allocator);
         errdefer fetched_block_children.deinit();
 
@@ -103,6 +109,7 @@ pub const Network = struct {
             .pending_rpc_requests = pending_rpc_requests,
             .pending_block_roots = pending_block_roots,
             .fetched_blocks = fetched_blocks,
+            .fetched_block_ssz = fetched_block_ssz,
             .fetched_block_children = fetched_block_children,
             .timed_out_requests = .empty,
         };
@@ -126,6 +133,12 @@ pub const Network = struct {
             self.allocator.destroy(block_ptr);
         }
         self.fetched_blocks.deinit();
+
+        var ssz_it = self.fetched_block_ssz.iterator();
+        while (ssz_it.next()) |entry| {
+            self.allocator.free(entry.value_ptr.*);
+        }
+        self.fetched_block_ssz.deinit();
 
         var children_it = self.fetched_block_children.iterator();
         while (children_it.next()) |entry| {
@@ -332,7 +345,26 @@ pub const Network = struct {
         try gop.value_ptr.append(self.allocator, root);
     }
 
+    /// Returns the pre-serialized SSZ bytes for a cached block, if stored.
+    pub fn getFetchedBlockSsz(self: *Self, root: types.Root) ?[]const u8 {
+        return self.fetched_block_ssz.get(root);
+    }
+
+    /// Store pre-serialized SSZ bytes alongside a cached block.
+    /// Caller transfers ownership of `ssz_bytes` to the map.
+    pub fn storeFetchedBlockSsz(self: *Self, root: types.Root, ssz_bytes: []u8) !void {
+        const gop = try self.fetched_block_ssz.getOrPut(root);
+        if (gop.found_existing) {
+            self.allocator.free(gop.value_ptr.*);
+        }
+        gop.value_ptr.* = ssz_bytes;
+    }
+
     pub fn removeFetchedBlock(self: *Self, root: types.Root) bool {
+        if (self.fetched_block_ssz.fetchRemove(root)) |ssz_entry| {
+            self.allocator.free(ssz_entry.value);
+        }
+
         if (self.fetched_blocks.fetchRemove(root)) |entry| {
             var block_ptr = entry.value;
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -56,6 +56,9 @@ pub const BeamNode = struct {
     node_registry: *const NodeNameRegistry,
     /// Explicitly configured subnet ids for attestation import (adds to validator-derived subnets).
     aggregation_subnet_ids: ?[]const u32 = null,
+    /// Serializes BeamNode work between the libxev main thread (onInterval) and
+    /// the libp2p worker thread (onGossip / onReqRespResponse / onReqRespRequest).
+    mutex: std.Thread.Mutex = .{},
 
     const Self = @This();
 
@@ -129,6 +132,9 @@ pub const BeamNode = struct {
     pub fn onGossip(ptr: *anyopaque, data: *const networks.GossipMessage, sender_peer_id: []const u8) anyerror!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
 
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
         switch (data.*) {
             .block => |signed_block| {
                 const block = signed_block.block;
@@ -151,6 +157,7 @@ pub const BeamNode = struct {
                     self.logger.warn("failed to compute block root for incoming gossip block: {any}", .{err});
                     return;
                 };
+
                 _ = self.network.removePendingBlockRoot(block_root);
 
                 if (!hasParentBlock) {
@@ -877,6 +884,8 @@ pub const BeamNode = struct {
 
     pub fn onReqRespResponse(ptr: *anyopaque, event: *const networks.ReqRespResponseEvent) anyerror!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
+        self.mutex.lock();
+        defer self.mutex.unlock();
         try self.handleReqRespResponse(event);
     }
 
@@ -892,6 +901,9 @@ pub const BeamNode = struct {
 
         switch (data.*) {
             .blocks_by_root => |request| {
+                self.mutex.lock();
+                defer self.mutex.unlock();
+
                 const roots = request.roots.constSlice();
 
                 self.logger.debug(
@@ -1100,30 +1112,37 @@ pub const BeamNode = struct {
         var current_interval: isize = start_interval;
         while (current_interval <= itime_intervals) : (current_interval += 1) {
             const interval: usize = @intCast(current_interval);
-            self.chain.onInterval(interval) catch |e| {
-                self.logger.err("error ticking chain to time(intervals)={d} err={any}", .{ interval, e });
-                // no point going further if chain is not ticked properly
-                return e;
-            };
+            const slot: types.Slot = @intCast(@divFloor(interval, constants.INTERVALS_PER_SLOT));
 
-            // Replay blocks that were queued waiting for the forkchoice clock to advance,
-            // then fetch any attestation head roots that were missing during replay.
-            const pending_missing_roots = self.chain.processPendingBlocks();
-            defer self.allocator.free(pending_missing_roots);
-            if (pending_missing_roots.len > 0) {
-                self.fetchBlockByRoots(pending_missing_roots, 0) catch |err| {
-                    self.logger.warn(
-                        "failed to fetch {d} missing block(s) from pending blocks: {any}",
-                        .{ pending_missing_roots.len, err },
-                    );
+            {
+                self.mutex.lock();
+                defer self.mutex.unlock();
+
+                self.chain.onInterval(interval) catch |e| {
+                    self.logger.err("error ticking chain to time(intervals)={d} err={any}", .{ interval, e });
+                    // no point going further if chain is not ticked properly
+                    return e;
                 };
+
+                // Replay blocks that were queued waiting for the forkchoice clock to advance,
+                // then fetch any attestation head roots that were missing during replay.
+                const pending_missing_roots = self.chain.processPendingBlocks();
+                defer self.allocator.free(pending_missing_roots);
+                if (pending_missing_roots.len > 0) {
+                    self.fetchBlockByRoots(pending_missing_roots, 0) catch |err| {
+                        self.logger.warn(
+                            "failed to fetch {d} missing block(s) from pending blocks: {any}",
+                            .{ pending_missing_roots.len, err },
+                        );
+                    };
+                }
+
+                // Sweep timed-out RPC requests to prevent sync stalls from non-responsive peers.
+                self.sweepTimedOutRequests();
+
+                self.processReadyCachedBlocks(slot);
             }
 
-            // Sweep timed-out RPC requests to prevent sync stalls from non-responsive peers.
-            self.sweepTimedOutRequests();
-
-            const slot: types.Slot = @intCast(@divFloor(interval, constants.INTERVALS_PER_SLOT));
-            self.processReadyCachedBlocks(slot);
             if (self.validator) |*validator| {
                 // we also tick validator per interval in case it would
                 // need to sync its future duties when its an independent validator

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -412,7 +412,8 @@ pub const BeamNode = struct {
                     .{&descendant_root},
                 );
 
-                const missing_roots = self.chain.onBlock(cached_block.*, .{}) catch |err| {
+                const block_ssz = self.network.getFetchedBlockSsz(descendant_root);
+                const missing_roots = self.chain.onBlock(cached_block.*, .{ .sszBytes = block_ssz }) catch |err| {
                     if (err == chainFactory.BlockProcessingError.MissingPreState) {
                         // Parent still missing, keep it cached
                         self.logger.debug(
@@ -604,15 +605,27 @@ pub const BeamNode = struct {
         var block_owned = true;
         errdefer if (block_owned) self.allocator.destroy(block_ptr);
 
-        types.sszClone(self.allocator, types.SignedBlock, signed_block, block_ptr) catch {
+        // Clone the block and capture its SSZ bytes in one pass.
+        // sszCloneAndGetBytes serializes the original block once (read-only on `signed_block`),
+        // then deserializes into the clone. The returned bytes are stored alongside the cached
+        // block so that onBlock never needs to re-serialize a live SignedBlock, which has been
+        // observed to cause memory corruption on the next cached block's processing.
+        const ssz_bytes = types.sszCloneAndGetBytes(self.allocator, types.SignedBlock, signed_block, block_ptr) catch {
             return CacheBlockError.CloneFailed;
         };
         errdefer if (block_owned) block_ptr.deinit();
+        errdefer self.allocator.free(ssz_bytes);
 
         self.network.cacheFetchedBlock(block_root, block_ptr) catch {
             return CacheBlockError.CachingFailed;
         };
         block_owned = false;
+
+        // Store the SSZ bytes after caching; ignore store failure (block is already cached,
+        // onBlock will fall back to fresh serialization if bytes are unavailable).
+        self.network.storeFetchedBlockSsz(block_root, ssz_bytes) catch {
+            self.allocator.free(ssz_bytes);
+        };
     }
 
     fn processBlockByRootChunk(self: *Self, block_ctx: *const BlockByRootContext, signed_block: *const types.SignedBlock) !void {

--- a/pkgs/types/src/lib.zig
+++ b/pkgs/types/src/lib.zig
@@ -72,6 +72,7 @@ pub const Bytes52 = utils.Bytes52;
 pub const GenesisSpec = utils.GenesisSpec;
 pub const ChainSpec = utils.ChainSpec;
 pub const sszClone = utils.sszClone;
+pub const sszCloneAndGetBytes = utils.sszCloneAndGetBytes;
 pub const IsJustifiableSlot = utils.IsJustifiableSlot;
 pub const RootToSlotCache = utils.RootToSlotCache;
 

--- a/pkgs/types/src/utils.zig
+++ b/pkgs/types/src/utils.zig
@@ -224,6 +224,20 @@ pub fn sszClone(allocator: Allocator, comptime T: type, data: T, cloned: *T) !vo
     try ssz.deserialize(T, bytes.items[0..], cloned, allocator);
 }
 
+// Like sszClone but also returns the serialized bytes (caller owns the slice).
+// Using the same ssz.serialize pass for both clone and bytes avoids a second
+// serialize call on the same value, which has been observed to corrupt in-memory
+// List/Bitlist state when the value is later reused (e.g. cached blocks).
+pub fn sszCloneAndGetBytes(allocator: Allocator, comptime T: type, data: T, cloned: *T) ![]u8 {
+    var bytes: std.ArrayList(u8) = .empty;
+    // Do NOT defer deinit — caller takes ownership of the buffer.
+    errdefer bytes.deinit(allocator);
+
+    try ssz.serialize(T, data, &bytes, allocator);
+    try ssz.deserialize(T, bytes.items[0..], cloned, allocator);
+    return bytes.toOwnedSlice(allocator);
+}
+
 test "isSlotJustified treats finalized boundary as implicit" {
     var justified_slots = try types.JustifiedSlots.init(std.testing.allocator);
     defer justified_slots.deinit();


### PR DESCRIPTION
## Summary

Fixes two distinct segfaults observed during catch-up sync on x86_64:

1. **`ssz.serialize` corrupting live cached `SignedBlock`s.** Stack bottoms out in
   `onBlock` iterating `aggregated_attestations` (or later in `verifySignatures`)
   with a dangling slice into a cached block's heap buffer. Root cause:
   `ssz.serialize` on a live cached `SignedBlock` (directly, or via `sszClone`)
   mutates nested `List` / `Bitlist` fields (`aggregation_bits`, `proof_data`),
   so the next read of the same cached block crashes.

2. **`fetched_blocks` hashmap rehash race** (folded in from #741). The map in the
   network layer is shared between the libxev main thread (`onInterval`) and the
   libp2p worker thread (`onGossip` / `onReqRespResponse` / `onReqRespRequest`).
   When the worker inserts and triggers a rehash, the main thread's in-flight
   lookups/iterations become invalid and panic.

## Changes

### ssz-corruption fix (cherry-picked from `fix/libp2p-glue-c-abi-x86_64`)

- `1aecb39 chain, database: persist pre-forkchoice signed block SSZ for rocksdb`
- `1fd70ea node, types: capture block SSZ bytes at cache time, never re-serialize cached blocks`

Highlights:

- `types/utils`: new `sszCloneAndGetBytes` — one serialize pass returning both a
  deep clone and the SSZ bytes (caller owns), avoiding a second serialize on the
  same value.
- `network`: new `fetched_block_ssz` map (root → `[]u8`) with lifecycle tied to
  `cacheFetchedBlock` / `removeFetchedBlock` / `deinit`; `getFetchedBlockSsz` /
  `storeFetchedBlockSsz` helpers.
- `node.cacheBlockAndFetchParent`: uses `sszCloneAndGetBytes` and stores the
  bytes alongside the cached block.
- `chain.CachedProcessedBlockInfo`: new `sszBytes: ?[]const u8` field.
- `node.processCachedDescendants`: retrieves stored bytes and passes them via
  `blockInfo.sszBytes`.
- `chain.onBlock` / `updateBlockDb`: uses `blockInfo.sszBytes` when present,
  falls back to a disposable-clone serialize only for locally produced blocks.

### Hashmap rehash race fix (cherry-picked from #741)

- `71280e3 fix race condition leading to seg faults` (by @anshalshukla)

Adds a `std.Thread.Mutex` to `BeamNode` that serializes work between the
libxev main thread and the libp2p worker thread. Locks are taken around:

- `onGossip`
- `onReqRespResponse`
- `onReqRespRequest` (`.blocks_by_root` branch)
- `onInterval` (chain tick, pending replay, RPC sweep, `processReadyCachedBlocks`)

## Test plan

- [x] `zig fmt --check .`
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings`
- [x] `zig build test --summary all`
- [x] `zig build simtest --summary all`
- [ ] Soak under catch-up-sync scenario on x86_64 hardware to confirm both
      original crashes are resolved