### PR TITLE
parallelise: review follow-ups (metrics, FFI hoist, determinism, prewarm)

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -599,6 +599,16 @@ fn mainInner() !void {
             });
             defer thread_pool.deinit();
 
+            // Pre-warm the XMSS verifier on the main thread before any worker
+            // can call `verifyAggregatedPayload`. The Rust-side verifier setup
+            // is documented as idempotent but is not hardened against
+            // first-time-init races between concurrent callers; doing it once
+            // here removes that race regardless of the Rust implementation.
+            xmss.setupVerifier() catch |err| {
+                std.debug.print("xmss.setupVerifier failed: {any}\n", .{err});
+                return err;
+            };
+
             // 3-node setup: validators 0,1 start immediately; validator 2 (node 3) starts after finalization
             var validator_ids_1 = [_]usize{0};
             var validator_ids_2 = [_]usize{1};

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -20,6 +20,7 @@ const key_manager_lib = @import("@zeam/key-manager");
 const Clock = node_lib.Clock;
 const BeamNode = node_lib.BeamNode;
 const ThreadPool = @import("@zeam/thread-pool").ThreadPool;
+const xmss = @import("@zeam/xmss");
 const types = @import("@zeam/types");
 const LoggerConfig = utils_lib.ZeamLoggerConfig;
 const NodeCommand = @import("main.zig").NodeCommand;
@@ -319,6 +320,16 @@ pub const Node = struct {
             .thread_count = @intCast(worker_count),
         });
         errdefer self.thread_pool.deinit();
+
+        // Pre-warm the XMSS verifier on the main thread before any worker can
+        // call `verifyAggregatedPayload`. The Rust-side verifier setup is
+        // documented as idempotent but is not hardened against first-time-init
+        // races between concurrent callers; doing it once here removes that
+        // race regardless of the Rust implementation.
+        xmss.setupVerifier() catch |err| {
+            self.thread_pool.deinit();
+            return err;
+        };
 
         try self.beam_node.init(allocator, .{
             .nodeId = @intCast(options.node_key_index),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -130,8 +130,27 @@ pub const BeamChain = struct {
     public_key_cache: xmss.PublicKeyCache,
     // Cache for root to slot mapping to optimize block processing performance.
     root_to_slot_cache: types.RootToSlotCache,
-    // Optional worker pool for parallelizing CPU-bound steps (currently: attestation signature
-    // verification). Owned by the caller (e.g. the CLI's main), not by the chain.
+    /// Optional worker pool for parallelizing CPU-bound steps (currently:
+    /// attestation signature verification and `compactAttestations`). Owned
+    /// by the caller (e.g. the CLI's main), not by the chain.
+    ///
+    /// Thread-safety invariants required of the pool's environment when set:
+    ///
+    ///   1. `chain.allocator` MUST be safe to use concurrently from worker
+    ///      threads. The CLI today wires this to a `GeneralPurposeAllocator`
+    ///      whose `alloc`/`free` are internally serialized; an `ArenaAllocator`
+    ///      or any custom non-thread-safe allocator would race. If a future
+    ///      change swaps the allocator, audit every consumer of `thread_pool`
+    ///      (`stf.verifySignaturesParallel`, `types.compactAttestations`).
+    ///   2. The XMSS verifier must be set up before the pool's first verify.
+    ///      The CLI calls `xmss.setupVerifier()` on the main thread right after
+    ///      pool construction; without that pre-warm, concurrent first-time
+    ///      verifies could race the Rust-side initialization.
+    ///   3. `xmss.PublicKeyCache` is documented NOT thread-safe. Workers must
+    ///      not call its `getOrPut` directly. The current parallel paths
+    ///      respect this: cache access is confined to a serial pre-phase.
+    ///
+    /// New consumers of `thread_pool` should preserve all three invariants.
     thread_pool: ?*ThreadPool = null,
 
     // Callback for pruning cached blocks after finalization advances

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -200,6 +200,12 @@ pub fn verifySignaturesParallel(
         public_keys: []*const xmss.HashSigPublicKey,
         message_hash: [32]u8,
         epoch: u64,
+        // Per-task elapsed time (nanoseconds) measured inside the worker. We
+        // record this so the post-pool emit can call `observe()` once per
+        // attestation, matching the granularity of the serial path. Without
+        // per-task timing the histogram would receive one batch sample per
+        // block and percentiles would diverge from the serial baseline.
+        elapsed_ns: u64 = 0,
         result: ?anyerror = null,
         verified: bool = false,
     };
@@ -283,21 +289,33 @@ pub fn verifySignaturesParallel(
         fn runOne(task: *VerifyTask, err_flag: *std.atomic.Value(bool)) void {
             if (err_flag.load(.acquire)) return;
             task.verified = true;
+            // Time the FFI verify call with a monotonic Timer so the per-task
+            // sample matches what the serial path observes. `Timer.start()`
+            // only fails on platforms without a monotonic clock (none of the
+            // supported zeam targets) — fall through with elapsed_ns=0 if it
+            // ever does, rather than poisoning the result with garbage.
+            var timer = std.time.Timer.start() catch null;
             task.signature_proof.verify(task.public_keys, &task.message_hash, task.epoch) catch |err| {
+                if (timer) |*t| task.elapsed_ns = t.read();
                 task.result = err;
                 err_flag.store(true, .release);
+                return;
             };
+            if (timer) |*t| task.elapsed_ns = t.read();
         }
     };
 
     var any_err = std.atomic.Value(bool).init(false);
-    const batch_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.start();
     try thread_pool.scope(Runner.runScope, .{ tasks, &any_err });
-    _ = batch_timer.observe();
 
-    // Collect metrics and surface the first error (deterministic: index order).
+    // Emit one histogram sample per verified task so the parallel path's
+    // percentiles match the serial path (which observes once per
+    // attestation). Mixing the two granularities into the same histogram
+    // would silently distort P50/P99 across deployments.
     for (tasks) |*task| {
         if (!task.verified) continue;
+        const elapsed_s: f32 = @as(f32, @floatFromInt(task.elapsed_ns)) / std.time.ns_per_s;
+        zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(elapsed_s);
         if (task.result) |_| {
             zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_invalid_total.incr();
         } else {

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -833,89 +833,66 @@ const CompactGroupSlot = struct {
     err: ?anyerror = null,
 };
 
-fn compactAttestationGroup(
+/// Per-entry preparation built serially before any worker thread runs.
+///
+/// Holds the per-child `*const HashSigPublicKey` slices that the multi-proof
+/// aggregate path needs. Building these slices requires `xmss.PublicKey.fromBytes`,
+/// which is a Rust FFI call whose thread-safety we do not control. By
+/// constructing every prep on the main thread we keep `fromBytes` out of the
+/// parallel worker entirely; worker code only invokes the Rust `aggregate`
+/// entry point on already-deserialized handles.
+const CompactGroupPrep = struct {
+    entry: CompactGroupEntry,
+    /// Empty for single-proof groups (no aggregation needed). For multi-proof
+    /// groups, one `[]*const HashSigPublicKey` per child, in `entry.indices`
+    /// order.
+    child_pk_slices: []const []*const xmss.HashSigPublicKey,
+};
+
+/// Single-proof passthrough — clone proof, derive aggregation bits.
+fn compactSingleProof(
+    allocator: Allocator,
+    att_data: attestation.AttestationData,
+    sig: *const aggregation.AggregatedSignatureProof,
+) !CompactGroupResult {
+    var cloned_proof: aggregation.AggregatedSignatureProof = undefined;
+    try utils.sszClone(allocator, aggregation.AggregatedSignatureProof, sig.*, &cloned_proof);
+    errdefer cloned_proof.deinit();
+
+    var att_bits = try attestation.AggregationBits.init(allocator);
+    errdefer att_bits.deinit();
+    for (0..cloned_proof.participants.len()) |i| {
+        if (cloned_proof.participants.get(i) catch false) {
+            try attestation.aggregationBitsSet(&att_bits, i, true);
+        }
+    }
+
+    return .{
+        .attestation = .{ .aggregation_bits = att_bits, .data = att_data },
+        .signature = cloned_proof,
+    };
+}
+
+/// Multi-proof aggregation using pre-built per-child pubkey slices. Safe to
+/// run from a worker thread: no FFI deserialization, only `aggregate()` which
+/// receives const handles.
+fn compactMultiProofWithPrep(
     allocator: Allocator,
     att_data: attestation.AttestationData,
     indices: []const usize,
     sig_slice: []const aggregation.AggregatedSignatureProof,
-    validators: *const Validators,
+    child_pk_slices: []const []*const xmss.HashSigPublicKey,
 ) !CompactGroupResult {
-    if (indices.len == 1) {
-        // Single proof — clone and pass through.
-        const idx = indices[0];
-        var cloned_proof: aggregation.AggregatedSignatureProof = undefined;
-        try utils.sszClone(allocator, aggregation.AggregatedSignatureProof, sig_slice[idx], &cloned_proof);
-        errdefer cloned_proof.deinit();
-
-        var att_bits = try attestation.AggregationBits.init(allocator);
-        errdefer att_bits.deinit();
-        for (0..cloned_proof.participants.len()) |i| {
-            if (cloned_proof.participants.get(i) catch false) {
-                try attestation.aggregationBitsSet(&att_bits, i, true);
-            }
-        }
-
-        return .{
-            .attestation = .{ .aggregation_bits = att_bits, .data = att_data },
-            .signature = cloned_proof,
-        };
-    }
-
-    // Multiple proofs — merge via recursive children aggregation.
     const epoch: u64 = att_data.slot;
     var message_hash: [32]u8 = undefined;
     try zeam_utils.hashTreeRoot(attestation.AttestationData, att_data, &message_hash, allocator);
 
-    // Collect children proofs.
     const children = try allocator.alloc(aggregation.AggregatedSignatureProof, indices.len);
     defer allocator.free(children);
     for (indices, 0..) |idx, i| {
         children[i] = sig_slice[idx];
     }
 
-    // Build per-child public key arrays.
-    var child_pk_allocs: std.ArrayList([]*const xmss.HashSigPublicKey) = .empty;
-    defer {
-        for (child_pk_allocs.items) |arr| allocator.free(arr);
-        child_pk_allocs.deinit(allocator);
-    }
-    var child_pk_slices: std.ArrayList([]*const xmss.HashSigPublicKey) = .empty;
-    defer child_pk_slices.deinit(allocator);
-
-    var child_pk_wrappers: std.ArrayList(xmss.PublicKey) = .empty;
-    defer {
-        for (child_pk_wrappers.items) |*pw| pw.deinit();
-        child_pk_wrappers.deinit(allocator);
-    }
-
-    for (children) |*child| {
-        var n_participants: usize = 0;
-        for (0..child.participants.len()) |i| {
-            if (child.participants.get(i) catch false) {
-                n_participants += 1;
-            }
-        }
-
-        const cpks = try allocator.alloc(*const xmss.HashSigPublicKey, n_participants);
-        errdefer allocator.free(cpks);
-
-        var cpk_idx: usize = 0;
-        for (0..child.participants.len()) |i| {
-            if (child.participants.get(i) catch false) {
-                if (i >= validators.len()) continue;
-                const val = validators.get(@intCast(i)) catch continue;
-                const pk = xmss.PublicKey.fromBytes(&val.attestation_pubkey) catch continue;
-                try child_pk_wrappers.append(allocator, pk);
-                cpks[cpk_idx] = pk.handle;
-                cpk_idx += 1;
-            }
-        }
-
-        try child_pk_allocs.append(allocator, cpks);
-        try child_pk_slices.append(allocator, cpks[0..cpk_idx]);
-    }
-
-    // Aggregate children into single proof.
     var proof = try aggregation.AggregatedSignatureProof.init(allocator);
     errdefer proof.deinit();
 
@@ -926,7 +903,7 @@ fn compactAttestationGroup(
         allocator,
         null, // no raw XMSS participants
         children,
-        child_pk_slices.items,
+        child_pk_slices,
         empty_pks,
         empty_sigs,
         &message_hash,
@@ -934,7 +911,6 @@ fn compactAttestationGroup(
         &proof,
     );
 
-    // Create attestation bits from merged participants.
     var att_bits = try attestation.AggregationBits.init(allocator);
     errdefer att_bits.deinit();
     for (0..proof.participants.len()) |i| {
@@ -947,6 +923,23 @@ fn compactAttestationGroup(
         .attestation = .{ .aggregation_bits = att_bits, .data = att_data },
         .signature = proof,
     };
+}
+
+fn runCompactGroupPrep(
+    allocator: Allocator,
+    prep: CompactGroupPrep,
+    sig_slice: []const aggregation.AggregatedSignatureProof,
+) !CompactGroupResult {
+    if (prep.entry.indices.len == 1) {
+        return compactSingleProof(allocator, prep.entry.att_data, &sig_slice[prep.entry.indices[0]]);
+    }
+    return compactMultiProofWithPrep(
+        allocator,
+        prep.entry.att_data,
+        prep.entry.indices,
+        sig_slice,
+        prep.child_pk_slices,
+    );
 }
 
 pub fn compactAttestations(
@@ -1007,8 +1000,12 @@ pub fn compactAttestations(
         out_sigs.deinit();
     }
 
-    // Snapshot groups in iterator order so serial and parallel paths preserve
-    // the same output ordering semantics.
+    // Snapshot groups and sort deterministically. `std.AutoHashMap.iterator()`
+    // order is not stable across runs (insertion order is preserved only until
+    // the next rehash), so two validators producing the same attestation set
+    // could otherwise emit byte-different blocks. Sort by AttestationData
+    // (slot, head.root, target.root, source.root) — totally ordered, cheap on
+    // small block counts (≤ MAX_ATTESTATIONS).
     var group_entries: std.ArrayList(CompactGroupEntry) = .empty;
     defer group_entries.deinit(allocator);
     {
@@ -1021,9 +1018,86 @@ pub fn compactAttestations(
         }
     }
 
+    const SortCtx = struct {
+        fn lessThan(_: void, a: CompactGroupEntry, b: CompactGroupEntry) bool {
+            if (a.att_data.slot != b.att_data.slot) return a.att_data.slot < b.att_data.slot;
+            const head_cmp = std.mem.order(u8, &a.att_data.head.root, &b.att_data.head.root);
+            if (head_cmp != .eq) return head_cmp == .lt;
+            const target_cmp = std.mem.order(u8, &a.att_data.target.root, &b.att_data.target.root);
+            if (target_cmp != .eq) return target_cmp == .lt;
+            const source_cmp = std.mem.order(u8, &a.att_data.source.root, &b.att_data.source.root);
+            if (source_cmp != .eq) return source_cmp == .lt;
+            // Slot ties on each checkpoint resolved by checkpoint slot.
+            if (a.att_data.head.slot != b.att_data.head.slot) return a.att_data.head.slot < b.att_data.head.slot;
+            if (a.att_data.target.slot != b.att_data.target.slot) return a.att_data.target.slot < b.att_data.target.slot;
+            return a.att_data.source.slot < b.att_data.source.slot;
+        }
+    };
+    std.mem.sort(CompactGroupEntry, group_entries.items, {}, SortCtx.lessThan);
+
+    // -------- Serial pre-phase: build CompactGroupPrep for every entry --------
+    //
+    // All `xmss.PublicKey.fromBytes` calls happen on this thread. The Rust FFI
+    // for pubkey deserialization is not documented as `Send`, and `setupVerifier`
+    // (called transitively) carries first-time-init races. By doing every FFI
+    // construction here we ensure the parallel worker only invokes
+    // `aggregate()` on already-deserialized handles.
+    //
+    // All wrapper handles are owned by `pubkey_wrappers`; we deinit each at the
+    // end so Rust handles do not leak. The slice arrays themselves live in a
+    // single `prep_slice_arena` to keep cleanup branch-free.
+    var pubkey_wrappers: std.ArrayList(xmss.PublicKey) = .empty;
+    defer {
+        for (pubkey_wrappers.items) |*pw| pw.deinit();
+        pubkey_wrappers.deinit(allocator);
+    }
+
+    var prep_slice_arena = std.heap.ArenaAllocator.init(allocator);
+    defer prep_slice_arena.deinit();
+    const prep_alloc = prep_slice_arena.allocator();
+
+    const preps = try allocator.alloc(CompactGroupPrep, group_entries.items.len);
+    defer allocator.free(preps);
+
+    for (group_entries.items, 0..) |entry, ei| {
+        if (entry.indices.len == 1) {
+            preps[ei] = .{ .entry = entry, .child_pk_slices = &.{} };
+            continue;
+        }
+
+        const child_arr = try prep_alloc.alloc([]*const xmss.HashSigPublicKey, entry.indices.len);
+
+        for (entry.indices, 0..) |sig_idx, child_i| {
+            const child = &sig_slice[sig_idx];
+            var n_participants: usize = 0;
+            for (0..child.participants.len()) |i| {
+                if (child.participants.get(i) catch false) n_participants += 1;
+            }
+
+            const cpks = try prep_alloc.alloc(*const xmss.HashSigPublicKey, n_participants);
+
+            var cpk_idx: usize = 0;
+            for (0..child.participants.len()) |i| {
+                if (child.participants.get(i) catch false) {
+                    if (i >= validators.len()) continue;
+                    const val = validators.get(@intCast(i)) catch continue;
+                    const pk = xmss.PublicKey.fromBytes(&val.attestation_pubkey) catch continue;
+                    try pubkey_wrappers.append(allocator, pk);
+                    cpks[cpk_idx] = pk.handle;
+                    cpk_idx += 1;
+                }
+            }
+            child_arr[child_i] = cpks[0..cpk_idx];
+        }
+
+        preps[ei] = .{ .entry = entry, .child_pk_slices = child_arr };
+    }
+
     if (thread_pool) |pool| {
-        // Parallelize per-AttestationData compaction on the shared worker pool.
-        const slots = try allocator.alloc(CompactGroupSlot, group_entries.items.len);
+        // Parallel path: per-AttestationData aggregation across the shared
+        // worker pool. Workers receive prebuilt `CompactGroupPrep` and never
+        // touch FFI deserialization themselves.
+        const slots = try allocator.alloc(CompactGroupSlot, preps.len);
         defer allocator.free(slots);
         for (slots) |*slot| slot.* = .{};
         errdefer {
@@ -1038,28 +1112,26 @@ pub fn compactAttestations(
         const Runner = struct {
             fn runScope(
                 scope: anytype,
-                entries: []const CompactGroupEntry,
+                preps_in: []const CompactGroupPrep,
                 sigs: []const aggregation.AggregatedSignatureProof,
-                vals: *const Validators,
                 alloc: Allocator,
                 out_slots: []CompactGroupSlot,
                 any_err: *std.atomic.Value(bool),
             ) Allocator.Error!void {
-                for (entries, 0..) |entry, i| {
-                    try scope.spawn(runOne, .{ alloc, entry, sigs, vals, &out_slots[i], any_err });
+                for (preps_in, 0..) |prep, i| {
+                    try scope.spawn(runOne, .{ alloc, prep, sigs, &out_slots[i], any_err });
                 }
             }
 
             fn runOne(
                 alloc: Allocator,
-                entry: CompactGroupEntry,
+                prep: CompactGroupPrep,
                 sigs: []const aggregation.AggregatedSignatureProof,
-                vals: *const Validators,
                 out_slot: *CompactGroupSlot,
                 any_err: *std.atomic.Value(bool),
             ) void {
                 if (any_err.load(.acquire)) return;
-                const result = compactAttestationGroup(alloc, entry.att_data, entry.indices, sigs, vals) catch |err| {
+                const result = runCompactGroupPrep(alloc, prep, sigs) catch |err| {
                     out_slot.err = err;
                     any_err.store(true, .release);
                     return;
@@ -1070,9 +1142,8 @@ pub fn compactAttestations(
 
         var any_err = std.atomic.Value(bool).init(false);
         try pool.scope(Runner.runScope, .{
-            group_entries.items,
+            preps,
             sig_slice,
-            validators,
             allocator,
             slots,
             &any_err,
@@ -1099,8 +1170,8 @@ pub fn compactAttestations(
             sig_moved = true;
         }
     } else {
-        for (group_entries.items) |entry| {
-            var result = try compactAttestationGroup(allocator, entry.att_data, entry.indices, sig_slice, validators);
+        for (preps) |prep| {
+            var result = try runCompactGroupPrep(allocator, prep, sig_slice);
 
             var att_moved = false;
             var sig_moved = false;


### PR DESCRIPTION
Follow-up to #780 (now merged into `main`). Targets `main`. Each fix is independent — no consensus impact, all corrections are local to the parallel paths introduced by #780.

## Bot review classification

Adversarial review on #780 raised six concerns. Verdict + action:

| # | Concern | Verdict | This PR |
|---|---------|---------|---------|
| 1 | `pool.scope` synchronicity — *Critical, memory safety* | **Invalid**. `lib.zig:466-484` does `defer self.scopeWait(&s)` and the wait loop drains `pending == 0` before return. Doc string explicitly says *"block until every task spawned on `scope` has completed"* | No fix needed |
| 2 | Unvetted thread-pool dep — *High, supply chain* | **Process concern**, not addressable in code | Out of scope. Requires governance decision (vendor / fork / continue pinning by hash) |
| 3 | XMSS FFI thread-safety — *High* | **Mostly invalid**, but real adjacent risk | Pre-warm `xmss.setupVerifier()` on main thread; hoist `xmss.PublicKey.fromBytes` out of workers in `compactAttestations` |
| 4 | Thread-pool ownership inconsistency — *Medium* | **Valid observation, not a bug**: `cli/main.zig` (devnet) and `cli/node.zig` (Node struct) are mutually exclusive code paths. No deployment runs both | No structural change. Documented invariants on `chain.thread_pool` so future consumers understand the contract |
| 5 | `compactAttestations` not fully reviewed — *Medium, liveness risk* | **Mostly invalid** (`aggregation_bits` derived from same `proof.participants`, cannot diverge). But real determinism gap missed by the bot: hashmap iteration order | Sort `group_entries` deterministically by `AttestationData` |
| 6 | Metrics timer semantics — *Low* | **Valid** | Per-task histogram observation in `verifySignaturesParallel`, matching serial granularity |

Bot also missed: shared allocator across parallel workers (production = GPA = thread-safe; documented), and `setupVerifier` first-call race (fixed by pre-warm).

## Changes

### `pkgs/state-transition/src/transition.zig`
- `VerifyTask` carries `elapsed_ns: u64`. Worker times the FFI verify call with `std.time.Timer` (monotonic) and stores ns into the task slot.
- Post-pool emit replaces the single batch `observe()` with one `Histogram.record(elapsed_s)` per verified task. Histogram percentiles now match the serial path's granularity.

### `pkgs/types/src/block.zig`
- New `CompactGroupPrep` carries pre-built per-child `[]*const HashSigPublicKey` slices.
- New helpers `compactSingleProof` / `compactMultiProofWithPrep` / `runCompactGroupPrep` replace the monolithic `compactAttestationGroup`.
- All `xmss.PublicKey.fromBytes` calls happen serially in a pre-phase before `pool.scope`. Workers receive prebuilt handles and only invoke `aggregate()` (which takes const handles).
- `pubkey_wrappers` ArrayList owns wrapper lifetime for the duration of the scope call; freed on unwind.
- `group_entries` sorted by `AttestationData` (slot → head/target/source root bytes → checkpoint slots) before any processing. Both serial and parallel branches consume the sorted list.

### `pkgs/cli/src/main.zig` and `pkgs/cli/src/node.zig`
- Both pool-creation sites call `xmss.setupVerifier()` immediately after `ThreadPool.init`, before any consumer runs a parallel verify. Removes first-time-init race regardless of Rust implementation.

### `pkgs/node/src/chain.zig`
- Expanded doc comment on `BeamChain.thread_pool` to spell out the three invariants new consumers must preserve (allocator thread-safety, `setupVerifier` pre-warm, `PublicKeyCache` non-thread-safety).

## Test plan

- [x] `zig build all` — clean rebuild, EXIT=0.
- [x] `zig build test` — all existing unit tests pass.
- [x] `zeam --help` — built CLI starts and prints usage.
- [ ] Devnet: confirm `lean_pq_sig_aggregated_signatures_verification_time_seconds` percentiles look reasonable under the parallel path (should match serial baseline).
- [ ] Devnet: confirm two validators producing the same attestation set emit byte-identical blocks (covered by deterministic sort).