### PR TITLE
fix: treat block_cache miss as stale in justifications cleanup

### DIFF
--- a/pkgs/types/src/state.zig
+++ b/pkgs/types/src/state.zig
@@ -516,8 +516,22 @@ pub const BeamState = struct {
                         var iter = justifications.iterator();
                         while (iter.next()) |entry| {
                             const root = entry.key_ptr.*;
-                            const slot = block_cache.get(root) orelse return StateTransitionError.InvalidJustificationRoot;
-                            if (slot <= finalized_slot) {
+                            // A miss in `block_cache` for a root that's still in
+                            // `state.justifications` is not an error — it's the
+                            // expected outcome once finalization has advanced past
+                            // the root's slot. `RootToSlotCache.prune` removes
+                            // entries with `slot <= (some prior finalized_slot)`
+                            // and finalization is monotonic, so a miss always
+                            // implies `slot <= finalized_slot` now. Treat it
+                            // identically to the explicit `<=` branch and drop
+                            // the root. Returning `InvalidJustificationRoot` here
+                            // wedges both the block-import path and the slot-tick
+                            // path until checkpoint-sync restart (see #771).
+                            const is_stale = if (block_cache.get(root)) |slot|
+                                slot <= finalized_slot
+                            else
+                                true;
+                            if (is_stale) {
                                 try roots_to_remove.append(allocator, root);
                             }
                         }
@@ -1064,6 +1078,127 @@ test "pruning keeps pending justifications" {
         }
     }
     try std.testing.expect(found);
+}
+
+test "process_attestations drops pending justifications missing from block_cache" {
+    // Regression for #771. State carries a pending-justification root whose
+    // block lives at a slot not covered by `block_cache`. Finalization
+    // advances during this call and the cleanup loop must drop the root,
+    // not abort the whole STF with InvalidJustificationRoot.
+    //
+    // Production trigger: the chain-owned RootToSlotCache has been pruned to
+    // some earlier finalized slot, so the lookup misses for any
+    // state.justifications root at or before that slot. Pre-fix behaviour
+    // wedged the node because the same pre-state -> same miss -> same error
+    // on every retry and every slot-tick-driven STF run.
+    //
+    // Test repro: use the null-cache fallback, which populates
+    // owned_cache only from latest_finalized.slot+1 onwards. Seeding
+    // state.justifications_roots with the genesis root (slot 0) puts it
+    // outside that window, so the cache lookup misses during cleanup.
+    var logger_config = zeam_utils.getTestLoggerConfig();
+    const logger = logger_config.logger(null);
+    var state = try makeGenesisState(std.testing.allocator, 3);
+    defer state.deinit();
+
+    // Phase 1: justify slot 1 so the later src=slot 1 attestation is accepted.
+    try state.process_slots(std.testing.allocator, 1, logger);
+    var block_1 = try makeBlock(std.testing.allocator, &state, state.slot, &[_]attestation.AggregatedAttestation{});
+    defer block_1.deinit();
+    try state.process_block(std.testing.allocator, block_1, logger, null);
+
+    try state.process_slots(std.testing.allocator, 2, logger);
+    var block_2_parent_root: Root = undefined;
+    try zeam_utils.hashTreeRoot(block.BeamBlockHeader, state.latest_block_header, &block_2_parent_root, std.testing.allocator);
+
+    var att_0_to_1 = try makeAggregatedAttestation(
+        std.testing.allocator,
+        &[_]usize{ 0, 1 },
+        state.slot,
+        .{ .root = block_1.parent_root, .slot = 0 },
+        .{ .root = block_2_parent_root, .slot = 1 },
+    );
+    var att_0_to_1_transferred = false;
+    defer if (!att_0_to_1_transferred) att_0_to_1.deinit();
+
+    var block_2 = try makeBlock(std.testing.allocator, &state, state.slot, &[_]attestation.AggregatedAttestation{att_0_to_1});
+    att_0_to_1_transferred = true;
+    defer block_2.deinit();
+    try state.process_block(std.testing.allocator, block_2, logger, null);
+
+    try std.testing.expectEqual(@as(Slot, 0), state.latest_finalized.slot);
+    try std.testing.expectEqual(@as(Slot, 1), state.latest_justified.slot);
+
+    // Phase 2: extend the chain so historical_block_hashes and justified_slots
+    // are long enough for the forthcoming src=1 tgt=2 attestation.
+    try state.process_slots(std.testing.allocator, 3, logger);
+    var block_3 = try makeBlock(std.testing.allocator, &state, state.slot, &[_]attestation.AggregatedAttestation{});
+    defer block_3.deinit();
+    try state.process_block(std.testing.allocator, block_3, logger, null);
+
+    try state.process_slots(std.testing.allocator, 4, logger);
+    var block_4 = try makeBlock(std.testing.allocator, &state, state.slot, &[_]attestation.AggregatedAttestation{});
+    defer block_4.deinit();
+    try state.process_block_header(std.testing.allocator, block_4, logger);
+
+    // Phase 3: seed state.justifications_roots with the genesis root. Its
+    // slot (0) is <= latest_finalized.slot (also 0), which is the range
+    // initRootToSlotCache explicitly skips, so the STF's owned cache does
+    // not contain it.
+    const genesis_root = try state.historical_block_hashes.get(0);
+
+    var pending_roots = try JustificationRoots.init(std.testing.allocator);
+    errdefer pending_roots.deinit();
+    try pending_roots.append(genesis_root);
+
+    var pending_validators = try JustificationValidators.init(std.testing.allocator);
+    errdefer pending_validators.deinit();
+    try pending_validators.append(true);
+    try pending_validators.append(false);
+    try pending_validators.append(false);
+
+    state.justifications_roots.deinit();
+    state.justifications_roots = pending_roots;
+    state.justifications_validators.deinit();
+    state.justifications_validators = pending_validators;
+
+    // Phase 4: drive finalization from slot 0 to slot 1. src=slot 1, tgt=slot
+    // 2, empty [src+1, tgt) window => can_target_finalize holds, so
+    // latest_finalized advances and the cleanup loop runs.
+    const source_1_root = try state.historical_block_hashes.get(1);
+    const slot_2_root = try state.historical_block_hashes.get(2);
+    var att_1_to_2 = try makeAggregatedAttestation(
+        std.testing.allocator,
+        &[_]usize{ 0, 1 },
+        state.slot,
+        .{ .root = source_1_root, .slot = 1 },
+        .{ .root = slot_2_root, .slot = 2 },
+    );
+    var att_1_to_2_transferred = false;
+    defer if (!att_1_to_2_transferred) att_1_to_2.deinit();
+
+    var attestations_list = try block.AggregatedAttestations.init(std.testing.allocator);
+    defer {
+        for (attestations_list.slice()) |*att| {
+            att.deinit();
+        }
+        attestations_list.deinit();
+    }
+    try attestations_list.append(att_1_to_2);
+    att_1_to_2_transferred = true;
+
+    // Pre-fix: returned StateTransitionError.InvalidJustificationRoot because
+    // the cleanup loop looked up genesis_root in a cache that only covers
+    // slot > latest_finalized. Post-fix: the miss is treated as "stale, drop"
+    // and the STF completes normally.
+    try state.process_attestations(std.testing.allocator, attestations_list, logger, null);
+
+    try std.testing.expectEqual(@as(Slot, 1), state.latest_finalized.slot);
+    try std.testing.expectEqual(@as(Slot, 2), state.latest_justified.slot);
+
+    for (state.justifications_roots.constSlice()) |root| {
+        try std.testing.expect(!std.mem.eql(u8, &root, &genesis_root));
+    }
 }
 
 test "root_to_slot_cache lifecycle" {

--- a/pkgs/types/src/state.zig
+++ b/pkgs/types/src/state.zig
@@ -517,20 +517,29 @@ pub const BeamState = struct {
                         while (iter.next()) |entry| {
                             const root = entry.key_ptr.*;
                             // A miss in `block_cache` for a root that's still in
-                            // `state.justifications` is not an error — it's the
-                            // expected outcome once finalization has advanced past
-                            // the root's slot. `RootToSlotCache.prune` removes
-                            // entries with `slot <= (some prior finalized_slot)`
-                            // and finalization is monotonic, so a miss always
-                            // implies `slot <= finalized_slot` now. Treat it
-                            // identically to the explicit `<=` branch and drop
-                            // the root. Returning `InvalidJustificationRoot` here
-                            // wedges both the block-import path and the slot-tick
-                            // path until checkpoint-sync restart (see #771).
+                            // `state.justifications` has two possible causes:
+                            //   1. `RootToSlotCache.prune` evicted it. That only
+                            //      removes entries with `slot <= (some prior
+                            //      finalized_slot)` and finalization advances
+                            //      monotonically, so `slot <= finalized_slot` now.
+                            //   2. The block was re-orged or never fully imported,
+                            //      so we have no slot info at all. `slot` could be
+                            //      anything, but the drop is still correct — we
+                            //      can't finalize a root we don't have.
+                            // Either way, treat the miss identically to the
+                            // explicit `<=` branch and drop the root. Returning
+                            // `InvalidJustificationRoot` here wedges both the
+                            // block-import path and the slot-tick path until
+                            // checkpoint-sync restart (see #771).
                             const is_stale = if (block_cache.get(root)) |slot|
                                 slot <= finalized_slot
-                            else
-                                true;
+                            else blk: {
+                                logger.debug(
+                                    "dropping stale justification root=0x{x}: not in block_cache (finalized_slot={d})",
+                                    .{ &root, finalized_slot },
+                                );
+                                break :blk true;
+                            };
                             if (is_stale) {
                                 try roots_to_remove.append(allocator, root);
                             }


### PR DESCRIPTION
Fixes #771.

The post-finalization prune loop in `processAttestations` looked each pending-justification root up in `block_cache` and hard-errored with `StateTransitionError.InvalidJustificationRoot` on a miss. Once the **chain-owned** cache was pruned past any root still sitting in a cached per-state `justifications_roots` map, the miss became permanent: the same pre-state re-failed on every block retry and every slot-tick-driven STF run — wedging the node until checkpoint-sync restart.

## Why the miss is actually reachable

See [#771 follow-up comment](https://github.com/blockblaz/zeam/issues/771#issuecomment-4296405621) for the full timeline. Short version: the global `root_to_slot_cache` is pruned against **chain-wide** `latestFinalized.slot`, but cached `BeamState.justifications_roots` are pinned to the **per-state** `latest_finalized.slot`, which is frozen at import time. When a cross-fork reorg advances chain-wide finality past a reachable cached state's own finalized slot, that state's `justifications_roots` can reference roots the global cache has just evicted.

On devnet-4 this happened at `06:56:29.535`: importing a late-arriving competing block at slot 267 advanced `latestFinalized` 171→252 and triggered `prune(252)`. Fork-choice then swung back to `92a7(268)` (whose post-state still had `latest_finalized=171`), and the next block on top of it (`b4bd9e5f(269)`) hit this loop with a root in `(171, 252]` that was no longer in the cache.

## Fix (this PR — narrow hotfix)

`RootToSlotCache.prune(F)` removes exactly the entries with `slot <= F`. So a miss either means the root was once in the cache and has since been pruned (⇒ pre-finalization ⇒ same outcome as the explicit `<=` branch — drop it) or it was never populated for a root that nonetheless lives in `state.historical_block_hashes` (no slot info to finalize against — drop is still the only safe action). In both cases: treat the miss identically to the `<=` branch, drop the root, continue.

This is option (1) from the issue — minimal, stays inside `state.zig`, no changes to state shape, SSZ types, or the chain-layer prune policy. Sufficient to unwedge this class of stall.

## Out of scope (follow-ups)

Captured in the #771 follow-up comment, not addressed here:

- **Structural coherence fix (preferred follow-up).** Evict cached states whose `latest_finalized.slot < chain latestFinalized.slot` when `onFinalization` fires. Makes the missed-lookup path unreachable in practice and tightens memory. Cleaner than widening the prune floor.
- **Slot-tick resilience.** A hard STF error on block import should reject the block, not freeze forkchoice/time (option 4 in the issue, same "STF error wedges tick" pattern as #749).
- **Observability.** The pre-fix error site didn't log the offending root or either finalized_slot. This PR adds a `logger.debug` in the drop path; an `err`-level log with `root`/`state_finalized`/`new_finalized` on any future hard-failure branches would make repeats trivial to diagnose.

## Scope

Deliberately narrow:

- no changes to `state.justifications_roots` / `justifications_validators` shape
- no changes to `pruneCachedBlocksCallback` or `RootToSlotCache`
- no changes to the forkchoice/tick loop

## Test plan

- [x] `zig fmt --check .`
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings`
- [x] `zig build test --summary all` — 19 tests pass in `pkgs/types/src/lib.zig` (was 18, +1 regression)
- [x] `zig build simtest --summary all`
- [x] New regression test `process_attestations drops pending justifications missing from block_cache` fails against the unpatched cleanup loop with `InvalidJustificationRoot` (verified by locally reverting just the src change), passes with the fix.