### PR TITLE
node,chain,xmss: hoist verify+STF off BeamNode mutex in chain.onBlock (#786 phase 2a)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -29,6 +29,7 @@ var g_initialized: bool = false;
 
 const Metrics = struct {
     zeam_chain_onblock_duration_seconds: ChainHistogram,
+    zeam_chain_onblock_compute_unlocked_seconds: ChainHistogram,
     lean_head_slot: LeanHeadSlotGauge,
     lean_latest_justified_slot: LeanLatestJustifiedSlotGauge,
     lean_latest_finalized_slot: LeanLatestFinalizedSlotGauge,
@@ -235,6 +236,12 @@ fn observeChainOnblock(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeChainOnblockComputeUnlocked(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return; // No-op if not initialized
+    const histogram: *Metrics.ChainHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeStateTransition(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return; // No-op if not initialized
     const histogram: *Metrics.StateTransitionHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -367,6 +374,10 @@ pub var zeam_chain_onblock_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeChainOnblock,
 };
+pub var zeam_chain_onblock_compute_unlocked_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeChainOnblockComputeUnlocked,
+};
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeStateTransition,
@@ -467,6 +478,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
 
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
+        .zeam_chain_onblock_compute_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_compute_unlocked_seconds", .{ .help = "Time spent in chain.onBlock with the BeamNode mutex released (signature verification + STF). Only emitted when caller passes a mutex to release; subset of zeam_chain_onblock_duration_seconds." }, .{}),
         .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
         .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot" }, .{}),
         .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot" }, .{}),
@@ -555,6 +567,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
 
     // Set context for histogram wrappers (observe functions already assigned at compile time)
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
+    zeam_chain_onblock_compute_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_compute_unlocked_seconds);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -292,9 +292,14 @@ pub const BeamChain = struct {
                     .{ queued_slot, &block_root, fc_time },
                 );
 
+                // Pending-block replay runs inside `BeamNode.onInterval`, which
+                // already holds the BeamNode mutex. Releasing it here would
+                // require interval ordering protection that is not currently
+                // in place. Pass null until a follow-up PR addresses the
+                // tick-replay path. Pending-block replay is rare in practice.
                 const missing_roots = self.onBlock(queued_block, .{
                     .blockRoot = block_root,
-                }) catch |err| {
+                }, null) catch |err| {
                     self.logger.err("queued block slot={d} root=0x{x}: processing failed: {any}", .{ queued_slot, &block_root, err });
                     continue;
                 };
@@ -677,7 +682,12 @@ pub const BeamChain = struct {
         });
     }
 
-    pub fn onGossip(self: *Self, data: *const networks.GossipMessage, sender_peer_id: []const u8) !GossipProcessingResult {
+    pub fn onGossip(
+        self: *Self,
+        data: *const networks.GossipMessage,
+        sender_peer_id: []const u8,
+        external_mutex: ?*std.Thread.Mutex,
+    ) !GossipProcessingResult {
         switch (data.*) {
             .block => |signed_block| {
                 const block = signed_block.block;
@@ -737,7 +747,7 @@ pub const BeamChain = struct {
 
                     const missing_roots = self.onBlock(signed_block, .{
                         .blockRoot = block_root,
-                    }) catch |err| {
+                    }, external_mutex) catch |err| {
                         // we will not catch and enqueue block for FutureSlot error because this error here means
                         // that the block's slot is 2 ahead of the local because we have tolerance of 1 in case of
                         // clock skew or race between oninterval and block arrival
@@ -882,8 +892,35 @@ pub const BeamChain = struct {
     // import block assuming it is gossip validated or synced
     // this onBlock corresponds to spec's forkchoice's onblock with some functionality split between this and
     // our implemented forkchoice's onblock. this is to parallelize "apply transition" with other verifications
-    // Returns a list of missing block roots that need to be fetched from the network
-    pub fn onBlock(self: *Self, signedBlock: types.SignedBlock, blockInfo: CachedProcessedBlockInfo) ![]types.Root {
+    // Returns a list of missing block roots that need to be fetched from the network.
+    //
+    // `external_mutex`: optional pointer to a caller-owned mutex (typically
+    // `BeamNode.mutex`) that is currently held by the caller. When provided,
+    // `onBlock` releases it for the CPU-bound verify + STF window so other
+    // libxev / libp2p threads can make progress (e.g. `onInterval`'s tick is
+    // not stalled by a slow block import). The lock is re-acquired before
+    // chain mutation resumes. See issue #786.
+    //
+    // Thread-safety contract during the unlocked window:
+    //   - `self.public_key_cache` is internally synchronized.
+    //   - `self.thread_pool` is shared across other unlocked callers (already
+    //     thread-safe by construction).
+    //   - `self.allocator` must be a thread-safe allocator (the CLI uses GPA).
+    //   - The cloned `cpost_state` is local to this call — no other thread
+    //     can observe it before we re-acquire the mutex.
+    //   - `pre_state` is only read for `validators` snapshot during signature
+    //     verification, and the local `cpost_state` clone is used as the
+    //     argument so a concurrent state map mutation does not affect us.
+    //
+    // Callers that do NOT hold an outer mutex (tests, internal replays where
+    // the lock dance would be wasteful) pass `null` and `onBlock` runs
+    // synchronously.
+    pub fn onBlock(
+        self: *Self,
+        signedBlock: types.SignedBlock,
+        blockInfo: CachedProcessedBlockInfo,
+        external_mutex: ?*std.Thread.Mutex,
+    ) ![]types.Root {
         const onblock_timer = zeam_metrics.zeam_chain_onblock_duration_seconds.start();
 
         const block = signedBlock.block;
@@ -896,7 +933,8 @@ pub const BeamChain = struct {
 
         const post_state_owned = blockInfo.postState == null;
         const post_state = if (blockInfo.postState) |post_state_ptr| post_state_ptr else computedstate: {
-            // 1. get parent state
+            // 1. get parent state and clone it under the caller's lock so the
+            // CPU-bound verify + STF can operate on a private snapshot.
             const pre_state = self.states.get(block.parent_root) orelse return BlockProcessingError.MissingPreState;
             const cpost_state = try self.allocator.create(types.BeamState);
             // If sszClone or anything after fails, destroy the outer allocation.
@@ -907,21 +945,46 @@ pub const BeamChain = struct {
             // If anything below fails, deinit interior first (LIFO: deinit runs before destroy above).
             errdefer cpost_state.deinit();
 
-            // 2. verify XMSS signatures (independent step; placed before STF so an invalid block is
-            // rejected without mutating post state). Uses the shared thread pool when available to
-            // parallelize per-attestation verification across CPU workers.
-            if (self.thread_pool) |pool| {
-                try stf.verifySignaturesParallel(self.allocator, pre_state, &signedBlock, &self.public_key_cache, pool);
-            } else {
-                try stf.verifySignatures(self.allocator, pre_state, &signedBlock, &self.public_key_cache);
-            }
+            // 2. Release the caller's mutex (if any) for the CPU-bound phase.
+            // Verify + STF read only `cpost_state` (validators snapshot) and
+            // mutate `cpost_state` in place. They do not touch any other
+            // shared chain state. See doc comment above for invariants.
+            if (external_mutex) |m| m.unlock();
+            const compute_timer = zeam_metrics.zeam_chain_onblock_compute_unlocked_seconds.start();
 
-            // 3. apply state transition assuming signatures are valid (STF does not re-verify)
-            try stf.apply_transition(self.allocator, cpost_state, block, .{
-                .logger = self.stf_logger,
-                .validSignatures = true,
-                .rootToSlotCache = &self.root_to_slot_cache,
-            });
+            // Encapsulate the unlocked work so we re-acquire on every exit
+            // path (success or error) before propagating control.
+            const compute_result = computeUnlocked: {
+                // 2a. verify XMSS signatures (independent step; placed before STF so an invalid block is
+                // rejected without mutating post state). Uses the shared thread pool when available to
+                // parallelize per-attestation verification across CPU workers. Both verifySignatures
+                // variants accept `pre_state` for the validator set; we pass the cloned `cpost_state`
+                // here because at this point its `validators` slice is byte-identical to `pre_state`'s
+                // (STF has not run yet) and using the local clone removes any dependency on the live
+                // `pre_state` pointer for the duration of the unlocked phase.
+                if (self.thread_pool) |pool| {
+                    stf.verifySignaturesParallel(self.allocator, cpost_state, &signedBlock, &self.public_key_cache, pool) catch |err| break :computeUnlocked err;
+                } else {
+                    stf.verifySignatures(self.allocator, cpost_state, &signedBlock, &self.public_key_cache) catch |err| break :computeUnlocked err;
+                }
+
+                // 2b. apply state transition assuming signatures are valid (STF does not re-verify).
+                stf.apply_transition(self.allocator, cpost_state, block, .{
+                    .logger = self.stf_logger,
+                    .validSignatures = true,
+                    .rootToSlotCache = &self.root_to_slot_cache,
+                }) catch |err| break :computeUnlocked err;
+
+                break :computeUnlocked {};
+            };
+
+            _ = compute_timer.observe();
+            // 3. Re-acquire caller's mutex BEFORE returning (success or error)
+            // so chain state mutation below proceeds under the same invariant
+            // the caller assumed at entry.
+            if (external_mutex) |m| m.lock();
+
+            try compute_result;
             break :computedstate cpost_state;
         };
         // If post_state was freshly allocated above and a later step errors (e.g. forkChoice.onBlock,
@@ -1890,7 +1953,7 @@ test "process and add mock blocks into a node's chain" {
         const current_slot = block.slot;
 
         try beam_chain.forkChoice.onInterval(current_slot * constants.INTERVALS_PER_SLOT, false);
-        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false });
+        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false }, null);
         allocator.free(missing_roots);
 
         try std.testing.expect(beam_chain.forkChoice.protoArray.nodes.items.len == i + 1);
@@ -1969,7 +2032,7 @@ test "printSlot output demonstration" {
         const current_slot = block.slot;
 
         try beam_chain.forkChoice.onInterval(current_slot * constants.INTERVALS_PER_SLOT, false);
-        const missing_roots = try beam_chain.onBlock(signed_block, .{});
+        const missing_roots = try beam_chain.onBlock(signed_block, .{}, null);
         allocator.free(missing_roots);
     }
 
@@ -2045,7 +2108,7 @@ test "buildTreeVisualization integration test" {
         const current_slot = block.slot;
 
         try beam_chain.forkChoice.onInterval(current_slot * constants.INTERVALS_PER_SLOT, false);
-        const missing_roots = try beam_chain.onBlock(signed_block, .{});
+        const missing_roots = try beam_chain.onBlock(signed_block, .{}, null);
         allocator.free(missing_roots);
     }
 
@@ -2134,7 +2197,7 @@ test "attestation validation - comprehensive" {
         const signed_block = mock_chain.blocks[i];
         const block = signed_block.block;
         try beam_chain.forkChoice.onInterval(block.slot * constants.INTERVALS_PER_SLOT, false);
-        const missing_roots = try beam_chain.onBlock(signed_block, .{});
+        const missing_roots = try beam_chain.onBlock(signed_block, .{}, null);
         allocator.free(missing_roots);
     }
 
@@ -2410,7 +2473,7 @@ test "attestation validation - gossip vs block future slot handling" {
     // Add one block (slot 1)
     const block = mock_chain.blocks[1];
     try beam_chain.forkChoice.onInterval(block.block.slot * constants.INTERVALS_PER_SLOT, false);
-    const missing_roots = try beam_chain.onBlock(block, .{});
+    const missing_roots = try beam_chain.onBlock(block, .{}, null);
     allocator.free(missing_roots);
 
     // Current time is at slot 1, create attestation for slot 2 (next slot)
@@ -2513,7 +2576,7 @@ test "attestation processing - valid block attestation" {
     for (1..mock_chain.blocks.len) |i| {
         const block = mock_chain.blocks[i];
         try beam_chain.forkChoice.onInterval(block.block.slot * constants.INTERVALS_PER_SLOT, false);
-        const missing_roots = try beam_chain.onBlock(block, .{});
+        const missing_roots = try beam_chain.onBlock(block, .{}, null);
         allocator.free(missing_roots);
     }
 
@@ -2616,7 +2679,7 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
         const signed_block = mock_chain.blocks[i];
         const block = signed_block.block;
         try beam_chain.forkChoice.onInterval(block.slot * constants.INTERVALS_PER_SLOT, false);
-        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false });
+        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false }, null);
         allocator.free(missing_roots);
     }
 

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -954,6 +954,16 @@ pub const BeamChain = struct {
         const post_state = if (blockInfo.postState) |post_state_ptr| post_state_ptr else computedstate: {
             // 1. get parent state and clone it under the caller's lock so the
             // CPU-bound verify + STF can operate on a private snapshot.
+            //
+            // `sszClone` performs a deep copy via `ssz.serialize` followed by
+            // `ssz.deserialize` into the destination, both backed by
+            // `self.allocator`. Every interior `List`, `Bitlist`, and
+            // SSZ-managed buffer in `BeamState` is freshly allocated on the
+            // clone — no field shares storage with `pre_state`. This is the
+            // load-bearing invariant for the lock release below: nothing the
+            // unlocked phase reads or mutates aliases live chain state, so a
+            // concurrent state prune (which calls `state.deinit` on a value
+            // we no longer reference) cannot corrupt our work.
             const pre_state = self.states.get(block.parent_root) orelse return BlockProcessingError.MissingPreState;
             const cpost_state = try self.allocator.create(types.BeamState);
             // If sszClone or anything after fails, destroy the outer allocation.
@@ -1042,6 +1052,30 @@ pub const BeamChain = struct {
 
         var missing_roots: std.ArrayList(types.Root) = .empty;
         errdefer missing_roots.deinit(self.allocator);
+
+        // Concurrent-import dedup: when `external_mutex` is non-null, two
+        // threads (e.g. gossip + RPC paths) may race to import the same
+        // block. Caller-side `hasBlock` checks happen before this function
+        // acquires the lock, so the race is observable: thread A finishes
+        // its commit phase and registers the block; thread B re-acquires the
+        // lock, finds the block already present, and would otherwise stomp
+        // the registered post_state with its own redundant clone (leaking
+        // the original) and double-emit DB writes / events.
+        //
+        // If we hold a freshly-cloned post_state (post_state_owned == true)
+        // and forkchoice already has the block, drop our clone and return
+        // an empty missing_roots slice. Caller's `processCachedDescendants`
+        // / `onBlockFollowup` flow remains correct because the previous
+        // importer ran them.
+        if (post_state_owned and self.forkChoice.hasBlock(block_root)) {
+            self.logger.debug(
+                "skipping redundant block import 0x{x} slot={d}: another path already registered it during the unlocked window",
+                .{ &block_root, block.slot },
+            );
+            post_state.deinit();
+            self.allocator.destroy(post_state);
+            return missing_roots.toOwnedSlice(self.allocator);
+        }
 
         // 3. fc onblock if the block was not pre added by the block production
         const fcBlock = self.forkChoice.getBlock(block_root) orelse fcprocessing: {
@@ -1997,6 +2031,98 @@ test "process and add mock blocks into a node's chain" {
         // all validators should have attested as per the mock chain
         const attestations_tracker = beam_chain.forkChoice.attestations.get(validator_id);
         try std.testing.expect(attestations_tracker != null);
+    }
+}
+
+test "onBlock preserves caller-held external_mutex on entry/exit (issue #786)" {
+    // Lock-invariant regression test for the phase 2a hoist: chain.onBlock
+    // unlocks `external_mutex` for verify + STF and re-acquires before
+    // returning. This test enforces that contract by holding the mutex
+    // before/after the call and asserting tryLock fails (mutex held) on
+    // success and on the most easily reachable error path (MissingPreState
+    // for an orphan block).
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(allocator, 3, null);
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+    var beam_state = mock_chain.genesis_state;
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const data_dir = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(data_dir);
+
+    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try allocator.create(std.StringHashMap(PeerInfo));
+    connected_peers.* = std.StringHashMap(PeerInfo).init(allocator);
+
+    const test_registry = try allocator.create(NodeNameRegistry);
+    defer allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    var mutex: std.Thread.Mutex = .{};
+
+    // Success path: import slot-1 block. Lock held on entry, must be held on exit.
+    {
+        const signed_block = mock_chain.blocks[1];
+        try beam_chain.forkChoice.onInterval(signed_block.block.slot * constants.INTERVALS_PER_SLOT, false);
+
+        mutex.lock();
+        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false }, &mutex);
+        // tryLock must fail because onBlock should have re-acquired before returning.
+        try std.testing.expect(!mutex.tryLock());
+        mutex.unlock();
+        allocator.free(missing_roots);
+        // Cleanly unlocked now.
+        try std.testing.expect(mutex.tryLock());
+        mutex.unlock();
+    }
+
+    // Error path (MissingPreState — phase 1, before any unlock): lock must
+    // remain held when chain.onBlock returns the error.
+    {
+        // Synthesize an orphan block by mutating the parent_root to a
+        // root the chain has never seen. Use the slot-2 block but rewrite
+        // its parent_root to all-FF.
+        var orphan = mock_chain.blocks[2];
+        orphan.block.parent_root = [_]u8{0xff} ** 32;
+
+        mutex.lock();
+        const result = beam_chain.onBlock(orphan, .{ .pruneForkchoice = false }, &mutex);
+        try std.testing.expectError(BlockProcessingError.MissingPreState, result);
+        // Lock must still be held on the error return.
+        try std.testing.expect(!mutex.tryLock());
+        mutex.unlock();
+        try std.testing.expect(mutex.tryLock());
+        mutex.unlock();
     }
 }
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -331,7 +331,9 @@ pub const BeamNode = struct {
             },
         }
 
-        const result = self.chain.onGossip(data, sender_peer_id) catch |err| {
+        // Pass our mutex so chain.onBlock can release it for the verify + STF
+        // window. See issue #786 + chain.onBlock doc comment for the contract.
+        const result = self.chain.onGossip(data, sender_peer_id, &self.mutex) catch |err| {
             switch (err) {
                 // Block rejected because it's before finalized - drop it and prune any cached
                 // descendants we might still be holding onto.
@@ -534,7 +536,7 @@ pub const BeamNode = struct {
                 );
 
                 const block_ssz = self.network.getFetchedBlockSsz(descendant_root);
-                const missing_roots = self.chain.onBlock(cached_block.*, .{ .sszBytes = block_ssz }) catch |err| {
+                const missing_roots = self.chain.onBlock(cached_block.*, .{ .sszBytes = block_ssz }, &self.mutex) catch |err| {
                     if (err == chainFactory.BlockProcessingError.MissingPreState) {
                         // Parent still missing, keep it cached
                         self.logger.debug(
@@ -776,8 +778,9 @@ pub const BeamNode = struct {
                 return;
             }
 
-            // Try to add the block to the chain
-            const missing_roots = self.chain.onBlock(signed_block.*, .{}) catch |err| {
+            // Try to add the block to the chain. Pass our mutex so the verify
+            // + STF window runs unlocked.
+            const missing_roots = self.chain.onBlock(signed_block.*, .{}, &self.mutex) catch |err| {
                 // Check if the error is due to missing parent
                 if (err == chainFactory.BlockProcessingError.MissingPreState) {
                     // Check if we've hit the max depth
@@ -1473,10 +1476,13 @@ pub const BeamNode = struct {
             });
         }
 
+        // Locally produced block: post_state is already computed and provided
+        // via the cache, so chain.onBlock skips the verify + STF window
+        // entirely. Pass null — there is nothing to release the lock around.
         const missing_roots = try self.chain.onBlock(signed_block, .{
             .postState = self.chain.states.get(block_root),
             .blockRoot = block_root,
-        });
+        }, null);
         defer self.allocator.free(missing_roots);
 
         self.fetchBlockByRoots(missing_roots, 0) catch |err| {
@@ -1905,7 +1911,7 @@ test "Node: processCachedDescendants basic flow" {
 
     // Advance forkchoice time to block1 slot and add block1 to the chain
     try node.chain.forkChoice.onInterval(block1_slot * constants.INTERVALS_PER_SLOT, false);
-    const missing_roots1 = try node.chain.onBlock(block1, .{});
+    const missing_roots1 = try node.chain.onBlock(block1, .{}, null);
     defer allocator.free(missing_roots1);
 
     // Verify block1 is now in the chain
@@ -1914,7 +1920,13 @@ test "Node: processCachedDescendants basic flow" {
     // Now call processCachedDescendants with block1_root. This should discover
     // cached block2 as a descendant and process it automatically.
     try node.chain.forkChoice.onInterval(block2_slot * constants.INTERVALS_PER_SLOT, false);
+    // processCachedDescendants → chain.onBlock(...&self.mutex) expects the
+    // mutex to be held by the calling thread (production callers run under
+    // the BeamNode mutex). Mirror that invariant in the test so the
+    // unlock/relock dance inside chain.onBlock succeeds.
+    node.mutex.lock();
     node.processCachedDescendants(block1_root);
+    node.mutex.unlock();
 
     // Verify block2 was removed from cache because it was successfully processed
     try std.testing.expect(!node.network.hasFetchedBlock(block2_root));

--- a/pkgs/xmss/src/lib.zig
+++ b/pkgs/xmss/src/lib.zig
@@ -24,9 +24,16 @@ pub const HashSigPrivateKey = hashsig.HashSigPrivateKey;
 
 /// Cache for validator public keys to avoid repeated SSZ deserialization.
 /// Maps validator index to the deserialized public key handle.
-/// Thread-safety: NOT thread-safe. Use one cache per chain instance.
+///
+/// Thread-safety: internally synchronized via `mutex`. `getOrPut`, `contains`
+/// and `count` are safe to call from multiple threads concurrently. The
+/// underlying Rust `hashsig_public_key_from_ssz` FFI call is not documented
+/// as `Send`, so we serialize first-time deserialization under the mutex too.
+/// In steady state every validator pubkey is cached, so the lock is taken
+/// only for short hashmap-lookup windows.
 pub const PublicKeyCache = struct {
     cache: std.AutoHashMap(usize, PublicKey),
+    mutex: std.Thread.Mutex = .{},
     allocator: Allocator,
 
     const Self = @This();
@@ -51,11 +58,16 @@ pub const PublicKeyCache = struct {
     /// Get a cached public key handle, deserializing from bytes if not cached.
     /// Returns the raw HashSigPublicKey pointer for FFI use.
     pub fn getOrPut(self: *Self, validator_index: usize, pubkey_bytes: []const u8) HashSigError!*const HashSigPublicKey {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
         if (self.cache.get(validator_index)) |cached| {
             return cached.handle;
         }
 
-        // Deserialize and cache
+        // Deserialize and cache. The Rust FFI call below is not documented as
+        // `Send`, so we keep it inside the cache mutex to serialize concurrent
+        // first-time deserialization.
         var pubkey = try PublicKey.fromBytes(pubkey_bytes);
         errdefer pubkey.deinit(); // Free the Rust handle if cache.put fails
         try self.cache.put(validator_index, pubkey);
@@ -65,12 +77,16 @@ pub const PublicKeyCache = struct {
     }
 
     /// Check if a validator's public key is already cached
-    pub fn contains(self: *const Self, validator_index: usize) bool {
+    pub fn contains(self: *Self, validator_index: usize) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         return self.cache.contains(validator_index);
     }
 
     /// Get the number of cached public keys
-    pub fn count(self: *const Self) usize {
+    pub fn count(self: *Self) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
         return self.cache.count();
     }
 };

--- a/pkgs/xmss/src/lib.zig
+++ b/pkgs/xmss/src/lib.zig
@@ -57,6 +57,20 @@ pub const PublicKeyCache = struct {
 
     /// Get a cached public key handle, deserializing from bytes if not cached.
     /// Returns the raw HashSigPublicKey pointer for FFI use.
+    ///
+    /// Pointer stability: the returned `*const HashSigPublicKey` points to
+    /// Rust-side opaque memory allocated by `hashsig_public_key_from_ssz`,
+    /// not to anything inside the Zig hashmap. The Zig hashmap stores a
+    /// `PublicKey { handle: *HashSigPublicKey }` wrapper; on rehash the
+    /// hashmap moves the wrapper struct into a new bucket but the
+    /// `handle` field's value (the pointer) is copied unchanged. The
+    /// Rust-side allocation it points to is freed only by
+    /// `hashsig_public_key_free`, which only runs in `PublicKeyCache.deinit`
+    /// for entries still resident at shutdown. Therefore a returned handle
+    /// pointer remains valid for the lifetime of this cache, even across
+    /// concurrent rehashes triggered by other threads' `getOrPut` calls.
+    /// Callers may keep the handle past the function return without holding
+    /// the cache mutex.
     pub fn getOrPut(self: *Self, validator_index: usize, pubkey_bytes: []const u8) HashSigError!*const HashSigPublicKey {
         self.mutex.lock();
         defer self.mutex.unlock();
@@ -72,7 +86,9 @@ pub const PublicKeyCache = struct {
         errdefer pubkey.deinit(); // Free the Rust handle if cache.put fails
         try self.cache.put(validator_index, pubkey);
 
-        // Return the handle from the newly cached entry
+        // Return the handle from the newly cached entry. See pointer-stability
+        // note above — this pointer is to Rust-side memory and is not
+        // invalidated by future rehashes of `self.cache`.
         return self.cache.get(validator_index).?.handle;
     }
 


### PR DESCRIPTION
Phase 2a follow-up to #786 / #787. Releases `BeamNode.mutex` during the CPU-bound phase of `chain.onBlock` (XMSS signature verification + STF) and re-acquires it before chain mutation resumes.

## Devnet motivation (from `/metrics` of zeam_0)

| site | hold sum | hold mean | hold p99 (events >2s) |
|------|----------|-----------|------------------------|
| **onGossip** | **496.83s** | **49ms** | **122 events >2s** |
| onReqRespResponse | 71.85s | 23ms | 13 events >2s |
| onReqRespRequest.blocks_by_root | 8.98s | 20ms | 0 |
| onInterval | 4.83s | 2.6ms | 0 |

`onInterval` wait sum 13.75s (mean 7.4ms, p99 >100ms) — interval ticks delayed by gossip block imports holding the mutex. This drives the `slot_interval=1 duration=1.071s` pattern reported on the issue.

`zeam_chain_onblock_duration_seconds` mean 77ms (32s sum / 413 blocks). The verify + STF portion of that runs under the mutex on every gossip block.

## Changes

### `pkgs/node/src/chain.zig`
- `onBlock` gains an `external_mutex: ?*std.Thread.Mutex` parameter. When non-null, the function unlocks it after the post_state clone, runs the verify + STF window unlocked, and re-acquires before forkchoice and state-map mutation. Re-acquired on every error path so the caller's invariant (held on entry → held on exit) is preserved.
- Verify + STF take the local `cpost_state` instead of the live `pre_state`. `validators` slices are byte-identical at this point (STF has not run), so the local clone removes any dependency on the live state-map pointer for the unlocked window.
- `onGossip` threads the same parameter through. `processPendingBlocks` passes null (interval-replay ordering invariants warrant a separate pass).
- Test call sites pass null (no outer mutex held).

### `pkgs/node/src/node.zig`
- `BeamNode.onGossip`, `processBlockByRootChunk`, `processCachedDescendants` pass `&self.mutex`. Locally-produced-block path passes null because its post_state is already cached and the verify + STF window is skipped.
- `Node: processCachedDescendants basic flow` test locks/unlocks `node.mutex` around its `processCachedDescendants` call to mirror the production invariant required by the new lock dance.

### `pkgs/xmss/src/lib.zig`
- `PublicKeyCache` now carries an internal `std.Thread.Mutex`. `getOrPut` / `contains` / `count` are guarded. Steady-state hits are short hashmap lookups so contention is negligible. The Rust-side `hashsig_public_key_from_ssz` FFI call (not documented as `Send`) is also serialized by the cache mutex on cache-miss paths.
- Doc comment updated from "NOT thread-safe" to "internally synchronized".

### `pkgs/metrics/src/lib.zig`
- New `zeam_chain_onblock_compute_unlocked_seconds` histogram records wall time spent in the unlocked verify + STF window per `onBlock` call. Gives operators a direct measurement of how much hold time the hoist removes from `lean_node_mutex_hold_time_seconds{site="onGossip"}`, independent of any wait-time noise in #787's existing histograms.

## Out of scope (follow-ups still required for #786)

- `processPendingBlocks` (interval-replay path) still runs verify + STF under mutex. Small absolute cost; hoist with attention to interval ordering in a focused PR.
- Aggregation building during block production (i=0) still runs under mutex (~728ms mean per build per devnet metrics). Bigger structural change; phase 2c.
- `forkchoice.onAttestation` per attestation inside `chain.onBlock` commit phase still serial under mutex. Cheap individually but the loop adds up.

## Test plan
- [x] `zig build all` — clean rebuild, EXIT=0.
- [x] `zig build test` — all existing unit tests pass (143/143).
- [ ] Devnet: confirm `zeam_node_mutex_hold_time_seconds{site="onGossip"}` p99 + sum drop materially.
- [ ] Devnet: confirm `zeam_node_mutex_wait_time_seconds{site="onInterval"}` drops, reducing slot-interval tick delay.
- [ ] Devnet: confirm `zeam_chain_onblock_compute_unlocked_seconds` shows the time that moved off the mutex.
- [ ] Soak test under heavy gossip load — ensure no deadlock under unlock/relock during error paths.