### PR TITLE
fix: cache RPC future-slot blocks; tolerate small clock skew (#788)

### DIFF
--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -9,6 +9,13 @@ pub const SECONDS_PER_INTERVAL_MS: isize = @divFloor(params.SECONDS_PER_SLOT * s
 // This prevents accepting attestations that are too far ahead of the current slot
 pub const MAX_FUTURE_SLOT_TOLERANCE = 1;
 
+// Maximum number of intervals (sub-slot ticks) in the future that a block is allowed
+// to lead the local fork-choice clock. Soaks up tiny clock skews between peers/CI
+// nodes so a block whose slot has just begun on the sender — but not yet ticked
+// locally — is accepted instead of rejected with FutureSlot. Larger gaps still fall
+// through to the future-block cache and replay on tick. See issue #788.
+pub const MAX_FUTURE_INTERVAL_TOLERANCE = 1;
+
 // Maximum depth for recursive block fetching
 // When fetching parent blocks, we stop after this many levels to avoid infinite loops
 pub const MAX_BLOCK_FETCH_DEPTH = 512;

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1631,7 +1631,12 @@ pub const ForkChoice = struct {
             // we will use parent block later as per the finalization gadget
             _ = parent_block;
 
-            if (slot * constants.INTERVALS_PER_SLOT > self.fcStore.slot_clock.time.load(.monotonic)) {
+            // Allow a small interval-level tolerance so blocks that arrive at the
+            // very start of their slot (before the local clock has ticked) are not
+            // rejected as FutureSlot under routine clock skew. Larger gaps are still
+            // rejected and the caller is expected to cache + replay on tick.
+            // See issue #788.
+            if (slot * constants.INTERVALS_PER_SLOT > self.fcStore.slot_clock.time.load(.monotonic) + constants.MAX_FUTURE_INTERVAL_TOLERANCE) {
                 return ForkChoiceError.FutureSlot;
             } else if (slot < self.fcStore.latest_finalized.slot) {
                 return ForkChoiceError.PreFinalizedSlot;

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -732,6 +732,45 @@ pub const BeamNode = struct {
                     return;
                 }
 
+                // RPC-fetched block arrived too early for local clock - cache and replay
+                // when the slot clock catches up (mirrors the gossip-path FutureSlot
+                // handler). Without this branch, blocks fetched during a sync catch-up
+                // window after a delayed onInterval (see #786 mutex contention) are
+                // dropped permanently, leaving the head stuck at the justified
+                // checkpoint with no descendants. See issue #788.
+                if (err == forkchoice.ForkChoiceError.FutureSlot) {
+                    if (self.cacheFutureBlock(block_root, signed_block.*)) |_| {
+                        self.logger.debug(
+                            "cached future RPC block 0x{s} at slot {d} from peer {s}{f}",
+                            .{
+                                std.fmt.bytesToHex(block_root, .lower)[0..],
+                                signed_block.block.slot,
+                                block_ctx.peer_id,
+                                self.node_registry.getNodeNameFromPeerId(block_ctx.peer_id),
+                            },
+                        );
+                    } else |cache_err| {
+                        if (cache_err == CacheBlockError.PreFinalized) {
+                            self.logger.info(
+                                "future RPC block 0x{s} is pre-finalized (slot={d}), pruning cached descendants",
+                                .{ std.fmt.bytesToHex(block_root, .lower)[0..], signed_block.block.slot },
+                            );
+                            _ = self.network.pruneCachedBlocks(block_root, null);
+                        } else if (cache_err == CacheBlockError.AlreadyCached) {
+                            self.logger.debug(
+                                "future RPC block 0x{s} already cached",
+                                .{std.fmt.bytesToHex(block_root, .lower)[0..]},
+                            );
+                        } else {
+                            self.logger.warn("failed to cache future RPC block 0x{s}: {any}", .{
+                                std.fmt.bytesToHex(block_root, .lower)[0..],
+                                cache_err,
+                            });
+                        }
+                    }
+                    return;
+                }
+
                 self.logger.warn("failed to import block fetched via RPC 0x{x} from peer {s}{f}: {any}", .{
                     &block_root,
                     block_ctx.peer_id,


### PR DESCRIPTION
## Summary

Closes #788.

Two fixes for the FutureSlot rejection loop in which a node under timing
desync rejects RPC-fetched future-slot blocks permanently, leaving the
head stuck at the justified checkpoint with no descendants.

- **`processBlockByRootChunk`**: add an `error.FutureSlot` branch that
  caches the block via `cacheFutureBlock` (mirrors the existing
  gossip-path handler at line 268). `processReadyCachedBlocks` already
  replays cached blocks once the slot clock catches up.
- **`forkchoice.onBlockUnlocked`**: accept blocks up to
  `MAX_FUTURE_INTERVAL_TOLERANCE = 1` intervals ahead of the local
  clock to soak up routine sub-slot skews. Larger gaps still fall
  through to the future-block cache and replay on tick.

## Root cause

Issue #788 reported `head=finalized=justified=93` with the chain frozen
on `zeam_0`. The trace showed peers acknowledging the block by root but
the local node logging only `processed pending blocks count=0` — the RPC
import path silently dropped the block.

`processBlockByRootChunk` previously caught `MissingPreState` and
`PreFinalizedSlot` but treated `error.FutureSlot` as a generic warn +
return. The forkchoice check at `forkchoice.zig:1634` is strict:
`slot * INTERVALS_PER_SLOT > slot_clock.time` returns `FutureSlot` with
no tolerance. Combined with the mutex contention identified in #786,
which delays `onInterval`, blocks arriving during the catch-up window
are rejected before the local clock advances and never retried —
justified gets no descendants and `computeFCHeadUnlocked` defaults the
head to justified.

The gossip path already had two safety nets (`pending_blocks` queue for
1-slot-ahead and `cacheFutureBlock` for 2+-slot-ahead). The RPC path
had neither.

## Test plan

- [x] `zig build` (release) succeeds
- [x] `zig build test` succeeds
- [ ] Devnet observation: confirm head no longer freezes at justified
      checkpoint under interval-vs-gossip timing desync
- [ ] Confirm `processCachedDescendants` replays the cached future
      block when the slot clock ticks past its slot