### PR TITLE
forkchoice: accept safe target regression instead of hard-erroring

### DIFF
--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1249,17 +1249,23 @@ pub const ForkChoice = struct {
         const cutoff_weight = try std.math.divCeil(u64, 2 * self.config.genesis.numValidators(), 3);
         const safe_target = try self.computeFCHeadUnlocked(false, cutoff_weight);
 
-        // Can't regress on safe target
+        // Safe target regression is a legitimate fork-choice outcome, not a
+        // bug: the deepest 2/3-supported descendant of `latest_justified` can
+        // move to a shallower slot when attestation weights shift across
+        // branches or when `latest_justified` itself advances to a different
+        // subtree. Previously this returned `InvalidSafeTargetCompute`, which
+        // aborted the interval-3 tick and wedged the node's time loop on
+        // devnet-4 whenever target divergence produced a shallower
+        // 2/3-supermajority subtree. Accept the new value and surface the
+        // regression via a warn-level log so operators retain visibility.
         if (safe_target.slot < self.safeTarget.slot) {
-            self.logger.err("invalid safe target compute regression  new={d} < current={d} ", .{
+            self.logger.warn("safe target regressed new={d} < current={d}; accepting new value", .{
                 safe_target.slot,
                 self.safeTarget.slot,
             });
-            return ForkChoiceError.InvalidSafeTargetCompute;
         }
 
         self.safeTarget = safe_target;
-        // Update safe target slot metric
         zeam_metrics.metrics.lean_safe_target_slot.set(self.safeTarget.slot);
         return self.safeTarget;
     }


### PR DESCRIPTION
## Problem

At every `i=3` tick, `updateSafeTargetUnlocked` recomputes the safe target (deepest 2/3-supported descendant of `latest_justified`) and hard-errors with `InvalidSafeTargetCompute` if the new slot is lower than the cached one. That invariant is wrong — safe target can legitimately move shallower when attestation weights shift across branches or when the justified checkpoint advances to a different subtree.

On devnet-4 this wedged `zeam_0`:

```
[forkchoice] invalid safe target compute regression new=10674 < current=10698
[node] error ticking chain to time(intervals)=53513 err=error.InvalidSafeTargetCompute
```

The error aborted the tick, `last_interval` stopped advancing, forkchoice stopped consuming aggregates, and justification stalled.

## Fix

Downgrade the check to a `warn` log and accept the new value. Safe target is a per-tick hint with no monotonicity requirement, and the new value comes from the same `computeFCHeadUnlocked` call we already trust on the non-regressing path.

## Known structural difference from leanSpec (not addressed here)

`leanSpec`'s [`update_safe_target`](https://github.com/blockblaz/lean-specs/blob/main/src/lean_spec/subspecs/forkchoice/store.py) merges `latest_new_aggregated_payloads` with `latest_known_aggregated_payloads` at the **map** level before extracting per-validator votes for the LMD-GHOST walk.

`zeam`'s `updateSafeTargetUnlocked` → `computeFCHeadUnlocked(false, cutoff)` → `computeDeltasUnlocked(from_known=false)` only reads the `latest_new_aggregated_payloads` map, but it does so indirectly: per-validator weights come from the `attestations` tracker's `latestNew` field, which is updated by **both** the gossip and block paths (`is_from_block=true` promotes a sufficiently recent block attestation into `tracker.latestNew` at `forkchoice.zig:1369`). In practice this makes `tracker.latestNew` equivalent to "last-known vote per validator from any source," so the under-count scenarios `leanSpec` warns about (proposer self-attestation, self-gossip that never loops back) are not actually lost by `zeam` today.

Map-level alignment with the spec is still desirable for clarity and to remove a class of latent mismatches, but it is not a validated root cause of the stall this PR fixes, and has been moved to follow-up.

## Test plan

- [x] `zig fmt --check .`
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] `zig build test --summary all`
- [ ] Redeploy on devnet-4 and confirm `zeam_0` keeps ticking through target divergence

## Follow-ups

- Merge `latest_new_aggregated_payloads` with `latest_known_aggregated_payloads` in `updateSafeTargetUnlocked` to match the spec shape.
- Broader tick resilience: `onInterval` errors should reject the offending block, not freeze time (see #749, #776).
- Drop `ForkChoiceError.InvalidSafeTargetCompute` once no callers reference it.