### PR TITLE
build, rust: funnel prover glue crates through a single staticlib shim

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,36 +31,22 @@ fn setTestRunLabelFromCompile(b: *Builder, run_step: *std.Build.Step.Run, compil
     setTestRunLabel(b, run_step, source_name);
 }
 
-// Add the glue libs to a compile target
+// Add the glue libs to a compile target.
+//
+// Every per-prover Rust crate is funnelled through a single `zeam-glue`
+// `staticlib` shim so that Rust's allocator shim
+// (`__rust_alloc`, `__rust_dealloc`, `__rust_realloc`, `__rust_alloc_zeroed`)
+// is emitted exactly once. When multiple Rust staticlibs were linked together
+// directly, `ld64` on macOS rejected the duplicate strong definitions and the
+// `build-all-provers` job broke on any fresh (cache-miss) rebuild.
+// See blockblaz/zeam#773.
 fn addRustGlueLib(b: *Builder, comp: *Builder.Step.Compile, target: Builder.ResolvedTarget, prover: ProverChoice) void {
-    // Conditionally include prover libraries based on selection
-    // Use profile-specific directories for single-prover builds
-    switch (prover) {
-        .dummy => {
-            comp.addObjectFile(b.path("rust/target/release/libhashsig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/release/libmultisig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/release/liblibp2p_glue.a"));
-        },
-        .risc0 => {
-            comp.addObjectFile(b.path("rust/target/risc0-release/librisc0_glue.a"));
-            comp.addObjectFile(b.path("rust/target/risc0-release/libhashsig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/risc0-release/libmultisig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/risc0-release/liblibp2p_glue.a"));
-        },
-        .openvm => {
-            comp.addObjectFile(b.path("rust/target/openvm-release/libopenvm_glue.a"));
-            comp.addObjectFile(b.path("rust/target/openvm-release/libhashsig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/openvm-release/libmultisig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/openvm-release/liblibp2p_glue.a"));
-        },
-        .all => {
-            comp.addObjectFile(b.path("rust/target/release/librisc0_glue.a"));
-            comp.addObjectFile(b.path("rust/target/release/libopenvm_glue.a"));
-            comp.addObjectFile(b.path("rust/target/release/libhashsig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/release/libmultisig_glue.a"));
-            comp.addObjectFile(b.path("rust/target/release/liblibp2p_glue.a"));
-        },
-    }
+    const glue_path = switch (prover) {
+        .dummy, .all => "rust/target/release/libzeam_glue.a",
+        .risc0 => "rust/target/risc0-release/libzeam_glue.a",
+        .openvm => "rust/target/openvm-release/libzeam_glue.a",
+    };
+    comp.addObjectFile(b.path(glue_path));
     comp.linkLibC();
     comp.linkSystemLibrary("unwind");
     if (target.result.os.tag == .macos) {
@@ -700,27 +686,33 @@ fn setSpectestArgsAndEnv(
 }
 
 fn build_rust_project(b: *Builder, path: []const u8, prover: ProverChoice) *Builder.Step.Run {
-    // Build only the selected prover crates
-    // Use optimized profiles for single-prover builds to reduce binary size
+    // Every Rust glue crate is routed through the `zeam-glue` staticlib shim;
+    // feature flags control which per-prover rlibs get linked in. See the
+    // comment on `addRustGlueLib` and blockblaz/zeam#773.
     const cargo_build = switch (prover) {
         .dummy => b.addSystemCommand(&.{
-            "cargo", "+nightly",      "-C", path,          "-Z", "unstable-options",
-            "build", "--release",     "-p", "libp2p-glue", "-p", "hashsig-glue",
-            "-p",    "multisig-glue",
+            "cargo",                   "+nightly",         "-C",                    path,
+            "-Z",                      "unstable-options", "build",                 "--release",
+            "-p",                      "zeam-glue",        "--no-default-features", "--features",
+            "libp2p,hashsig,multisig",
         }),
         .risc0 => b.addSystemCommand(&.{
-            "cargo",      "+nightly",  "-C",            path, "-Z",            "unstable-options",
-            "build",      "--profile", "risc0-release", "-p", "libp2p-glue",   "-p",
-            "risc0-glue", "-p",        "hashsig-glue",  "-p", "multisig-glue",
+            "cargo",         "+nightly",                      "-C",        path,
+            "-Z",            "unstable-options",              "build",     "--profile",
+            "risc0-release", "-p",                            "zeam-glue", "--no-default-features",
+            "--features",    "libp2p,hashsig,multisig,risc0",
         }),
         .openvm => b.addSystemCommand(&.{
-            "cargo",       "+nightly",  "-C",             path, "-Z",            "unstable-options",
-            "build",       "--profile", "openvm-release", "-p", "libp2p-glue",   "-p",
-            "openvm-glue", "-p",        "hashsig-glue",   "-p", "multisig-glue",
+            "cargo",          "+nightly",                       "-C",        path,
+            "-Z",             "unstable-options",               "build",     "--profile",
+            "openvm-release", "-p",                             "zeam-glue", "--no-default-features",
+            "--features",     "libp2p,hashsig,multisig,openvm",
         }),
         .all => b.addSystemCommand(&.{
-            "cargo", "+nightly",  "-C",    path, "-Z", "unstable-options",
-            "build", "--release", "--all",
+            "cargo",                                "+nightly",         "-C",                    path,
+            "-Z",                                   "unstable-options", "build",                 "--release",
+            "-p",                                   "zeam-glue",        "--no-default-features", "--features",
+            "libp2p,hashsig,multisig,risc0,openvm",
         }),
     };
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9188,6 +9188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeam-glue"
+version = "0.1.0"
+dependencies = [
+ "hashsig-glue",
+ "libp2p-glue",
+ "multisig-glue",
+ "openvm-glue",
+ "risc0-glue",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,8 +6,9 @@ members = [
   "risc0-glue",
   "hashsig-glue",
   "multisig-glue",
+  "zeam-glue",
 ]
-default-members = ["libp2p-glue", "openvm-glue", "risc0-glue", "hashsig-glue", "multisig-glue"]
+default-members = ["zeam-glue"]
 
 [profile.release]
 # LTO (Link Time Optimization) is disabled to avoid symbol conflicts between risc0 and openvm.

--- a/rust/hashsig-glue/Cargo.toml
+++ b/rust/hashsig-glue/Cargo.toml
@@ -14,5 +14,7 @@ ssz = { package = "ethereum_ssz", version = "0.10" }
 test-config = []
 
 [lib]
-crate-type = ["staticlib"]
+# Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be funnelled
+# through the `zeam-glue` staticlib shim. See blockblaz/zeam#773.
+crate-type = ["rlib"]
 name = "hashsig_glue"

--- a/rust/libp2p-glue/Cargo.toml
+++ b/rust/libp2p-glue/Cargo.toml
@@ -28,4 +28,6 @@ default-features = false
 features = ["identify", "yamux", "noise", "dns", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic", "upnp", "ping", "gossipsub"]
 
 [lib]
-crate-type = ["staticlib"]
+# Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be funnelled
+# through the `zeam-glue` staticlib shim. See blockblaz/zeam#773.
+crate-type = ["rlib"]

--- a/rust/multisig-glue/Cargo.toml
+++ b/rust/multisig-glue/Cargo.toml
@@ -9,5 +9,7 @@ leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", re
 backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
 
 [lib]
-crate-type = ["staticlib"]
+# Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be funnelled
+# through the `zeam-glue` staticlib shim. See blockblaz/zeam#773.
+crate-type = ["rlib"]
 name = "multisig_glue"

--- a/rust/openvm-glue/Cargo.toml
+++ b/rust/openvm-glue/Cargo.toml
@@ -15,5 +15,7 @@ openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v
 openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.3.0" }
 
 [lib]
-crate-type = ["staticlib"]
+# Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be funnelled
+# through the `zeam-glue` staticlib shim. See blockblaz/zeam#773.
+crate-type = ["rlib"]
 name = "openvm_glue"

--- a/rust/risc0-glue/Cargo.toml
+++ b/rust/risc0-glue/Cargo.toml
@@ -9,5 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11.2"
 
 [lib]
-crate-type = ["staticlib"]
+# Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be funnelled
+# through the `zeam-glue` staticlib shim. See blockblaz/zeam#773.
+crate-type = ["rlib"]
 name = "risc0_glue"

--- a/rust/zeam-glue/Cargo.toml
+++ b/rust/zeam-glue/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "zeam-glue"
+version = "0.1.0"
+edition = "2021"
+
+# Unified FFI shim that re-exports the `#[no_mangle] pub extern "C"` symbols from
+# every per-prover glue crate. The shim is the only crate in the workspace that
+# produces a `staticlib`; the underlying glue crates are plain `rlib`s, pulled
+# in as dependencies under feature flags.
+#
+# Why: each `staticlib` Rust produces bundles its own copy of Rust's allocator
+# shim (`__rust_alloc`, `__rust_dealloc`, `__rust_realloc`, `__rust_alloc_zeroed`).
+# On macOS, `ld64` refuses to coalesce the duplicates when Zig links multiple
+# such staticlibs into a single executable, breaking `build-all-provers`.
+# Funnelling every glue rlib through a single staticlib emits the shim once.
+# See blockblaz/zeam#773.
+
+[dependencies]
+libp2p-glue   = { path = "../libp2p-glue",   optional = true }
+hashsig-glue  = { path = "../hashsig-glue",  optional = true }
+multisig-glue = { path = "../multisig-glue", optional = true }
+risc0-glue    = { path = "../risc0-glue",    optional = true }
+openvm-glue   = { path = "../openvm-glue",   optional = true }
+
+[features]
+# Features are intentionally additive and have no defaults so `build.zig`
+# can opt into exactly the set that matches the requested `-Dprover=...`.
+libp2p   = ["dep:libp2p-glue"]
+hashsig  = ["dep:hashsig-glue"]
+multisig = ["dep:multisig-glue"]
+risc0    = ["dep:risc0-glue"]
+openvm   = ["dep:openvm-glue"]
+
+[lib]
+name = "zeam_glue"
+crate-type = ["staticlib"]

--- a/rust/zeam-glue/src/lib.rs
+++ b/rust/zeam-glue/src/lib.rs
@@ -1,0 +1,25 @@
+//! Unified FFI shim for the Zig side.
+//!
+//! Each feature below corresponds to a per-prover glue rlib. The explicit
+//! `extern crate` binding forces Cargo/rustc to link the dependency into this
+//! `staticlib` even though no Rust-level item from it is referenced here —
+//! the only things we care about are the `#[no_mangle] pub extern "C"`
+//! functions defined in those crates, which rustc preserves in the final
+//! archive as long as the rlib is part of the link set.
+//!
+//! See blockblaz/zeam#773 for the motivation.
+
+#[cfg(feature = "libp2p")]
+extern crate libp2p_glue;
+
+#[cfg(feature = "hashsig")]
+extern crate hashsig_glue;
+
+#[cfg(feature = "multisig")]
+extern crate multisig_glue;
+
+#[cfg(feature = "risc0")]
+extern crate risc0_glue;
+
+#[cfg(feature = "openvm")]
+extern crate openvm_glue;


### PR DESCRIPTION
Closes #773. Supersedes #774.

## Problem

`build-all-provers (macos-latest)` was failing on any fresh (cache-miss) rebuild with:

```
error: duplicate symbol definition:
__RNvCs..._7___rustc12___rust_alloc
__RNvCs..._7___rustc14___rust_dealloc
__RNvCs..._7___rustc14___rust_realloc
__RNvCs..._7___rustc19___rust_alloc_zeroed
```

Each per-prover Rust crate was built as its own `staticlib`, and every `staticlib` bundles Rust's allocator shim. `ld64` on macOS refuses to coalesce the duplicate strong definitions when Zig links multiple of those archives into one executable. Past CI runs only looked green because `Swatinem/rust-cache` hits restored rlibs from an older Rust toolchain where the collision did not happen; a toolchain pin (#774) could not resurrect that cache state, so the issue had to be fixed structurally.

## Fix

Route every glue crate through a single `staticlib` shim.

- New `rust/zeam-glue/` crate is the only workspace member that produces a `staticlib`.
- The five existing glue crates (`libp2p-glue`, `hashsig-glue`, `multisig-glue`, `risc0-glue`, `openvm-glue`) are now `rlib`s.
- `zeam-glue` pulls them in as optional dependencies behind `libp2p` / `hashsig` / `multisig` / `risc0` / `openvm` features; `extern crate` bindings in `lib.rs` guarantee their `#[no_mangle] pub extern "C"` symbols stay in the final archive.
- `build.zig` selects the feature set that matches `-Dprover=...` (e.g. `libp2p,hashsig,multisig,risc0,openvm` for `all`) and links the single `libzeam_glue.a` from the appropriate profile directory.

Result: the allocator shim is emitted exactly once regardless of how many provers are enabled.

## Local verification (macOS, arm64)

- `zig build -Dprover=dummy` ✓
- `zig build -Dprover=all` ✓ (this was the failing combination)
- `zig build test --summary all` ✓
- `zig build simtest --summary all` ✓
- `zig fmt --check .` ✓
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` ✓
- `cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings` ✓
- `nm rust/target/release/libzeam_glue.a | grep '___rust_alloc'` → exactly one `T` definition of each shim (the rest are `U` references within the archive).

All prover FFI symbols (`create_and_run_network`, `xmss_setup_prover`, `hashsig_sign`, …) are present in the consolidated archive.

## Scope

Draft while CI runs the full matrix. No toolchain changes, no dependency bumps, no logic changes in any glue crate.