### PR TITLE
ci(hive): hoist simulators/lean Cargo.lock to hive root before docker build

### DIFF
--- a/.github/scripts/hive-summary.sh
+++ b/.github/scripts/hive-summary.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Emit a markdown summary of a hive results directory.
+#
+# Reads every `<unix>-<hex>.json` suite file hive writes under RESULTS_DIR,
+# aggregates pass/fail/timeout counts across suites, and for each failure
+# pulls the relevant slice out of the suite's testDetailsLog (via the
+# {begin,end} byte offsets hive records on each failing test) so the
+# summary can show why the test failed without forcing the reader to
+# download the artifact.
+#
+# Usage: hive-summary.sh <results-dir> [output-file]
+#
+#   <results-dir>   directory hive wrote with `--results-root`
+#   [output-file]   file to append the markdown summary to; defaults to
+#                   stdout. Intended to be pointed at $GITHUB_STEP_SUMMARY
+#                   and/or a PR-comment fragment.
+#
+# Output is markdown. If the directory has no suite files (e.g. hive
+# failed before running any tests) the script still emits a summary
+# block noting that no results were produced.
+
+set -euo pipefail
+
+results_dir="${1:-}"
+output="${2:-/dev/stdout}"
+
+if [ -z "$results_dir" ]; then
+  echo "usage: $0 <results-dir> [output-file]" >&2
+  exit 2
+fi
+
+if [ ! -d "$results_dir" ]; then
+  echo "results directory not found: $results_dir" >&2
+  exit 1
+fi
+
+# Emit markdown to a temp buffer first so a partial failure doesn't
+# truncate an already-open $GITHUB_STEP_SUMMARY.
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+shopt -s nullglob
+# Suite files are named `<unix>-<hex>.json` (see libhive/testmanager.go:
+# writeSuiteFile). `hive.json` is the top-level run metadata and must be
+# excluded.
+suites=()
+for f in "$results_dir"/*.json; do
+  base="$(basename "$f")"
+  [ "$base" = "hive.json" ] && continue
+  suites+=("$f")
+done
+
+if [ "${#suites[@]}" -eq 0 ]; then
+  {
+    echo "### Hive test results"
+    echo
+    echo "No suite result files were produced in \`$results_dir\`. This usually means hive failed before any test suite finished (e.g. during client or simulator image build)."
+  } >> "$tmp"
+  cat "$tmp" >> "$output"
+  exit 0
+fi
+
+# Aggregate counters and a compact per-failure record in a single jq pass
+# per suite. Timeouts are counted both as failures and as a separate
+# bucket, matching how hiveview displays them.
+total=0
+passed=0
+failed=0
+timeouts=0
+# Failures list: one record per line, tab-separated fields:
+#   <suite>\t<test>\t<timeout?>\t<details_log>\t<begin>\t<end>\t<inline_details>
+failures_tsv=""
+
+for suite in "${suites[@]}"; do
+  suite_name="$(jq -r '.name // "(unnamed)"' "$suite")"
+  details_log_rel="$(jq -r '.testDetailsLog // ""' "$suite")"
+  details_log_abs=""
+  if [ -n "$details_log_rel" ] && [ -f "$results_dir/$details_log_rel" ]; then
+    details_log_abs="$results_dir/$details_log_rel"
+  fi
+
+  counts="$(jq -r '
+    [.testCases[].summaryResult] as $r
+    | [($r|length),
+       ([$r[] | select(.pass==true)] | length),
+       ([$r[] | select(.pass==false)] | length),
+       ([$r[] | select(.timeout==true)] | length)]
+    | @tsv
+  ' "$suite")"
+  IFS=$'\t' read -r t p f to <<<"$counts"
+  total=$((total + t))
+  passed=$((passed + p))
+  failed=$((failed + f))
+  timeouts=$((timeouts + to))
+
+  suite_failures="$(jq -r --arg suite "$suite_name" --arg log "$details_log_abs" '
+    .testCases
+    | to_entries
+    | map(select(.value.summaryResult.pass == false))
+    | .[]
+    | [$suite,
+       .value.name,
+       (.value.summaryResult.timeout // false | tostring),
+       $log,
+       (.value.summaryResult.log.begin // ""),
+       (.value.summaryResult.log.end   // ""),
+       (.value.summaryResult.details   // "")]
+    | @tsv
+  ' "$suite")"
+  if [ -n "$suite_failures" ]; then
+    failures_tsv+="${suite_failures}"$'\n'
+  fi
+done
+
+# Devnet label is carried through by the caller via HIVE_DEVNET_LABEL; we
+# intentionally don't re-parse it from the results (hive's JSON doesn't
+# record the client-file path).
+devnet_label="${HIVE_DEVNET_LABEL:-unknown}"
+simulator_label="${HIVE_SIMULATOR_LABEL:-unknown}"
+
+{
+  echo "### Hive test results"
+  echo
+  echo "| Simulator | Devnet | Suites | Tests | Passed | Failed | Timeouts |"
+  echo "|---|---|---|---|---|---|---|"
+  echo "| \`$simulator_label\` | \`$devnet_label\` | ${#suites[@]} | $total | $passed | $failed | $timeouts |"
+  echo
+} >> "$tmp"
+
+if [ "$failed" -eq 0 ]; then
+  echo "All $total tests passed." >> "$tmp"
+  cat "$tmp" >> "$output"
+  exit 0
+fi
+
+# Snippet budget per failure. GitHub step summary caps at 1 MiB total
+# and PR comments at 65536 chars, so keep each excerpt bounded and
+# collapse via <details> so the comment stays scannable.
+snippet_bytes=1024
+
+{
+  echo "<details open>"
+  echo "<summary><strong>Failed tests ($failed)</strong></summary>"
+  echo
+} >> "$tmp"
+
+# Read the TSV line-by-line. Using a file descriptor to avoid subshell
+# scoping of the loop variables.
+while IFS=$'\t' read -r suite name timeout log_path begin end inline; do
+  [ -z "$name" ] && continue
+
+  badge=""
+  [ "$timeout" = "true" ] && badge=" _(timeout)_"
+
+  {
+    echo "<hr>"
+    echo
+    echo "**\`$suite\`** → \`$name\`$badge"
+    echo
+  } >> "$tmp"
+
+  # Prefer the inline `details` string if the suite recorded one;
+  # otherwise slice the log file using the byte offsets hive wrote.
+  excerpt=""
+  if [ -n "$inline" ]; then
+    excerpt="$inline"
+  elif [ -n "$begin" ] && [ -n "$end" ] && [ -n "$log_path" ] && [ -f "$log_path" ]; then
+    count=$((end - begin))
+    if [ "$count" -gt 0 ]; then
+      # `dd` skips `begin` bytes then reads `count` bytes. Cap at
+      # snippet_bytes so a runaway test log doesn't blow the summary.
+      if [ "$count" -gt "$snippet_bytes" ]; then
+        count="$snippet_bytes"
+      fi
+      excerpt="$(dd if="$log_path" bs=1 skip="$begin" count="$count" 2>/dev/null || true)"
+    fi
+  fi
+
+  if [ -n "$excerpt" ]; then
+    {
+      echo '```'
+      # Strip trailing whitespace and cap length as a defence in depth.
+      printf '%s\n' "$excerpt" | head -c "$snippet_bytes"
+      echo
+      echo '```'
+    } >> "$tmp"
+  else
+    echo "_(no details recorded; check the uploaded hive results artifact)_" >> "$tmp"
+  fi
+  echo >> "$tmp"
+done <<<"$failures_tsv"
+
+echo "</details>" >> "$tmp"
+
+cat "$tmp" >> "$output"

--- a/.github/scripts/hive-summary.sh
+++ b/.github/scripts/hive-summary.sh
@@ -68,8 +68,16 @@ total=0
 passed=0
 failed=0
 timeouts=0
-# Failures list: one record per line, tab-separated fields:
-#   <suite>\t<test>\t<timeout?>\t<details_log>\t<begin>\t<end>\t<inline_details>
+# Failures list: one record per line, tab-separated fields.
+#
+# Only single-line fields are carried through the TSV: this avoids the
+# well-known jq @tsv pitfall where an embedded newline in a string would
+# round-trip as the literal two-char sequence "\n" and ruin the rendered
+# excerpt. In particular the `details` string (which can be multi-line)
+# is NOT in the TSV; when we need it we re-read it from the source suite
+# file with a targeted jq keyed by the test's entry key.
+#
+#   <suite_name>\t<suite_file>\t<test_key>\t<test_name>\t<timeout?>\t<details_log>\t<begin>\t<end>
 failures_tsv=""
 
 for suite in "${suites[@]}"; do
@@ -94,18 +102,22 @@ for suite in "${suites[@]}"; do
   failed=$((failed + f))
   timeouts=$((timeouts + to))
 
-  suite_failures="$(jq -r --arg suite "$suite_name" --arg log "$details_log_abs" '
+  suite_failures="$(jq -r \
+    --arg suite "$suite_name" \
+    --arg suite_file "$suite" \
+    --arg log "$details_log_abs" '
     .testCases
     | to_entries
     | map(select(.value.summaryResult.pass == false))
     | .[]
     | [$suite,
+       $suite_file,
+       .key,
        .value.name,
        (.value.summaryResult.timeout // false | tostring),
        $log,
        (.value.summaryResult.log.begin // ""),
-       (.value.summaryResult.log.end   // ""),
-       (.value.summaryResult.details   // "")]
+       (.value.summaryResult.log.end   // "")]
     | @tsv
   ' "$suite")"
   if [ -n "$suite_failures" ]; then
@@ -145,9 +157,7 @@ snippet_bytes=1024
   echo
 } >> "$tmp"
 
-# Read the TSV line-by-line. Using a file descriptor to avoid subshell
-# scoping of the loop variables.
-while IFS=$'\t' read -r suite name timeout log_path begin end inline; do
+while IFS=$'\t' read -r suite suite_file test_key name timeout log_path begin end; do
   [ -z "$name" ] && continue
 
   badge=""
@@ -160,27 +170,36 @@ while IFS=$'\t' read -r suite name timeout log_path begin end inline; do
     echo
   } >> "$tmp"
 
-  # Prefer the inline `details` string if the suite recorded one;
-  # otherwise slice the log file using the byte offsets hive wrote.
+  # Resolve the failure excerpt. Priority order:
+  #   1. The suite's testDetailsLog file, sliced with the {begin,end}
+  #      byte offsets hive recorded (normal case: tests emit details via
+  #      the hive API, which hive appends to the shared log file).
+  #   2. The testCase's inline `details` field, fetched on demand with a
+  #      targeted jq keyed by the test's entry key. We go back to the
+  #      source JSON rather than carry the string through TSV so embedded
+  #      newlines survive intact.
   excerpt=""
-  if [ -n "$inline" ]; then
-    excerpt="$inline"
-  elif [ -n "$begin" ] && [ -n "$end" ] && [ -n "$log_path" ] && [ -f "$log_path" ]; then
+  if [ -n "$begin" ] && [ -n "$end" ] && [ -n "$log_path" ] && [ -f "$log_path" ]; then
     count=$((end - begin))
     if [ "$count" -gt 0 ]; then
-      # `dd` skips `begin` bytes then reads `count` bytes. Cap at
-      # snippet_bytes so a runaway test log doesn't blow the summary.
+      # Cap at snippet_bytes so a runaway test log doesn't blow the summary.
       if [ "$count" -gt "$snippet_bytes" ]; then
         count="$snippet_bytes"
       fi
-      excerpt="$(dd if="$log_path" bs=1 skip="$begin" count="$count" 2>/dev/null || true)"
+      # `tail -c +N` is 1-indexed; `begin` is 0-indexed. Uses buffered I/O
+      # (vs `dd bs=1`'s one-syscall-per-byte), so large offsets stay cheap.
+      excerpt="$(tail -c "+$((begin + 1))" "$log_path" 2>/dev/null | head -c "$count" || true)"
     fi
+  fi
+  if [ -z "$excerpt" ] && [ -n "$test_key" ] && [ -f "$suite_file" ]; then
+    excerpt="$(jq -r --arg k "$test_key" '
+      .testCases[$k].summaryResult.details // ""
+    ' "$suite_file")"
   fi
 
   if [ -n "$excerpt" ]; then
     {
       echo '```'
-      # Strip trailing whitespace and cap length as a defence in depth.
       printf '%s\n' "$excerpt" | head -c "$snippet_bytes"
       echo
       echo '```'

--- a/.github/scripts/hive-summary.sh
+++ b/.github/scripts/hive-summary.sh
@@ -9,26 +9,48 @@
 # summary can show why the test failed without forcing the reader to
 # download the artifact.
 #
-# Usage: hive-summary.sh <results-dir> [output-file]
+# Usage: hive-summary.sh <results-dir> [output-file] [counts-file]
 #
 #   <results-dir>   directory hive wrote with `--results-root`
 #   [output-file]   file to append the markdown summary to; defaults to
 #                   stdout. Intended to be pointed at $GITHUB_STEP_SUMMARY
 #                   and/or a PR-comment fragment.
+#   [counts-file]   optional file to write a key=value tally to
+#                   (suites=, total=, passed=, failed=, timeouts=). When
+#                   pointed at $GITHUB_OUTPUT this exposes the counts to
+#                   subsequent workflow steps; see the "Summarize hive
+#                   results" step in .github/workflows/hive.yml.
 #
 # Output is markdown. If the directory has no suite files (e.g. hive
 # failed before running any tests) the script still emits a summary
-# block noting that no results were produced.
+# block noting that no results were produced and writes zeros to the
+# counts file.
 
 set -euo pipefail
 
 results_dir="${1:-}"
 output="${2:-/dev/stdout}"
+counts_file="${3:-}"
 
 if [ -z "$results_dir" ]; then
-  echo "usage: $0 <results-dir> [output-file]" >&2
+  echo "usage: $0 <results-dir> [output-file] [counts-file]" >&2
   exit 2
 fi
+
+emit_counts() {
+  # Always emit a complete key set so callers that `cat` this into
+  # $GITHUB_OUTPUT don't end up with some keys unset when hive failed
+  # before writing any suite.
+  [ -z "$counts_file" ] && return 0
+  local s="$1" t="$2" p="$3" f="$4" to="$5"
+  {
+    echo "suites=$s"
+    echo "total=$t"
+    echo "passed=$p"
+    echo "failed=$f"
+    echo "timeouts=$to"
+  } >> "$counts_file"
+}
 
 if [ ! -d "$results_dir" ]; then
   echo "results directory not found: $results_dir" >&2
@@ -58,6 +80,7 @@ if [ "${#suites[@]}" -eq 0 ]; then
     echo "No suite result files were produced in \`$results_dir\`. This usually means hive failed before any test suite finished (e.g. during client or simulator image build)."
   } >> "$tmp"
   cat "$tmp" >> "$output"
+  emit_counts 0 0 0 0 0
   exit 0
 fi
 
@@ -143,6 +166,7 @@ simulator_label="${HIVE_SIMULATOR_LABEL:-unknown}"
 if [ "$failed" -eq 0 ]; then
   echo "All $total tests passed." >> "$tmp"
   cat "$tmp" >> "$output"
+  emit_counts "${#suites[@]}" "$total" "$passed" 0 0
   exit 0
 fi
 
@@ -213,3 +237,4 @@ done <<<"$failures_tsv"
 echo "</details>" >> "$tmp"
 
 cat "$tmp" >> "$output"
+emit_counts "${#suites[@]}" "$total" "$passed" "$failed" "$timeouts"

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -192,23 +192,49 @@ jobs:
           # build failure (e.g. "returned a non-zero code: 101") which is useless for
           # diagnosing cargo/compiler errors in CI.
           #
-          # `tee` is only for preserving the hive output as a run artifact; we
-          # must not let its exit status mask hive's, so we read the hive exit
-          # code out of PIPESTATUS rather than pipefail-ing the whole chain
-          # (tee itself should never fail here, but PIPESTATUS makes the intent
-          # explicit: trust hive's own exit code, don't infer success from a
-          # log-line grep).
+          # `|| true` suppresses pipefail/`set -e` so we can inspect hive's
+          # real exit code deliberately; it is read from PIPESTATUS[0] on
+          # the next line before any other command can clobber it.
           ./hive \
             --sim "${{ steps.cfg.outputs.simulator }}" \
             --client "zeam" \
             --results-root results \
             --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml \
             --docker.output \
-            2>&1 | tee hive.log
+            2>&1 | tee hive.log || true
           hive_rc="${PIPESTATUS[0]}"
+
+          # hive's exit code conflates two very different failure modes
+          # (see ethereum/hive hive.go, which calls fatal() for both):
+          # infrastructure errors (image build failure, simulator crash,
+          # bad flag, Docker client unavailable) and plain test failures.
+          # Both reach os.Exit(1) indistinguishably.
+          #
+          # This step should only go red on the former. Failing tests
+          # are already surfaced by the Summarize hive results step and
+          # the uploaded artifact; turning the whole step red on them
+          # would mask the number and identity of failures behind a
+          # single X and force reviewers into the job log.
+          #
+          # Disambiguate by checking whether hive got far enough to
+          # write any per-suite result file. libhive writes each suite
+          # as <unix>-<hex>.json in the results dir at suite-end (see
+          # libhive/testmanager.go::writeSuiteFile), so "non-zero exit
+          # with >=1 suite file" unambiguously means "tests ran to
+          # completion, some failed".
+          shopt -s nullglob
+          suite_results=()
+          for f in results/*.json; do
+            [ "$(basename "$f")" = "hive.json" ] && continue
+            suite_results+=("$f")
+          done
+
           if [ "$hive_rc" -ne 0 ]; then
-            echo "hive exited with status $hive_rc" >&2
-            exit "$hive_rc"
+            if [ "${#suite_results[@]}" -eq 0 ]; then
+              echo "hive exited $hive_rc before any suite finished; treating as infrastructure failure" >&2
+              exit "$hive_rc"
+            fi
+            echo "hive exited $hive_rc after running ${#suite_results[@]} suite(s); treating non-zero as test failures and continuing -- see the Summarize hive results step for details" >&2
           fi
 
       - name: Summarize hive results
@@ -223,10 +249,14 @@ jobs:
           # Aggregate pass/fail counts across every suite hive wrote and
           # render a markdown summary to (a) the workflow's Step Summary
           # tab and (b) a fragment file the PR-comment step re-reads so we
-          # don't have to keep two copies of the markdown logic.
+          # don't have to keep two copies of the markdown logic. Counts
+          # are also exported as step outputs so the PR-comment step can
+          # pick an accurate icon (the Run Hive step may succeed even
+          # when tests failed -- see the disambiguation comment there).
           summary_file="$GITHUB_WORKSPACE/hive-summary.md"
           : > "$summary_file"
-          "$GITHUB_WORKSPACE/.github/scripts/hive-summary.sh" src/results "$summary_file"
+          "$GITHUB_WORKSPACE/.github/scripts/hive-summary.sh" \
+            src/results "$summary_file" "$GITHUB_OUTPUT"
           cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
           echo "summary_file=$summary_file" >> "$GITHUB_OUTPUT"
 
@@ -247,9 +277,31 @@ jobs:
             const fs = require('fs');
             const simulator = '${{ steps.cfg.outputs.simulator }}';
             const devnet = '${{ steps.cfg.outputs.devnet }}';
-            const conclusion = '${{ steps.hive.outcome }}';
+            const hiveOutcome = '${{ steps.hive.outcome }}';
+            const failedCount = parseInt('${{ steps.summary.outputs.failed || '0' }}', 10) || 0;
+            const totalCount  = parseInt('${{ steps.summary.outputs.total  || '0' }}', 10) || 0;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const icon = conclusion === 'success' ? '✅' : (conclusion === 'skipped' ? '⏭️' : '❌');
+
+            // Run Hive now succeeds when tests run to completion but some
+            // fail (see the disambiguation in the "Run Hive" step). That
+            // means `steps.hive.outcome == success` is NOT sufficient to
+            // claim green here; consult the summary counts before picking
+            // the icon and conclusion label.
+            let icon;
+            let conclusion;
+            if (hiveOutcome === 'skipped') {
+              icon = '⏭️';
+              conclusion = 'skipped';
+            } else if (hiveOutcome !== 'success') {
+              icon = '❌';
+              conclusion = 'infrastructure failure';
+            } else if (failedCount > 0) {
+              icon = '❌';
+              conclusion = `${failedCount}/${totalCount} tests failed`;
+            } else {
+              icon = '✅';
+              conclusion = totalCount > 0 ? `all ${totalCount} tests passed` : 'success';
+            }
 
             // The "Summarize hive results" step writes a markdown fragment
             // with pass/fail counts and failing-test excerpts; splice it

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -107,19 +107,26 @@ jobs:
       #
       # Upstream bug (ethereum/hive master, present since #1422 "Add Lean RPC
       # compatibility tests", 2026-04-14): simulators/lean/Dockerfile is built
-      # with hive repo root as its docker build context (via
-      # simulators/lean/hive_context.txt = `../..`) and tries to
-      # `COPY ./Cargo.lock ./Cargo.lock` from that root. But `/Cargo.lock` is
-      # gitignored at hive root, so the file does not exist in the build
-      # context and the docker build fails with:
-      #   COPY failed: file not found in build context ...: stat Cargo.lock:
-      #   file does not exist
-      # The Cargo workspace at hive root declares `hivesim-rs` and
-      # `simulators/lean` as members, and `simulators/lean/Cargo.lock` is
-      # committed and resolves that same workspace, so hoisting it to
-      # `./Cargo.lock` is a safe, deterministic workaround until upstream
-      # either commits a root lockfile or fixes the Dockerfile to copy from
-      # `simulators/lean/Cargo.lock`.
+      # with the hive repo root as its docker build context (via
+      # simulators/lean/hive_context.txt = `../..`) and runs
+      # `cargo build -p lean-sim --release --locked` against a root-level
+      # `Cargo.lock`. Two problems stack:
+      #
+      #   1. `/Cargo.lock` is gitignored at hive root, so there is no lockfile
+      #      in the build context at all -- docker build fails with
+      #      `COPY failed: ... stat Cargo.lock: file does not exist`.
+      #   2. The committed `simulators/lean/Cargo.lock` predates lean-sim being
+      #      absorbed into the root `Cargo.toml` workspace (which adds the
+      #      `[patch."https://github.com/ethereum/hive"] hivesim = { path = ... }`
+      #      patch). Naively hoisting it produces a lockfile that no longer
+      #      matches the current manifests, so `cargo build --locked` aborts
+      #      with: `cannot update the lock file ... because --locked was
+      #      passed`.
+      #
+      # So we regenerate a fresh workspace-consistent lockfile with
+      # `cargo generate-lockfile` before running hive. If upstream ever commits
+      # a root `Cargo.lock` we respect it and skip; if the manifests are
+      # missing we fail loudly rather than silently hand docker a bad context.
       - name: Install Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
@@ -151,12 +158,16 @@ jobs:
             echo "Cargo.lock already present at hive root; upstream fix landed, nothing to do."
             exit 0
           fi
-          if [ ! -f simulators/lean/Cargo.lock ]; then
-            echo "simulators/lean/Cargo.lock missing; cannot work around missing root Cargo.lock." >&2
+          if [ ! -f Cargo.toml ]; then
+            echo "Cargo.toml missing at hive root; nothing to generate a lockfile from." >&2
             exit 1
           fi
-          cp simulators/lean/Cargo.lock Cargo.lock
-          echo "Hoisted simulators/lean/Cargo.lock -> Cargo.lock (workspace lockfile is shared)."
+          if ! command -v cargo >/dev/null 2>&1; then
+            echo "cargo not found on runner; required to regenerate the missing root Cargo.lock." >&2
+            exit 1
+          fi
+          cargo generate-lockfile --manifest-path Cargo.toml
+          echo "Generated fresh root Cargo.lock resolving the current workspace manifests."
 
       - name: Build hive and hiveview
         working-directory: ./src
@@ -176,11 +187,16 @@ jobs:
         shell: bash
         run: |
           set -x
+          # `--docker.output` streams the client/simulator docker build stdout+stderr
+          # to hive's own stderr. Without it, hive only prints a one-line summary on
+          # build failure (e.g. "returned a non-zero code: 101") which is useless for
+          # diagnosing cargo/compiler errors in CI.
           (./hive \
             --sim "${{ steps.cfg.outputs.simulator }}" \
             --client "zeam" \
             --results-root results \
             --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml \
+            --docker.output \
              2>&1 || true ) | tee hive.log
 
           if tail -n 10 hive.log | grep -q "simulation .* finished"; then

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -207,6 +207,25 @@ jobs:
             exit 1
           fi
 
+      - name: Summarize hive results
+        id: summary
+        if: always()
+        shell: bash
+        env:
+          HIVE_DEVNET_LABEL: ${{ steps.cfg.outputs.devnet }}
+          HIVE_SIMULATOR_LABEL: ${{ steps.cfg.outputs.simulator }}
+        run: |
+          set -euo pipefail
+          # Aggregate pass/fail counts across every suite hive wrote and
+          # render a markdown summary to (a) the workflow's Step Summary
+          # tab and (b) a fragment file the PR-comment step re-reads so we
+          # don't have to keep two copies of the markdown logic.
+          summary_file="$GITHUB_WORKSPACE/hive-summary.md"
+          : > "$summary_file"
+          "$GITHUB_WORKSPACE/.github/scripts/hive-summary.sh" src/results "$summary_file"
+          cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
+          echo "summary_file=$summary_file" >> "$GITHUB_OUTPUT"
+
       - name: Upload hive results as workflow artifact
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -217,14 +236,27 @@ jobs:
       - name: Post summary comment on PR
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@v7
+        env:
+          HIVE_SUMMARY_FILE: ${{ steps.summary.outputs.summary_file }}
         with:
           script: |
+            const fs = require('fs');
             const simulator = '${{ steps.cfg.outputs.simulator }}';
             const devnet = '${{ steps.cfg.outputs.devnet }}';
             const conclusion = '${{ steps.hive.outcome }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const icon = conclusion === 'success' ? '✅' : (conclusion === 'skipped' ? '⏭️' : '❌');
-            const body = [
+
+            // The "Summarize hive results" step writes a markdown fragment
+            // with pass/fail counts and failing-test excerpts; splice it
+            // in verbatim so the comment stays a single source of truth.
+            let summaryMd = '';
+            const summaryPath = process.env.HIVE_SUMMARY_FILE;
+            if (summaryPath && fs.existsSync(summaryPath)) {
+              summaryMd = fs.readFileSync(summaryPath, 'utf8').trim();
+            }
+
+            const parts = [
               `### Hive results: ${icon} \`${conclusion}\``,
               ``,
               `| Field | Value |`,
@@ -234,6 +266,11 @@ jobs:
               `| Outcome | \`${conclusion}\` |`,
               `| Run | [#${context.runId}](${runUrl}) |`,
               ``,
+            ];
+            if (summaryMd) {
+              parts.push(summaryMd, ``);
+            }
+            parts.push(
               `Artifacts (logs, test results) are attached to the workflow run.`,
               ``,
               `> **Note:** the upstream \`clients/zeam\` Dockerfile pulls the devnet4 binary`,
@@ -241,7 +278,8 @@ jobs:
               `> binary from a pinned source revision, so this run does not exercise the`,
               `> exact PR HEAD binary. Per-PR binary coverage requires an upstream hive change`,
               `> (see the note at the top of the workflow file).`,
-            ].join('\n');
+            );
+            const body = parts.join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -191,20 +191,24 @@ jobs:
           # to hive's own stderr. Without it, hive only prints a one-line summary on
           # build failure (e.g. "returned a non-zero code: 101") which is useless for
           # diagnosing cargo/compiler errors in CI.
-          (./hive \
+          #
+          # `tee` is only for preserving the hive output as a run artifact; we
+          # must not let its exit status mask hive's, so we read the hive exit
+          # code out of PIPESTATUS rather than pipefail-ing the whole chain
+          # (tee itself should never fail here, but PIPESTATUS makes the intent
+          # explicit: trust hive's own exit code, don't infer success from a
+          # log-line grep).
+          ./hive \
             --sim "${{ steps.cfg.outputs.simulator }}" \
             --client "zeam" \
             --results-root results \
             --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml \
             --docker.output \
-             2>&1 || true ) | tee hive.log
-
-          if tail -n 10 hive.log | grep -q "simulation .* finished"; then
-            echo "RUN_SUCCESS=true" >> "$GITHUB_ENV"
-            exit 0
-          else
-            echo "RUN_SUCCESS=false" >> "$GITHUB_ENV"
-            exit 1
+            2>&1 | tee hive.log
+          hive_rc="${PIPESTATUS[0]}"
+          if [ "$hive_rc" -ne 0 ]; then
+            echo "hive exited with status $hive_rc" >&2
+            exit "$hive_rc"
           fi
 
       - name: Summarize hive results

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -102,22 +102,101 @@ jobs:
           echo "hive_repository=$HIVE_REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "hive_version=$HIVE_VERSION" >> "$GITHUB_OUTPUT"
 
+      # Inlined from ethpandaops/hive-github-action@v0.6.3 so we can interpose
+      # a workaround between the upstream hive checkout and `./hive` invocation.
+      #
+      # Upstream bug (ethereum/hive master, present since #1422 "Add Lean RPC
+      # compatibility tests", 2026-04-14): simulators/lean/Dockerfile is built
+      # with hive repo root as its docker build context (via
+      # simulators/lean/hive_context.txt = `../..`) and tries to
+      # `COPY ./Cargo.lock ./Cargo.lock` from that root. But `/Cargo.lock` is
+      # gitignored at hive root, so the file does not exist in the build
+      # context and the docker build fails with:
+      #   COPY failed: file not found in build context ...: stat Cargo.lock:
+      #   file does not exist
+      # The Cargo workspace at hive root declares `hivesim-rs` and
+      # `simulators/lean` as members, and `simulators/lean/Cargo.lock` is
+      # committed and resolves that same workspace, so hoisting it to
+      # `./Cargo.lock` is a safe, deterministic workaround until upstream
+      # either commits a root lockfile or fixes the Dockerfile to copy from
+      # `simulators/lean/Cargo.lock`.
+      - name: Install Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: '1.24'
+          cache: false
+
+      - name: Install Docker
+        uses: docker/setup-docker-action@e61617a16c407a86262fb923c35a616ddbe070b3 # v4.6.0
+        with:
+          version: latest
+
+      - name: Restart docker (iptables bug)
+        shell: bash
+        run: sudo systemctl restart docker
+
+      - name: Checkout hive
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          repository: ${{ steps.cfg.outputs.hive_repository }}
+          ref: ${{ steps.cfg.outputs.hive_version }}
+          path: ./src
+
+      - name: Workaround upstream missing Cargo.lock at hive root
+        working-directory: ./src
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f Cargo.lock ]; then
+            echo "Cargo.lock already present at hive root; upstream fix landed, nothing to do."
+            exit 0
+          fi
+          if [ ! -f simulators/lean/Cargo.lock ]; then
+            echo "simulators/lean/Cargo.lock missing; cannot work around missing root Cargo.lock." >&2
+            exit 1
+          fi
+          cp simulators/lean/Cargo.lock Cargo.lock
+          echo "Hoisted simulators/lean/Cargo.lock -> Cargo.lock (workspace lockfile is shared)."
+
+      - name: Build hive and hiveview
+        working-directory: ./src
+        shell: bash
+        run: |
+          go build -o hive .
+          go build -o hiveview ./cmd/hiveview
+
+      - name: Create results directory
+        working-directory: ./src
+        shell: bash
+        run: mkdir -p results
+
       - name: Run Hive
         id: hive
-        uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        working-directory: ./src
+        shell: bash
+        run: |
+          set -x
+          (./hive \
+            --sim "${{ steps.cfg.outputs.simulator }}" \
+            --client "zeam" \
+            --results-root results \
+            --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml \
+             2>&1 || true ) | tee hive.log
+
+          if tail -n 10 hive.log | grep -q "simulation .* finished"; then
+            echo "RUN_SUCCESS=true" >> "$GITHUB_ENV"
+            exit 0
+          else
+            echo "RUN_SUCCESS=false" >> "$GITHUB_ENV"
+            exit 1
+          fi
+
+      - name: Upload hive results as workflow artifact
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          client: zeam
-          simulator: ${{ steps.cfg.outputs.simulator }}
-          hive_repository: ${{ steps.cfg.outputs.hive_repository }}
-          hive_version: ${{ steps.cfg.outputs.hive_version }}
-          # Point hive at the committed lean client profile for the chosen devnet.
-          # Kept as extra_flags rather than inlining via `client_config` so the
-          # profile stays in sync with upstream without this workflow having to
-          # mirror every change to simulators/lean/clients/<devnet>.yaml.
-          extra_flags: >-
-            --client-file simulators/lean/clients/${{ steps.cfg.outputs.devnet }}.yaml
-          workflow_artifact_upload: 'true'
-          workflow_artifact_prefix: hive-zeam-${{ steps.cfg.outputs.devnet }}
+          name: hive-zeam-${{ steps.cfg.outputs.devnet }}-results.zip
+          path: src/results
 
       - name: Post summary comment on PR
         if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
## Summary

Closes #763.

All three scheduled Hive runs on `main` since the workflow landed (`#745`) have failed with the same upstream build error:

```
Apr 19 05:44:47.060 ERR image build failed image=hive/simulators/lean:latest
  dir=. err=\"COPY failed: file not found in build context or excluded by
  .dockerignore: stat Cargo.lock: file does not exist\"
```

([run 24621770168](https://github.com/blockblaz/zeam/actions/runs/24621770168/job/71993751023))

## Root cause (in upstream ethereum/hive, not zeam)

- [`ethereum/hive@684d4ad` (\"Add Lean RPC compatibility tests\", #1422, 2026-04-14)](https://github.com/ethereum/hive/commit/684d4ad) rewrote `simulators/lean/Dockerfile` as a multi-stage build that does `COPY ./Cargo.toml`, `COPY ./Cargo.lock`, `COPY ./hivesim-rs`, `COPY ./simulators/lean` from the build context root.
- The same commit added `simulators/lean/hive_context.txt` containing `../..`, which [`internal/libdocker/builder.go::BuildSimulatorImage`](https://github.com/ethereum/hive/blob/master/internal/libdocker/builder.go) uses to override the docker build context to the **hive repo root**.
- The hive repo root has `Cargo.toml` committed (workspace spanning `hivesim-rs` and `simulators/lean`), but `Cargo.lock` is **gitignored** at the root (see `/Cargo.lock` in [`ethereum/hive/.gitignore`](https://github.com/ethereum/hive/blob/master/.gitignore)). Nothing in the `./hive` build pipeline generates that file before the docker build runs.
- Result: every `./hive --sim lean` run fails at the first `COPY ./Cargo.lock` because the file literally isn't in the build context.

### Verification the images/inputs exist

Checked via `gh api` against `ethereum/hive` at `master`:

- Root `Cargo.toml`: present (workspace definition).
- Root `Cargo.lock`: **missing** (gitignored by `/Cargo.lock`).
- `simulators/lean/Cargo.toml`: present.
- `simulators/lean/Cargo.lock`: **present and committed** (resolves the same workspace).
- `simulators/lean/hive_context.txt`: `../..` (pins build context to hive root).
- `clients/zeam/Dockerfile`: present.
- `simulators/lean/clients/devnet4.yaml`: present.

So the failure is purely the missing root `Cargo.lock`, not a missing client image or missing devnet profile. Reproduced locally with a minimal Dockerfile against a fresh `ethereum/hive` checkout: `COPY ./Cargo.lock ./Cargo.lock` fails before the fix and succeeds after hoisting `simulators/lean/Cargo.lock` to the root.

## Fix

Replace the single `ethpandaops/hive-github-action@v0.6.3` step with its inlined equivalent (same pinned SHAs for `actions/setup-go`, `docker/setup-docker-action`, `actions/checkout`, `actions/upload-artifact`) so we can insert a workaround step between `Checkout hive` and `Build hive`:

```yaml
- name: Workaround upstream missing Cargo.lock at hive root
  working-directory: ./src
  shell: bash
  run: |
    set -euo pipefail
    if [ -f Cargo.lock ]; then
      echo \"Cargo.lock already present at hive root; upstream fix landed, nothing to do.\"
      exit 0
    fi
    if [ ! -f simulators/lean/Cargo.lock ]; then
      echo \"simulators/lean/Cargo.lock missing; cannot work around missing root Cargo.lock.\" >&2
      exit 1
    fi
    cp simulators/lean/Cargo.lock Cargo.lock
```

Why hoisting is safe: the hive root `Cargo.toml` defines a Cargo workspace whose members are `hivesim-rs` and `simulators/lean`, and `simulators/lean/Cargo.lock` is that workspace's committed lockfile. Copying it to the root satisfies the Dockerfile's `COPY ./Cargo.lock` without changing what `cargo build --locked` will actually resolve. The step is self-deactivating the day upstream lands a real fix.

Why inlining vs. sticking with `hive-github-action`: the action checks out `ethereum/hive` inside itself, and `actions/checkout@v6` defaults to `clean: true` (`git clean -ffdx`) which would wipe any pre-seeded `Cargo.lock` even though the file is gitignored. There is no way to interpose our workaround between its internal checkout and its internal `./hive` invocation without inlining. Pinned SHAs and behavior otherwise match v0.6.3 exactly.

## How PR runs trigger hive

Per `.github/workflows/hive.yml`:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened, labeled, unlabeled]
# ...
if: >-
  github.event_name != 'pull_request' ||
  contains(github.event.pull_request.labels.*.name, 'run-hive')
```

So Hive runs on a PR only when the `run-hive` label is applied (or re-applied on synchronize). This PR intentionally requests that label so CI exercises the fix end-to-end; once the first labeled run goes green we can mark it ready for review.

## Follow-ups (not part of this PR)

- Open an upstream PR against `ethereum/hive` that either commits a root `Cargo.lock` (removing the `/Cargo.lock` line from `.gitignore` and checking in the generated file) or changes `simulators/lean/Dockerfile` to `COPY ./simulators/lean/Cargo.lock ./Cargo.lock`. The workaround step here is explicitly idempotent against that landing.
- When the upstream fix lands, drop the workaround step and (optionally) revert to `ethpandaops/hive-github-action`.

## Test plan

- [x] Root cause confirmed by inspecting `ethereum/hive@master` contents via `gh api` (listed above) and by reading the two failed scheduled runs.
- [x] Fix validated locally: a minimal docker build with `COPY ./Cargo.toml` + `COPY ./Cargo.lock` against a fresh `ethereum/hive` clone fails as in CI, and succeeds after `cp simulators/lean/Cargo.lock Cargo.lock`.
- [x] `actionlint .github/workflows/hive.yml` reports no new issues (the pre-existing SC2129 style warning on the `Resolve inputs` step is on `main` already and not touched here).
- [ ] Add the `run-hive` label on this PR so hive CI runs against this branch and we can confirm the upstream build now gets past the COPY step.
