### PR TITLE
ci: pin rust nightly to 2026-04-20

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -165,7 +165,8 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly
+        # Pinned to match ci.yml — see workaround note there.
+        toolchain: nightly-2026-04-20
 
     - name: Cache Zig packages
       uses: actions/cache@v4

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -166,7 +166,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         # Pinned to match ci.yml — see workaround note there.
-        toolchain: nightly-2026-04-20
+        toolchain: nightly-2026-04-21
 
     - name: Cache Zig packages
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,12 @@ concurrency:
 
 name: CI
 
-# NOTE: Rust nightly is pinned to 2026-04-20 across all jobs as a workaround for
-# a regression introduced in nightly-2026-04-21 that causes duplicate-symbol link
-# errors for `__rustc*__rust_{alloc,dealloc,realloc,alloc_zeroed}` when Zig links
+# NOTE: Rust nightly is pinned to nightly-2026-04-21 (which publishes the
+# 2026-04-20 build) across all jobs as a workaround for a regression that
+# causes duplicate-symbol link errors for
+# `__rustc*__rust_{alloc,dealloc,realloc,alloc_zeroed}` when Zig links
 # multiple Rust static libraries together (build-all-provers on macos-latest).
+# `nightly-2026-04-20` resolves to the 2026-04-19 build, which also fails.
 # Track removal in the linked tracking issue; revert to `nightly` once upstream
 # nightly no longer emits conflicting allocator shims in static-lib output.
 
@@ -107,7 +109,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2026-04-20
+        toolchain: nightly-2026-04-21
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -178,7 +180,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2026-04-20
+        toolchain: nightly-2026-04-21
         components: clippy, rustfmt
 
     - name: Cache Zig packages
@@ -259,7 +261,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2026-04-20
+        toolchain: nightly-2026-04-21
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -359,7 +361,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2026-04-20
+        toolchain: nightly-2026-04-21
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -431,7 +433,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly-2026-04-20
+        toolchain: nightly-2026-04-21
 
     - name: Cache Zig packages
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ concurrency:
 
 name: CI
 
+# NOTE: Rust nightly is pinned to 2026-04-20 across all jobs as a workaround for
+# a regression introduced in nightly-2026-04-21 that causes duplicate-symbol link
+# errors for `__rustc*__rust_{alloc,dealloc,realloc,alloc_zeroed}` when Zig links
+# multiple Rust static libraries together (build-all-provers on macos-latest).
+# Track removal in the linked tracking issue; revert to `nightly` once upstream
+# nightly no longer emits conflicting allocator shims in static-lib output.
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -100,7 +107,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2026-04-20
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -171,7 +178,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2026-04-20
         components: clippy, rustfmt
 
     - name: Cache Zig packages
@@ -252,7 +259,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2026-04-20
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -352,7 +359,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2026-04-20
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -424,7 +431,7 @@ jobs:
     - name: Set up Rust/Cargo
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2026-04-20
 
     - name: Cache Zig packages
       uses: actions/cache@v4


### PR DESCRIPTION
Workaround for #773.

Nightly 2026-04-21 emits per-rlib allocator shims that `ld64` won't coalesce, so `build-all-provers (macos-latest)` fails with `duplicate symbol definition: __rustc*__rust_{alloc,dealloc,realloc,alloc_zeroed}` whenever Zig links multiple prover staticlibs together. Nightly 2026-04-20 is the last revision where this works.

Pinning every `toolchain: nightly` site (5 in `ci.yml`, 1 in `auto-release.yml`) to `nightly-2026-04-20`. Stable and `risc0.yml` untouched.

Draft because this is a hold-your-nose workaround, not the fix. The long-term options and acceptance criteria live in #773; unpin when one of them lands.

## Test plan

- [ ] `build-all-provers (macos-latest)` green on this PR
- [ ] `build-all-provers (ubuntu-latest)` still green
- [ ] All other Rust-touching jobs still green (lint, test, Dummy prove, etc.)