### PR TITLE
 Add clock tick duration metric and logging

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -293,7 +293,8 @@ fn mainInner() !void {
                 ErrorHandler.logErrorWithOperation(err, "initialize event loop");
                 return err;
             };
-            var clock = Clock.init(gpa.allocator(), genesis, &loop) catch |err| {
+            var clock_logger_config = utils_lib.getLoggerConfig(console_log_level, null);
+            var clock = Clock.init(gpa.allocator(), genesis, &loop, &clock_logger_config) catch |err| {
                 ErrorHandler.logErrorWithOperation(err, "initialize clock");
                 return err;
             };
@@ -582,7 +583,7 @@ fn mainInner() !void {
             }
 
             var clock = try allocator.create(Clock);
-            clock.* = try Clock.init(allocator, chain_config.genesis.genesis_time, loop);
+            clock.* = try Clock.init(allocator, chain_config.genesis.genesis_time, loop, &logger1_config);
 
             // 3-node setup: validators 0,1 start immediately; validator 2 (node 3) starts after finalization
             var validator_ids_1 = [_]usize{0};

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -227,7 +227,7 @@ pub const Node = struct {
             .attestation_committee_count = chain_config.spec.attestation_committee_count,
         }, options.logger_config.logger(.network));
         errdefer self.network.deinit();
-        self.clock = try Clock.init(allocator, chain_config.genesis.genesis_time, &self.loop);
+        self.clock = try Clock.init(allocator, chain_config.genesis.genesis_time, &self.loop, options.logger_config);
         errdefer self.clock.deinit(allocator);
 
         var db = try database.Db.open(allocator, options.logger_config.logger(.database), options.database_path);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -98,6 +98,8 @@ const Metrics = struct {
     zeam_compact_attestations_time_seconds: CompactAttestationsTimeHistogram,
     zeam_compact_attestations_input_total: CompactAttestationsInputCounter,
     zeam_compact_attestations_output_total: CompactAttestationsOutputCounter,
+    // Tick interval duration: actual elapsed time between clock ticks (nominal 0.8s)
+    lean_tick_interval_duration_seconds: TickIntervalDurationHistogram,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
@@ -164,6 +166,7 @@ const Metrics = struct {
     const AttestationProductionTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
     // compactAttestations metric types
     const CompactAttestationsTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5 });
+    const TickIntervalDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6 });
     const CompactAttestationsInputCounter = metrics_lib.Counter(u64);
     const CompactAttestationsOutputCounter = metrics_lib.Counter(u64);
     // Validator status gauge types
@@ -331,6 +334,12 @@ fn observeCompactAttestations(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeTickIntervalDuration(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.TickIntervalDurationHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 /// The public variables the application interacts with.
 /// Calling `.start()` on these will start a new timer.
 pub var zeam_chain_onblock_duration_seconds: Histogram = .{
@@ -415,6 +424,10 @@ pub var zeam_compact_attestations_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeCompactAttestations,
 };
+pub var lean_tick_interval_duration_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeTickIntervalDuration,
+};
 
 /// Initializes the metrics system. Must be called once at startup.
 pub fn init(allocator: std.mem.Allocator) !void {
@@ -497,6 +510,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_compact_attestations_time_seconds = Metrics.CompactAttestationsTimeHistogram.init("zeam_compact_attestations_time_seconds", .{ .help = "Time taken by compactAttestations to merge payloads sharing the same AttestationData" }, .{}),
         .zeam_compact_attestations_input_total = Metrics.CompactAttestationsInputCounter.init("zeam_compact_attestations_input_total", .{ .help = "Total number of attestations input to compactAttestations" }, .{}),
         .zeam_compact_attestations_output_total = Metrics.CompactAttestationsOutputCounter.init("zeam_compact_attestations_output_total", .{ .help = "Total number of attestations output from compactAttestations after compaction" }, .{}),
+        .lean_tick_interval_duration_seconds = Metrics.TickIntervalDurationHistogram.init("lean_tick_interval_duration_seconds", .{ .help = "Elapsed time between clock ticks in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -533,6 +547,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_gossip_aggregation_size_bytes.context = @ptrCast(&metrics.lean_gossip_aggregation_size_bytes);
     lean_attestations_production_time_seconds.context = @ptrCast(&metrics.lean_attestations_production_time_seconds);
     zeam_compact_attestations_time_seconds.context = @ptrCast(&metrics.zeam_compact_attestations_time_seconds);
+    lean_tick_interval_duration_seconds.context = @ptrCast(&metrics.lean_tick_interval_duration_seconds);
     // Initialize sync status to idle at startup
     try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);
     try metrics.lean_node_sync_status.set(.{ .status = "syncing" }, 0);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -100,6 +100,8 @@ const Metrics = struct {
     zeam_compact_attestations_output_total: CompactAttestationsOutputCounter,
     // Tick interval duration: actual elapsed time between clock ticks (nominal 0.8s)
     lean_tick_interval_duration_seconds: TickIntervalDurationHistogram,
+    // Fork-choice tick interval duration: actual elapsed time between forkchoice tickIntervalUnlocked calls
+    zeam_fork_choice_tick_interval_duration_seconds: ForkChoiceTickIntervalDurationHistogram,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
@@ -167,6 +169,7 @@ const Metrics = struct {
     // compactAttestations metric types
     const CompactAttestationsTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5 });
     const TickIntervalDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6 });
+    const ForkChoiceTickIntervalDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6 });
     const CompactAttestationsInputCounter = metrics_lib.Counter(u64);
     const CompactAttestationsOutputCounter = metrics_lib.Counter(u64);
     // Validator status gauge types
@@ -340,6 +343,12 @@ fn observeTickIntervalDuration(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeForkChoiceTickIntervalDuration(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.ForkChoiceTickIntervalDurationHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 /// The public variables the application interacts with.
 /// Calling `.start()` on these will start a new timer.
 pub var zeam_chain_onblock_duration_seconds: Histogram = .{
@@ -428,6 +437,10 @@ pub var lean_tick_interval_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeTickIntervalDuration,
 };
+pub var zeam_fork_choice_tick_interval_duration_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeForkChoiceTickIntervalDuration,
+};
 
 /// Initializes the metrics system. Must be called once at startup.
 pub fn init(allocator: std.mem.Allocator) !void {
@@ -511,6 +524,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_compact_attestations_input_total = Metrics.CompactAttestationsInputCounter.init("zeam_compact_attestations_input_total", .{ .help = "Total number of attestations input to compactAttestations" }, .{}),
         .zeam_compact_attestations_output_total = Metrics.CompactAttestationsOutputCounter.init("zeam_compact_attestations_output_total", .{ .help = "Total number of attestations output from compactAttestations after compaction" }, .{}),
         .lean_tick_interval_duration_seconds = Metrics.TickIntervalDurationHistogram.init("lean_tick_interval_duration_seconds", .{ .help = "Elapsed time between clock ticks in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
+        .zeam_fork_choice_tick_interval_duration_seconds = Metrics.ForkChoiceTickIntervalDurationHistogram.init("zeam_fork_choice_tick_interval_duration_seconds", .{ .help = "Elapsed time between forkchoice node tick calls in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -548,6 +562,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_attestations_production_time_seconds.context = @ptrCast(&metrics.lean_attestations_production_time_seconds);
     zeam_compact_attestations_time_seconds.context = @ptrCast(&metrics.zeam_compact_attestations_time_seconds);
     lean_tick_interval_duration_seconds.context = @ptrCast(&metrics.lean_tick_interval_duration_seconds);
+    zeam_fork_choice_tick_interval_duration_seconds.context = @ptrCast(&metrics.zeam_fork_choice_tick_interval_duration_seconds);
     // Initialize sync status to idle at startup
     try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);
     try metrics.lean_node_sync_status.set(.{ .status = "syncing" }, 0);

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const xev = @import("xev").Dynamic;
+const zeam_metrics = @import("@zeam/metrics");
+const zeam_utils = @import("@zeam/utils");
 
 const constants = @import("./constants.zig");
 
@@ -14,12 +16,14 @@ pub const Clock = struct {
     genesis_time_ms: isize,
     current_interval_time_ms: isize,
     current_interval: isize,
+    last_tick_time_ms: ?isize,
     events: utils.EventLoop,
     // track those who subscribed for on slot callbacks
     on_interval_cbs: std.ArrayList(*OnIntervalCbWrapper),
     allocator: Allocator,
 
     timer: xev.Timer,
+    logger: zeam_utils.ModuleLogger,
 
     const Self = @This();
 
@@ -31,6 +35,7 @@ pub const Clock = struct {
         allocator: Allocator,
         genesis_time: usize,
         loop: *xev.Loop,
+        logger_config: *const zeam_utils.ZeamLoggerConfig,
     ) !Self {
         const events = try utils.EventLoop.init(loop);
         const timer = try xev.Timer.init();
@@ -43,10 +48,12 @@ pub const Clock = struct {
             .genesis_time_ms = genesis_time_ms,
             .current_interval_time_ms = current_interval_time_ms,
             .current_interval = current_interval,
+            .last_tick_time_ms = null,
             .events = events,
             .timer = timer,
             .on_interval_cbs = .empty,
             .allocator = allocator,
+            .logger = logger_config.logger(.clock),
         };
     }
 
@@ -60,6 +67,12 @@ pub const Clock = struct {
 
     pub fn tickInterval(self: *Self) void {
         const time_now_ms: isize = @intCast(std.time.milliTimestamp());
+        if (self.last_tick_time_ms) |last| {
+            const elapsed_s: f32 = @as(f32, @floatFromInt(time_now_ms - last)) / 1000.0;
+            zeam_metrics.lean_tick_interval_duration_seconds.record(elapsed_s);
+            self.logger.info("slot_interval={d} duration={d:.3}s", .{ @mod(self.current_interval, constants.INTERVALS_PER_SLOT), elapsed_s });
+        }
+        self.last_tick_time_ms = time_now_ms;
         while (self.current_interval_time_ms + constants.SECONDS_PER_INTERVAL_MS < time_now_ms + CLOCK_DISPARITY_MS) {
             self.current_interval_time_ms += constants.SECONDS_PER_INTERVAL_MS;
             self.current_interval += 1;

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2264,6 +2264,7 @@ test "getCanonicalAncestorAtDepth and getCanonicalityAnalysis" {
         .latest_known_aggregated_payloads = AggregatedPayloadsMap.init(allocator),
         .signatures_mutex = std.Thread.Mutex{},
         .status = .ready,
+        .last_node_tick_time_ms = null,
     };
     defer fork_choice.attestations.deinit();
     defer fork_choice.deltas.deinit(fork_choice.allocator);
@@ -2618,6 +2619,7 @@ fn buildTestTreeWithMockChain(allocator: Allocator, mock_chain: anytype) !struct
         .latest_known_aggregated_payloads = AggregatedPayloadsMap.init(allocator),
         .signatures_mutex = std.Thread.Mutex{},
         .status = .ready,
+        .last_node_tick_time_ms = null,
     };
 
     return .{
@@ -3603,6 +3605,7 @@ test "rebase: heavy attestation load - all validators tracked correctly" {
         .latest_known_aggregated_payloads = AggregatedPayloadsMap.init(allocator),
         .signatures_mutex = std.Thread.Mutex{},
         .status = .ready,
+        .last_node_tick_time_ms = null,
     };
     // Note: We don't defer proto_array.nodes/indices.deinit() here because they're
     // moved into fork_choice and will be deinitialized separately

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -307,6 +307,7 @@ pub const ForkChoice = struct {
     // `ready` on the first block-driven justified update.  Validator duties (block
     // production, attestation) must not run while status == .initing.
     status: ForkChoiceStatus,
+    last_node_tick_time_ms: ?i64,
 
     const Self = @This();
 
@@ -379,6 +380,7 @@ pub const ForkChoice = struct {
             // (slot > 0) start in `initing` and become `ready` once the first real justified
             // checkpoint is observed through block processing.
             .status = if (opts.anchorState.slot == 0) .ready else .initing,
+            .last_node_tick_time_ms = null,
         };
         if (fc.status == .initing) {
             fc.logger.info("[forkchoice] init: checkpoint-sync anchor at slot={d} — status=initing; awaiting first justified update before enabling validator duties", .{opts.anchorState.slot});
@@ -823,6 +825,14 @@ pub const ForkChoice = struct {
 
     // Internal unlocked version - assumes caller holds lock
     fn tickIntervalUnlocked(self: *Self, hasProposal: bool) !void {
+        const time_now_ms: i64 = std.time.milliTimestamp();
+        if (self.last_node_tick_time_ms) |last| {
+            const elapsed_s: f32 = @as(f32, @floatFromInt(time_now_ms - last)) / 1000.0;
+            zeam_metrics.zeam_fork_choice_tick_interval_duration_seconds.record(elapsed_s);
+            self.logger.info("slot_interval={d} duration={d:.3}s", .{ self.fcStore.slot_clock.slotInterval.load(.monotonic), elapsed_s });
+        }
+        self.last_node_tick_time_ms = time_now_ms;
+
         const new_time = self.fcStore.slot_clock.time.fetchAdd(1, .monotonic) + 1;
         const currentInterval = new_time % constants.INTERVALS_PER_SLOT;
         self.fcStore.slot_clock.slotInterval.store(currentInterval, .monotonic);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1583,7 +1583,7 @@ test "Node peer tracking on connect/disconnect" {
         },
     };
 
-    var clock = try clockFactory.Clock.init(allocator, genesis_config.genesis_time, ctx.loopPtr());
+    var clock = try clockFactory.Clock.init(allocator, genesis_config.genesis_time, ctx.loopPtr(), ctx.loggerConfig());
     defer clock.deinit(allocator);
 
     var node: BeamNode = undefined;

--- a/pkgs/node/src/testing.zig
+++ b/pkgs/node/src/testing.zig
@@ -108,7 +108,7 @@ pub const NodeTestContext = struct {
             },
         };
 
-        var clock = try clockFactory.Clock.init(allocator, genesis_config.genesis_time, &loop);
+        var clock = try clockFactory.Clock.init(allocator, genesis_config.genesis_time, &loop, logger_config);
         errdefer clock.deinit(allocator);
 
         return NodeTestContext{

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -147,6 +147,7 @@ const LoggerScope = enum {
 pub const ModuleTag = enum {
     api_server,
     cli,
+    clock,
     chain,
     configs,
     database,
@@ -486,6 +487,7 @@ fn getModuleTagName(tag: ModuleTag) []const u8 {
     return switch (tag) {
         .api_server => "api-server",
         .cli => "cli",
+        .clock => "clock",
         .chain => "chain",
         .configs => "configs",
         .database => "database",


### PR DESCRIPTION
This PR:
- Adds lean_tick_interval_duration_seconds histogram to measure the actual elapsed time between consecutive Clock.tickInterval() calls
- Adds structured logging to track slot interval durations in the node logs