### PR TITLE
ci(hive): document shared-client scenario reuse from ethereum/hive#1435

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -13,6 +13,25 @@
 #   - Simulator:          simulators/lean
 #   - Client profiles:    simulators/lean/clients/{devnet3,devnet4}.yaml
 #
+# Shared-client scenarios (upstream ethereum/hive#1435, merged 2026-04-21):
+#   The lean simulator's 13 finalized-state `rpc_compat: state ssz decodes *`
+#   scenarios now share a single zeam container via `SharedClientTestSpec`
+#   instead of booting one container per scenario. We inherit this for free
+#   by tracking `hive_version: master` (see `Checkout hive` step below) --
+#   no zeam-side flag toggles it; the reuse is a per-scenario decision made
+#   inside `simulators/lean/src/scenarios/rpc_compat.rs`. Per-scenario
+#   pass/fail is still reported individually in hiveview and in the summary
+#   comment, so the reduction shows up only as fewer `client zeam started`
+#   events in `hive.log`, not as a smaller test count.
+#
+#   Scenarios that need a fresh client (e.g. the `slot == 0` assertions)
+#   deliberately keep their own container via `NClientTestSpec`, so the
+#   total zeam boots per suite is (# non-shared scenarios) + 1, not 1.
+#
+#   If upstream ever regresses this we'll see it as a jump in wall-clock
+#   time on the scheduled run (zeam devnet4 boots take ~30-60s each); pin
+#   `hive_version` to `dc78759` or later in that case.
+#
 # Known limitation (tracked for follow-up, not this PR):
 #   The upstream zeam Dockerfile in ethereum/hive selects the devnet3 binary
 #   from a pinned source revision (build arg `zeam_devnet3_revision`) and the


### PR DESCRIPTION
## Summary

ethereum/hive#1435 merged on 2026-04-21. It adds \`SharedClientTestSpec\`
to \`hivesim-rs\` and switches the lean simulator's 13 finalized-state
\`rpc_compat: state ssz decodes *\` scenarios to share a single client
container instead of booting one per scenario.

Our CI already tracks \`hive_version: master\`, so the reuse is active
on the next scheduled run with no functional change needed on our side.
This PR just documents that in the workflow header so the behavior
change isn't invisible.

## What changed

- Header comment in \`.github/workflows/hive.yml\` only.
- Explains the reuse, where it is decided (inside the lean sim, not
  our workflow), what the expected fallback pin is if upstream
  regresses (\`dc78759\` or later), and why total zeam boots per suite
  is still \`(# non-shared scenarios) + 1\`, not \`1\`.

## Result

Scheduled run wall-clock should drop noticeably for the shared-client
cluster (13 container boots → 1). zeam devnet4 boots are ~30-60s each,
so the cluster goes from ~6-13 minutes to ~30-60s. Per-scenario pass/
fail is still reported individually in hiveview and the PR summary
comment.

## Test plan

- [ ] Wait for the next scheduled hive run (or flip the \`run-hive\`
      label on this PR to trigger one) and check \`hive.log\` for a
      single \`client zeam_devnet4 started\` event in the shared-client
      cluster, plus \`multi-test node registered\` events for each of
      the 13 scenarios.
- [ ] Confirm the suite JSON still reports 13 distinct rpc_compat
      state-decode rows, not one aggregated row.