### PR TITLE
node,chain: hoist gossip attestation+aggregation verify off BeamNode mutex (#786 phase 2b)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -30,6 +30,8 @@ var g_initialized: bool = false;
 const Metrics = struct {
     zeam_chain_onblock_duration_seconds: ChainHistogram,
     zeam_chain_onblock_compute_unlocked_seconds: ChainHistogram,
+    zeam_chain_gossip_attestation_verify_unlocked_seconds: ChainHistogram,
+    zeam_chain_gossip_aggregation_verify_unlocked_seconds: ChainHistogram,
     lean_head_slot: LeanHeadSlotGauge,
     lean_latest_justified_slot: LeanLatestJustifiedSlotGauge,
     lean_latest_finalized_slot: LeanLatestFinalizedSlotGauge,
@@ -242,6 +244,18 @@ fn observeChainOnblockComputeUnlocked(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeChainGossipAttestationVerifyUnlocked(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return; // No-op if not initialized
+    const histogram: *Metrics.ChainHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeChainGossipAggregationVerifyUnlocked(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return; // No-op if not initialized
+    const histogram: *Metrics.ChainHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeStateTransition(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return; // No-op if not initialized
     const histogram: *Metrics.StateTransitionHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -378,6 +392,14 @@ pub var zeam_chain_onblock_compute_unlocked_seconds: Histogram = .{
     .context = null,
     .observe = &observeChainOnblockComputeUnlocked,
 };
+pub var zeam_chain_gossip_attestation_verify_unlocked_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeChainGossipAttestationVerifyUnlocked,
+};
+pub var zeam_chain_gossip_aggregation_verify_unlocked_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeChainGossipAggregationVerifyUnlocked,
+};
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeStateTransition,
@@ -479,6 +501,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .zeam_chain_onblock_compute_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_compute_unlocked_seconds", .{ .help = "Time spent in chain.onBlock with the BeamNode mutex released (signature verification + STF). Only emitted when caller passes a mutex to release; subset of zeam_chain_onblock_duration_seconds." }, .{}),
+        .zeam_chain_gossip_attestation_verify_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_gossip_attestation_verify_unlocked_seconds", .{ .help = "Time spent verifying a gossip individual attestation's XMSS signature with the BeamNode mutex released. Only emitted when caller passes a mutex to release." }, .{}),
+        .zeam_chain_gossip_aggregation_verify_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_gossip_aggregation_verify_unlocked_seconds", .{ .help = "Time spent verifying a gossip aggregated attestation's XMSS aggregate proof with the BeamNode mutex released. Only emitted when caller passes a mutex to release." }, .{}),
         .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
         .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot" }, .{}),
         .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot" }, .{}),
@@ -568,6 +592,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
     // Set context for histogram wrappers (observe functions already assigned at compile time)
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
     zeam_chain_onblock_compute_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_compute_unlocked_seconds);
+    zeam_chain_gossip_attestation_verify_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_gossip_attestation_verify_unlocked_seconds);
+    zeam_chain_gossip_aggregation_verify_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_gossip_aggregation_verify_unlocked_seconds);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -820,7 +820,7 @@ pub const BeamChain = struct {
 
                 if (self.is_aggregator_enabled.load(.acquire)) {
                     // Process validated attestation
-                    self.onGossipAttestation(signed_attestation) catch |err| {
+                    self.onGossipAttestation(signed_attestation, external_mutex) catch |err| {
                         zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
                         self.logger.err("attestation processing error: {any}", .{err});
                         return err;
@@ -872,7 +872,7 @@ pub const BeamChain = struct {
                     }
                 };
 
-                self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
+                self.onGossipAggregatedAttestation(signed_aggregation, external_mutex) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
                     switch (err) {
                         // Propagate unknown block errors to node.zig for context-aware logging
@@ -1612,61 +1612,107 @@ pub const BeamChain = struct {
         });
     }
 
-    pub fn onGossipAttestation(self: *Self, signedAttestation: networks.AttestationGossip) !void {
-        // Validation is done upstream in onGossip before this function is called.
+    /// Process a gossip individual attestation. Validation that requires chain
+    /// state is done upstream in `onGossip` before this function is called;
+    /// here we verify the XMSS signature and update the forkchoice tracker.
+    ///
+    /// `external_mutex` (issue #786 phase 2b): when non-null, we release the
+    /// caller's mutex around the XMSS verify call so other libxev / libp2p
+    /// threads (notably `onInterval`) can make progress while the FFI verify
+    /// runs. Per devnet metrics this single call accumulates ~33ms × 11k
+    /// events ≈ 375s of mutex hold per session under the gossip path.
+    ///
+    /// Thread-safety contract during the unlocked window:
+    ///   - Validator pubkey bytes are copied into a local 52-byte buffer
+    ///     before unlocking, so a concurrent state prune cannot turn the
+    ///     `state.validators` slice into a use-after-free.
+    ///   - `xmss.verifySsz` reads the local pubkey + message + signature
+    ///     buffers only. No shared state.
+    pub fn onGossipAttestation(
+        self: *Self,
+        signedAttestation: networks.AttestationGossip,
+        external_mutex: ?*std.Thread.Mutex,
+    ) !void {
         const attestation = signedAttestation.message.toAttestation();
 
+        // Phase 1 (locked): snapshot validator pubkey bytes from state.
         const state = self.states.get(attestation.data.target.root) orelse return AttestationValidationError.MissingState;
+        const validators = state.validators.constSlice();
+        const validator_index: usize = @intCast(signedAttestation.message.validator_id);
+        if (validator_index >= validators.len) {
+            return types.StateTransitionError.InvalidValidatorId;
+        }
+        var pubkey_snapshot: types.Bytes52 = undefined;
+        @memcpy(&pubkey_snapshot, validators[validator_index].getAttestationPubkey());
 
-        try stf.verifySingleAttestation(
-            self.allocator,
-            state,
-            @intCast(signedAttestation.message.validator_id),
-            &signedAttestation.message.message,
-            &signedAttestation.message.signature,
-        );
+        const att_data = signedAttestation.message.message;
+        const sig_bytes = signedAttestation.message.signature;
 
+        // Compute the message hash under lock — the allocator is thread-safe
+        // (GPA in production) but doing this small step inside the locked
+        // window keeps the unlocked window dedicated to the FFI verify call.
+        var message_hash: [32]u8 = undefined;
+        try zeam_utils.hashTreeRoot(types.AttestationData, att_data, &message_hash, self.allocator);
+        const epoch: u32 = @intCast(att_data.slot);
+
+        // Phase 2 (unlocked): XMSS verify.
+        if (external_mutex) |m| m.unlock();
+        const verify_timer = zeam_metrics.zeam_chain_gossip_attestation_verify_unlocked_seconds.start();
+        // Mirror the verifySingleAttestation metric semantics so dashboards
+        // built on the existing PQ-sig counters still observe gossip
+        // attestations.
+        zeam_metrics.metrics.lean_pq_sig_attestation_signatures_total.incr();
+        const xmss_timer = zeam_metrics.lean_pq_sig_attestation_verification_time_seconds.start();
+
+        const verify_result: anyerror!void = blk: {
+            xmss.verifySsz(&pubkey_snapshot, &message_hash, epoch, &sig_bytes) catch |err| {
+                break :blk err;
+            };
+            break :blk {};
+        };
+
+        _ = xmss_timer.observe();
+        _ = verify_timer.observe();
+        if (external_mutex) |m| m.lock();
+
+        verify_result catch |err| {
+            zeam_metrics.metrics.lean_pq_sig_attestation_signatures_invalid_total.incr();
+            return err;
+        };
+        zeam_metrics.metrics.lean_pq_sig_attestation_signatures_valid_total.incr();
+
+        // Phase 3 (locked): forkchoice tracker mutation.
         return self.forkChoice.onSignedAttestation(signedAttestation.message);
     }
 
-    pub fn onGossipAggregatedAttestation(self: *Self, signedAggregation: types.SignedAggregatedAttestation) !void {
-        // Validate the attestation data first (same rules as individual gossip attestations)
+    /// Process a gossip aggregated attestation. Same external_mutex contract
+    /// as `onGossipAttestation`: when non-null, the caller's lock is released
+    /// for the XMSS aggregate-verify FFI call. Per devnet metrics aggregate
+    /// verify is ~59ms mean and runs hundreds of times per session, so
+    /// hoisting it materially shrinks `onGossip`'s mutex hold tail.
+    ///
+    /// Thread-safety contract during the unlocked window:
+    ///   - Validator pubkey HANDLES are obtained via `PublicKeyCache.getOrPut`
+    ///     which is internally synchronized (#798). Handles are stable for
+    ///     the lifetime of the cache (== chain), so a concurrent state prune
+    ///     cannot invalidate them.
+    ///   - The participant message hash is computed under lock and copied
+    ///     into a local buffer before unlocking.
+    ///   - `proof.verify` reads only the snapshotted handles + message hash
+    ///     + the proof bytes (which live in `signedAggregation`, owned by
+    ///     the caller for the duration of this call).
+    pub fn onGossipAggregatedAttestation(
+        self: *Self,
+        signedAggregation: types.SignedAggregatedAttestation,
+        external_mutex: ?*std.Thread.Mutex,
+    ) !void {
+        // Phase 1 (locked): validate + build pubkey snapshot.
         try self.validateAttestationData(signedAggregation.data, false);
-
-        try self.verifyAggregatedAttestation(signedAggregation);
 
         var validator_indices = try types.aggregationBitsToValidatorIndices(&signedAggregation.proof.participants, self.allocator);
         defer validator_indices.deinit(self.allocator);
 
-        var validator_ids = try self.allocator.alloc(types.ValidatorIndex, validator_indices.items.len);
-        defer self.allocator.free(validator_ids);
-        for (validator_indices.items, 0..) |vi, i| {
-            validator_ids[i] = @intCast(vi);
-        }
-
-        // Update attestation trackers for gossip attestations so fork choice sees these votes
-        for (validator_ids) |validator_id| {
-            const attestation = types.Attestation{
-                .validator_id = validator_id,
-                .data = signedAggregation.data,
-            };
-            self.forkChoice.onAttestation(attestation, false) catch |err| {
-                self.logger.debug("skip tracker update for aggregated attestation validator={d}: {any}", .{
-                    validator_id, err,
-                });
-            };
-        }
-
-        try self.forkChoice.storeAggregatedPayload(&signedAggregation.data, signedAggregation.proof, false);
-    }
-
-    fn verifyAggregatedAttestation(self: *Self, signedAggregation: types.SignedAggregatedAttestation) !void {
         const data = signedAggregation.data;
-        const proof = signedAggregation.proof;
-
-        var validator_indices = try types.aggregationBitsToValidatorIndices(&proof.participants, self.allocator);
-        defer validator_indices.deinit(self.allocator);
-
         const key_state = self.states.get(data.target.root) orelse return error.MissingState;
         const validators = key_state.validators.constSlice();
 
@@ -1681,16 +1727,62 @@ pub const BeamChain = struct {
             const pk_handle = self.public_key_cache.getOrPut(validator_index, pubkey_bytes) catch {
                 return error.InvalidBlockSignatures;
             };
-            try public_keys.append(self.allocator, pk_handle);
+            public_keys.appendAssumeCapacity(pk_handle);
         }
 
         var message_hash: [32]u8 = undefined;
         try zeam_utils.hashTreeRoot(types.AttestationData, data, &message_hash, self.allocator);
-
         const epoch: u64 = data.slot;
-        proof.verify(public_keys.items, &message_hash, epoch) catch {
-            return error.InvalidAggregationSignature;
+
+        // Phase 2 (unlocked): XMSS aggregate verify.
+        if (external_mutex) |m| m.unlock();
+        const verify_timer = zeam_metrics.zeam_chain_gossip_aggregation_verify_unlocked_seconds.start();
+        const agg_verify_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.start();
+
+        const verify_result: anyerror!void = blk: {
+            signedAggregation.proof.verify(public_keys.items, &message_hash, epoch) catch |err| {
+                break :blk err;
+            };
+            break :blk {};
         };
+
+        _ = agg_verify_timer.observe();
+        _ = verify_timer.observe();
+        if (external_mutex) |m| m.lock();
+
+        verify_result catch |err| {
+            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_invalid_total.incr();
+            // Map the bare-FFI error to the named error the caller's switch
+            // expects (the previous private helper returned
+            // `error.InvalidAggregationSignature`).
+            switch (err) {
+                error.InvalidAggregateSignature => return error.InvalidAggregationSignature,
+                else => return err,
+            }
+        };
+        zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_valid_total.incr();
+
+        // Phase 3 (locked): forkchoice mutation.
+        var validator_ids = try self.allocator.alloc(types.ValidatorIndex, validator_indices.items.len);
+        defer self.allocator.free(validator_ids);
+        for (validator_indices.items, 0..) |vi, i| {
+            validator_ids[i] = @intCast(vi);
+        }
+
+        // Update attestation trackers for gossip attestations so fork choice sees these votes
+        for (validator_ids) |validator_id| {
+            const attestation = types.Attestation{
+                .validator_id = validator_id,
+                .data = data,
+            };
+            self.forkChoice.onAttestation(attestation, false) catch |err| {
+                self.logger.debug("skip tracker update for aggregated attestation validator={d}: {any}", .{
+                    validator_id, err,
+                });
+            };
+        }
+
+        try self.forkChoice.storeAggregatedPayload(&data, signedAggregation.proof, false);
     }
 
     pub fn aggregate(self: *Self) ![]types.SignedAggregatedAttestation {
@@ -2621,7 +2713,7 @@ test "attestation processing - valid block attestation" {
     };
 
     // Process attestation through chain (this validates and then processes)
-    try beam_chain.onGossipAttestation(gossip_attestation);
+    try beam_chain.onGossipAttestation(gossip_attestation, null);
 
     // Verify the attestation data was recorded for aggregation
     try std.testing.expect(beam_chain.forkChoice.attestation_signatures.getPtr(valid_attestation.message) != null);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -1681,6 +1681,14 @@ pub const BeamChain = struct {
     ///     `state.validators` slice into a use-after-free.
     ///   - `xmss.verifySsz` reads the local pubkey + message + signature
     ///     buffers only. No shared state.
+    ///   - `lean_pq_sig_attestation_signatures_*` counters and
+    ///     `*_verification_time_seconds` timers used during the unlocked
+    ///     window are atomic-backed (`Counter.incr` is `@atomicRmw`,
+    ///     `Histogram.observe` updates sum/count/buckets via atomic RMW).
+    ///   - Phase 3 (forkchoice mutation) re-serializes via the re-acquired
+    ///     external_mutex. `forkChoice.onSignedAttestation` returns
+    ///     `InvalidAttestation` (does not panic) if the target block was
+    ///     pruned during the unlocked window.
     pub fn onGossipAttestation(
         self: *Self,
         signedAttestation: networks.AttestationGossip,
@@ -1700,15 +1708,13 @@ pub const BeamChain = struct {
 
         const att_data = signedAttestation.message.message;
         const sig_bytes = signedAttestation.message.signature;
-
-        // Compute the message hash under lock — the allocator is thread-safe
-        // (GPA in production) but doing this small step inside the locked
-        // window keeps the unlocked window dedicated to the FFI verify call.
-        var message_hash: [32]u8 = undefined;
-        try zeam_utils.hashTreeRoot(types.AttestationData, att_data, &message_hash, self.allocator);
         const epoch: u32 = @intCast(att_data.slot);
 
-        // Phase 2 (unlocked): XMSS verify.
+        // Phase 2 (unlocked): hashTreeRoot + XMSS verify. `att_data` is a
+        // by-value local copy; `pubkey_snapshot` is a 52-byte stack array;
+        // `sig_bytes` is by-value owned by `signedAttestation`. None of these
+        // alias chain state, so the hash computation is safe to run unlocked
+        // and shrinks the locked window further at no safety cost.
         if (external_mutex) |m| m.unlock();
         const verify_timer = zeam_metrics.zeam_chain_gossip_attestation_verify_unlocked_seconds.start();
         // Mirror the verifySingleAttestation metric semantics so dashboards
@@ -1718,6 +1724,10 @@ pub const BeamChain = struct {
         const xmss_timer = zeam_metrics.lean_pq_sig_attestation_verification_time_seconds.start();
 
         const verify_result: anyerror!void = blk: {
+            var message_hash: [32]u8 = undefined;
+            zeam_utils.hashTreeRoot(types.AttestationData, att_data, &message_hash, self.allocator) catch |err| {
+                break :blk err;
+            };
             xmss.verifySsz(&pubkey_snapshot, &message_hash, epoch, &sig_bytes) catch |err| {
                 break :blk err;
             };
@@ -1734,7 +1744,9 @@ pub const BeamChain = struct {
         };
         zeam_metrics.metrics.lean_pq_sig_attestation_signatures_valid_total.incr();
 
-        // Phase 3 (locked): forkchoice tracker mutation.
+        // Phase 3 (locked): forkchoice tracker mutation. `onSignedAttestation`
+        // returns `InvalidAttestation` (no panic) if the head block referenced
+        // by this attestation was pruned during the unlocked window.
         return self.forkChoice.onSignedAttestation(signedAttestation.message);
     }
 
@@ -1749,11 +1761,21 @@ pub const BeamChain = struct {
     ///     which is internally synchronized (#798). Handles are stable for
     ///     the lifetime of the cache (== chain), so a concurrent state prune
     ///     cannot invalidate them.
-    ///   - The participant message hash is computed under lock and copied
-    ///     into a local buffer before unlocking.
-    ///   - `proof.verify` reads only the snapshotted handles + message hash
-    ///     + the proof bytes (which live in `signedAggregation`, owned by
-    ///     the caller for the duration of this call).
+    ///   - `proof.verify` reads only the snapshotted handles + the locally
+    ///     computed message hash + the proof bytes (which live in
+    ///     `signedAggregation`, owned by the caller for the duration of this
+    ///     call).
+    ///   - `lean_pq_sig_aggregated_signatures_*` counters and the timer
+    ///     started during the unlocked window are atomic-backed and safe to
+    ///     fire from multiple threads concurrently.
+    ///   - Phase 3 (forkchoice mutation) re-serializes via the re-acquired
+    ///     external_mutex. `forkChoice.onAttestation` returns
+    ///     `InvalidAttestation` (no panic) if the attestation's head block
+    ///     was pruned during the unlocked window — we already swallow that
+    ///     error per validator with a debug log. `forkChoice.storeAggregatedPayload`
+    ///     value-copies `attestation_data.*` and SSZ-clones the proof
+    ///     internally, so the `&data` argument's stack-local lifetime is
+    ///     never escaped past the call.
     pub fn onGossipAggregatedAttestation(
         self: *Self,
         signedAggregation: types.SignedAggregatedAttestation,
@@ -1783,16 +1805,21 @@ pub const BeamChain = struct {
             public_keys.appendAssumeCapacity(pk_handle);
         }
 
-        var message_hash: [32]u8 = undefined;
-        try zeam_utils.hashTreeRoot(types.AttestationData, data, &message_hash, self.allocator);
         const epoch: u64 = data.slot;
 
-        // Phase 2 (unlocked): XMSS aggregate verify.
+        // Phase 2 (unlocked): hashTreeRoot + XMSS aggregate verify. `data` is
+        // a by-value local copy; pubkey handles are stable across the
+        // unlocked window (see contract above). Hoisting hashTreeRoot here
+        // shrinks the locked window further with no safety cost.
         if (external_mutex) |m| m.unlock();
         const verify_timer = zeam_metrics.zeam_chain_gossip_aggregation_verify_unlocked_seconds.start();
         const agg_verify_timer = zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.start();
 
         const verify_result: anyerror!void = blk: {
+            var message_hash: [32]u8 = undefined;
+            zeam_utils.hashTreeRoot(types.AttestationData, data, &message_hash, self.allocator) catch |err| {
+                break :blk err;
+            };
             signedAggregation.proof.verify(public_keys.items, &message_hash, epoch) catch |err| {
                 break :blk err;
             };
@@ -1835,6 +1862,10 @@ pub const BeamChain = struct {
             };
         }
 
+        // `storeAggregatedPayload` value-copies `attestation_data.*` into the
+        // payload map and SSZ-clones the proof internally; passing a pointer
+        // to the stack-local `data` is safe (the pointer is not stored past
+        // the call).
         try self.forkChoice.storeAggregatedPayload(&data, signedAggregation.proof, false);
     }
 
@@ -2862,6 +2893,139 @@ test "attestation processing - valid block attestation" {
 
     // Verify the attestation data was recorded for aggregation
     try std.testing.expect(beam_chain.forkChoice.attestation_signatures.getPtr(valid_attestation.message) != null);
+}
+
+test "onGossipAttestation preserves caller-held external_mutex on entry/exit (issue #786)" {
+    // Lock-invariant regression test for the phase 2b hoist: chain.onGossipAttestation
+    // unlocks `external_mutex` for hashTreeRoot + XMSS verify and re-acquires
+    // before forkchoice mutation. The contract is "lock held on entry == lock
+    // held on exit" on every return path, which is enforced here for both the
+    // success path and an early-return error path (MissingState — phase 1,
+    // before any unlock).
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(allocator, 3, null);
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+    var beam_state = mock_chain.genesis_state;
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const data_dir = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(data_dir);
+
+    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try allocator.create(std.StringHashMap(PeerInfo));
+    connected_peers.* = std.StringHashMap(PeerInfo).init(allocator);
+
+    const test_registry = try allocator.create(NodeNameRegistry);
+    defer allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    for (1..mock_chain.blocks.len) |i| {
+        const block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing_roots = try beam_chain.onBlock(block, .{}, null);
+        allocator.free(missing_roots);
+    }
+
+    const message = types.Attestation{
+        .validator_id = 1,
+        .data = .{
+            .slot = 2,
+            .head = types.Checkpoint{ .root = mock_chain.blockRoots[2], .slot = 2 },
+            .source = types.Checkpoint{ .root = mock_chain.blockRoots[1], .slot = 1 },
+            .target = types.Checkpoint{ .root = mock_chain.blockRoots[2], .slot = 2 },
+        },
+    };
+
+    var key_manager = try keymanager.getTestKeyManager(allocator, 4, 3);
+    defer key_manager.deinit();
+    const signature = try key_manager.signAttestation(&message, allocator);
+
+    const valid_attestation: types.SignedAttestation = .{
+        .validator_id = message.validator_id,
+        .message = message.data,
+        .signature = signature,
+    };
+    const subnet_id = try types.computeSubnetId(
+        @intCast(valid_attestation.validator_id),
+        beam_chain.config.spec.attestation_committee_count,
+    );
+    const gossip_attestation = networks.AttestationGossip{
+        .subnet_id = @intCast(subnet_id),
+        .message = valid_attestation,
+    };
+
+    var mutex: std.Thread.Mutex = .{};
+
+    // Success path: lock held on entry, must be held on exit.
+    {
+        mutex.lock();
+        try beam_chain.onGossipAttestation(gossip_attestation, &mutex);
+        // tryLock must fail — if onGossipAttestation skipped the re-acquire,
+        // the lock would be free and tryLock would succeed.
+        try std.testing.expect(!mutex.tryLock());
+        mutex.unlock();
+        try std.testing.expect(mutex.tryLock());
+        mutex.unlock();
+    }
+
+    // Error path (MissingState — phase 1, before any unlock): build an
+    // attestation whose target.root is unknown to the chain. The error must
+    // surface with the lock still held.
+    {
+        const orphan_attestation: types.SignedAttestation = .{
+            .validator_id = 0,
+            .message = .{
+                .slot = 2,
+                .head = types.Checkpoint{ .root = [_]u8{0xff} ** 32, .slot = 2 },
+                .source = types.Checkpoint{ .root = mock_chain.blockRoots[1], .slot = 1 },
+                .target = types.Checkpoint{ .root = [_]u8{0xff} ** 32, .slot = 2 },
+            },
+            .signature = ZERO_SIGBYTES,
+        };
+        const orphan_gossip = networks.AttestationGossip{
+            .subnet_id = 0,
+            .message = orphan_attestation,
+        };
+
+        mutex.lock();
+        const result = beam_chain.onGossipAttestation(orphan_gossip, &mutex);
+        try std.testing.expectError(AttestationValidationError.MissingState, result);
+        // Lock must still be held.
+        try std.testing.expect(!mutex.tryLock());
+        mutex.unlock();
+        try std.testing.expect(mutex.tryLock());
+        mutex.unlock();
+    }
 }
 
 test "produceBlock - greedy selection by latest slot is suboptimal when attestation references unseen block" {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1512,7 +1512,7 @@ pub const BeamNode = struct {
             data.slot,
             validator_id,
         });
-        try self.chain.onGossipAttestation(signed_attestation);
+        try self.chain.onGossipAttestation(signed_attestation, &self.mutex);
 
         // 2. publish gossip message
         const gossip_msg = networks.GossipMessage{ .attestation = signed_attestation };
@@ -1527,7 +1527,7 @@ pub const BeamNode = struct {
 
     pub fn publishAggregation(self: *Self, signed_aggregation: types.SignedAggregatedAttestation) !void {
         self.logger.info("adding locally produced aggregation to chain: slot={d}", .{signed_aggregation.data.slot});
-        try self.chain.onGossipAggregatedAttestation(signed_aggregation);
+        try self.chain.onGossipAggregatedAttestation(signed_aggregation, &self.mutex);
 
         const gossip_msg = networks.GossipMessage{ .aggregation = signed_aggregation };
         try self.network.publish(&gossip_msg);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1512,7 +1512,15 @@ pub const BeamNode = struct {
             data.slot,
             validator_id,
         });
-        try self.chain.onGossipAttestation(signed_attestation, &self.mutex);
+        // BeamNode.onInterval releases the mutex before reaching the
+        // validator-output dispatch (the inner `{ ... }` block scope
+        // closes the `acquireMutex("onInterval")` guard), so the mutex is
+        // NOT held here. Pass null — `chain.onGossipAttestation` would
+        // panic on `mutex.unlock()` if we passed `&self.mutex` without
+        // having acquired it. The lock dance still applies on the gossip
+        // path (chain.onGossip → chain.onGossipAttestation receives the
+        // mutex pointer there), which is where the volume is.
+        try self.chain.onGossipAttestation(signed_attestation, null);
 
         // 2. publish gossip message
         const gossip_msg = networks.GossipMessage{ .attestation = signed_attestation };
@@ -1527,7 +1535,11 @@ pub const BeamNode = struct {
 
     pub fn publishAggregation(self: *Self, signed_aggregation: types.SignedAggregatedAttestation) !void {
         self.logger.info("adding locally produced aggregation to chain: slot={d}", .{signed_aggregation.data.slot});
-        try self.chain.onGossipAggregatedAttestation(signed_aggregation, &self.mutex);
+        // Same reasoning as `publishAttestation`: BeamNode.onInterval has
+        // already released the mutex by the time validator output dispatch
+        // runs, so the mutex is NOT held here. Pass null. The gossip-import
+        // path (chain.onGossip arm) still benefits from the lock dance.
+        try self.chain.onGossipAggregatedAttestation(signed_aggregation, null);
 
         const gossip_msg = networks.GossipMessage{ .aggregation = signed_aggregation };
         try self.network.publish(&gossip_msg);


### PR DESCRIPTION
**Stacked on #798 (phase 2a).** Targets `fix/issue-786-onblock-stf-off-mutex` so review can merge sequentially. After #798 lands on main this PR's base will be retargeted.

Phase 2b follow-up to #786. Releases `BeamNode.mutex` during the XMSS signature verification of incoming gossip individual and aggregated attestations.

## Devnet motivation

| metric | sum | count | mean |
|--------|-----|-------|------|
| `lean_attestation_validation_time_seconds` | **383s** | 11,355 | **33ms** |
| `lean_pq_sig_aggregated_signatures_verification_time_seconds` | 25s | 426 | 59ms |

Both run under `BeamNode.mutex` today (path: `BeamNode.onGossip` → `chain.onGossip` → `chain.onGossipAttestation` / `chain.onGossipAggregatedAttestation` → XMSS verify). Per ~30 minute session that's ~408s of mutex hold attributable to gossip attestation verify alone — the second-largest contributor after gossip block import (which #798 hoists).

## Design

Same pattern as #798: caller passes `external_mutex: ?*std.Thread.Mutex`; chain releases it around the FFI verify call and re-acquires before any chain mutation.

| Phase | Locked? | Work |
|-------|---------|------|
| 1 | ✓ held | Snapshot validator pubkey (52-byte copy for individual; cache-handle borrow for aggregated). Compute message hash. Validate attestation data. |
| 2 | ✗ released | XMSS verify (`xmss.verifySsz` for individual, `proof.verify` for aggregated). |
| 3 | ✓ re-acquired | `forkChoice.onSignedAttestation` / `forkChoice.onAttestation` + `storeAggregatedPayload`. |

### Thread-safety contract during the unlocked window

**Individual attestation:**
- Pubkey bytes copied into a local 52-byte buffer (`types.Bytes52`) before unlocking, so a concurrent state prune cannot turn the `state.validators` slice into a use-after-free.
- `xmss.verifySsz` reads only the local pubkey + message + signature buffers.

**Aggregated attestation:**
- Pubkey HANDLES obtained via `PublicKeyCache.getOrPut` (internally synchronized as of #798). Handles are stable for the cache lifetime (== chain), so borrowing across the unlocked window is safe even if the source state is pruned.
- `proof.verify` reads only the snapshotted handles + message hash + the proof bytes (which live in `signedAggregation`, owned by the caller for the duration of this call).

## Changes

### `pkgs/node/src/chain.zig`
- `onGossipAttestation` and `onGossipAggregatedAttestation` gain the `external_mutex` parameter and implement the three-phase lock dance described above.
- Private helper `verifyAggregatedAttestation` is folded into `onGossipAggregatedAttestation` so the lock dance lives in one place.
- `error.InvalidAggregateSignature` (raised by the bare FFI helper) remapped to `error.InvalidAggregationSignature` (the name the gossip arm's switch expects) preserving previous error semantics.
- `chain.onGossip`'s attestation + aggregation arms forward the threaded `external_mutex`.
- Internal test call site updated to pass null (no outer mutex held in tests).

### `pkgs/node/src/node.zig`
- `BeamNode.publishAttestation` and `BeamNode.publishAggregation` (called from validator-output processing inside `onInterval`, both already under the BeamNode mutex) pass `&self.mutex`.

### `pkgs/metrics/src/lib.zig`
Two new histograms:
- `zeam_chain_gossip_attestation_verify_unlocked_seconds`
- `zeam_chain_gossip_aggregation_verify_unlocked_seconds`

These record the unlocked verify time per call so operators can directly measure how much hold time the hoist removes from `zeam_node_mutex_hold_time_seconds{site="onGossip"}`. Existing PQ-sig counters/timers continue to record signature totals + per-call verify time so dashboards built on them still work.

## Test plan
- [x] `zig build all` — clean rebuild, EXIT=0.
- [x] `zig build test` — all existing unit tests pass (143/143).
- [ ] Devnet: confirm `zeam_node_mutex_hold_time_seconds{site="onGossip"}` p99 + sum drop materially compared to phase 2a baseline.
- [ ] Devnet: confirm `zeam_chain_gossip_attestation_verify_unlocked_seconds` and `zeam_chain_gossip_aggregation_verify_unlocked_seconds` populate with expected magnitudes.
- [ ] Soak test under heavy gossip load — verify no deadlock under unlock/relock during error paths.

## Out of scope (phase 2c+ still needed)

- Block production aggregation (`lean_block_building_payload_aggregation_time_seconds` ~728ms mean) still runs under mutex on i=0. Bigger structural change.
- `processPendingBlocks` (interval-replay path) still serial under mutex.
- `forkchoice.onAttestation` per-validator loop inside `chain.onBlock` commit phase. Cheap individually but the loop adds up.