### PR TITLE
fix: rpc-compat — correct health service name and finalized state staleness

### DIFF
--- a/pkgs/cli/src/api_server.zig
+++ b/pkgs/cli/src/api_server.zig
@@ -243,7 +243,7 @@ pub const ApiServer = struct {
 
     /// Handle health check endpoint
     fn handleHealth(_: *const Self, request: *std.http.Server.Request) void {
-        const response = "{\"status\":\"healthy\",\"service\":\"zeam-api\"}";
+        const response = "{\"status\":\"healthy\",\"service\":\"lean-rpc-api\"}";
         _ = request.respond(response, .{
             .extra_headers = &.{
                 .{ .name = "content-type", .value = "application/json; charset=utf-8" },

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -1222,30 +1222,6 @@ pub const BeamChain = struct {
         // 3. commit all batch ops for finalized indices before we prune
         self.db.commit(&batch);
 
-        // 3b. Update cached_finalized_state so /lean/v0/states/finalized returns the
-        // freshest finalized state. We do this before pruning so the state at
-        // latestFinalized.root is still in self.states. The previous cache entry (if
-        // any) is freed and replaced by a clone of the new finalized state.
-        if (self.states.get(latestFinalized.root)) |new_finalized_state| {
-            if (self.cached_finalized_state) |old| {
-                old.deinit();
-                self.allocator.destroy(old);
-            }
-            self.cached_finalized_state = null;
-            const cloned = self.allocator.create(types.BeamState) catch |err| blk: {
-                self.logger.warn("could not allocate cached_finalized_state clone at slot {d}: {any}", .{ latestFinalized.slot, err });
-                break :blk null;
-            };
-            if (cloned) |ptr| {
-                types.sszClone(self.allocator, types.BeamState, new_finalized_state.*, ptr) catch |err| {
-                    self.logger.warn("could not clone finalized state at slot {d}: {any}", .{ latestFinalized.slot, err });
-                    self.allocator.destroy(ptr);
-                };
-                self.cached_finalized_state = ptr;
-                self.logger.debug("cached_finalized_state updated to slot {d}", .{latestFinalized.slot});
-            }
-        }
-
         // 4. Prunestates from memory
         // Get all canonical blocks from finalized to head (not just newly finalized)
         const states_count_before: isize = self.states.count();

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -1222,6 +1222,30 @@ pub const BeamChain = struct {
         // 3. commit all batch ops for finalized indices before we prune
         self.db.commit(&batch);
 
+        // 3b. Update cached_finalized_state so /lean/v0/states/finalized returns the
+        // freshest finalized state. We do this before pruning so the state at
+        // latestFinalized.root is still in self.states. The previous cache entry (if
+        // any) is freed and replaced by a clone of the new finalized state.
+        if (self.states.get(latestFinalized.root)) |new_finalized_state| {
+            if (self.cached_finalized_state) |old| {
+                old.deinit();
+                self.allocator.destroy(old);
+            }
+            self.cached_finalized_state = null;
+            const cloned = self.allocator.create(types.BeamState) catch |err| blk: {
+                self.logger.warn("could not allocate cached_finalized_state clone at slot {d}: {any}", .{ latestFinalized.slot, err });
+                break :blk null;
+            };
+            if (cloned) |ptr| {
+                types.sszClone(self.allocator, types.BeamState, new_finalized_state.*, ptr) catch |err| {
+                    self.logger.warn("could not clone finalized state at slot {d}: {any}", .{ latestFinalized.slot, err });
+                    self.allocator.destroy(ptr);
+                };
+                self.cached_finalized_state = ptr;
+                self.logger.debug("cached_finalized_state updated to slot {d}", .{latestFinalized.slot});
+            }
+        }
+
         // 4. Prunestates from memory
         // Get all canonical blocks from finalized to head (not just newly finalized)
         const states_count_before: isize = self.states.count();
@@ -1592,9 +1616,14 @@ pub const BeamChain = struct {
             return state;
         }
 
-        // Check if we already have a cached state from DB
+        // Check if we already have a cached state. Invalidate if it's behind the
+        // current finalized checkpoint (can happen if the cache was seeded from the
+        // DB at startup before any in-memory finalization happened).
         if (self.cached_finalized_state) |cached_state| {
-            return cached_state;
+            if (std.mem.eql(u8, &cached_state.latest_finalized.root, &finalized_checkpoint.root)) {
+                return cached_state;
+            }
+            // Stale — fall through to DB load below.
         }
 
         // Fallback: try to load from database


### PR DESCRIPTION
Fixes two failures from the hive `rpc-compat` simulator.

## Fix 1 — Health endpoint service name

```
assertion: health endpoint returned an unexpected service name
left: "zeam-api"  right: "lean-rpc-api"
```

One-liner: change the static service name in `handleHealth` from `"zeam-api"` to `"lean-rpc-api"`.

## Fix 2 — Finalized state endpoint returns stale `latest_finalized` slot

```
assertion: finalized state endpoint should expose client's latest
finalized slot through the embedded latest_finalized checkpoint
left: 8  right: 11
```

**Root cause:** `getFinalizedState()` has a three-level fallback:
1. `self.states` map (by finalized checkpoint root)
2. `self.cached_finalized_state` ← only seeded from DB at startup, never updated
3. DB load (`loadLatestFinalizedState`)

After finalization advances from slot 8 → slot 11, the state at slot 11 is briefly in `self.states` but then pruned as a finalized ancestor in the *next* round. `cached_finalized_state` was never refreshed, so `getFinalizedState` fell through to the stale DB seed (slot 8).

**Fix 1** (`processFinalizationAdvancement`): before pruning ancestors, clone the state at `latestFinalized.root` from `self.states` into `cached_finalized_state`. Old entry is freed.

**Fix 2** (`getFinalizedState`): compare `cached_finalized_state.latest_finalized.root` against the current finalized checkpoint root; if stale, fall through to DB rather than serving old data.

`zig build` passes ✅, `zig fmt` clean ✅