### PR TITLE
node,chain: hoist block production aggregation+STF off BeamNode mutex (#786 phase 2c)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -32,6 +32,7 @@ const Metrics = struct {
     zeam_chain_onblock_compute_unlocked_seconds: ChainHistogram,
     zeam_chain_gossip_attestation_verify_unlocked_seconds: ChainHistogram,
     zeam_chain_gossip_aggregation_verify_unlocked_seconds: ChainHistogram,
+    zeam_chain_produceblock_compute_unlocked_seconds: BlockBuildingTimeHistogram,
     lean_head_slot: LeanHeadSlotGauge,
     lean_latest_justified_slot: LeanLatestJustifiedSlotGauge,
     lean_latest_finalized_slot: LeanLatestFinalizedSlotGauge,
@@ -256,6 +257,12 @@ fn observeChainGossipAggregationVerifyUnlocked(ctx: ?*anyopaque, value: f32) voi
     histogram.observe(value);
 }
 
+fn observeChainProduceblockComputeUnlocked(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return; // No-op if not initialized
+    const histogram: *Metrics.BlockBuildingTimeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeStateTransition(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return; // No-op if not initialized
     const histogram: *Metrics.StateTransitionHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -400,6 +407,10 @@ pub var zeam_chain_gossip_aggregation_verify_unlocked_seconds: Histogram = .{
     .context = null,
     .observe = &observeChainGossipAggregationVerifyUnlocked,
 };
+pub var zeam_chain_produceblock_compute_unlocked_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeChainProduceblockComputeUnlocked,
+};
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
     .observe = &observeStateTransition,
@@ -503,6 +514,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_chain_onblock_compute_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_compute_unlocked_seconds", .{ .help = "Time spent in chain.onBlock with the BeamNode mutex released (signature verification + STF). Only emitted when caller passes a mutex to release; subset of zeam_chain_onblock_duration_seconds." }, .{}),
         .zeam_chain_gossip_attestation_verify_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_gossip_attestation_verify_unlocked_seconds", .{ .help = "Time spent verifying a gossip individual attestation's XMSS signature with the BeamNode mutex released. Only emitted when caller passes a mutex to release." }, .{}),
         .zeam_chain_gossip_aggregation_verify_unlocked_seconds = Metrics.ChainHistogram.init("zeam_chain_gossip_aggregation_verify_unlocked_seconds", .{ .help = "Time spent verifying a gossip aggregated attestation's XMSS aggregate proof with the BeamNode mutex released. Only emitted when caller passes a mutex to release." }, .{}),
+        .zeam_chain_produceblock_compute_unlocked_seconds = Metrics.BlockBuildingTimeHistogram.init("zeam_chain_produceblock_compute_unlocked_seconds", .{ .help = "Time spent in chain.produceBlock with the BeamNode mutex released (proposal-attestations aggregation + STF + block hash). Only emitted when caller passes a mutex to release; subset of lean_block_building_time_seconds." }, .{}),
         .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
         .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot" }, .{}),
         .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot" }, .{}),
@@ -594,6 +606,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     zeam_chain_onblock_compute_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_compute_unlocked_seconds);
     zeam_chain_gossip_attestation_verify_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_gossip_attestation_verify_unlocked_seconds);
     zeam_chain_gossip_aggregation_verify_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_gossip_aggregation_verify_unlocked_seconds);
+    zeam_chain_produceblock_compute_unlocked_seconds.context = @ptrCast(&metrics.zeam_chain_produceblock_compute_unlocked_seconds);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -431,25 +431,51 @@ pub const BeamChain = struct {
         };
     }
 
-    pub fn produceBlock(self: *Self, opts: BlockProductionParams) !ProducedBlock {
+    /// Construct a fresh block for the given slot/proposer.
+    ///
+    /// `external_mutex` (issue #786 phase 2c): when non-null, the caller's
+    /// mutex is released around the CPU-heavy phase — proposal-attestation
+    /// aggregation + STF + block hash. Per devnet metrics block building
+    /// runs at ~826ms mean (12.07s aggregation work over 15 builds), which
+    /// single-handedly stalls 1+ libxev tick when held under BeamNode.mutex.
+    ///
+    /// Thread-safety contract during the unlocked window:
+    ///   - The cloned `post_state` is local to this call. STF mutates it
+    ///     in place; nothing else can observe it before we re-acquire.
+    ///   - `getProposalAttestations` reads forkchoice internal state under
+    ///     forkchoice's own RwLock (shared). Concurrent `onGossipBlock` /
+    ///     `storeAggregatedPayload` paths take the RwLock for write, so
+    ///     reads serialize correctly even with the outer BeamNode.mutex
+    ///     released. We pass `post_state` (not the live `pre_state`) as
+    ///     the validator/checkpoint snapshot for the same reason as in
+    ///     `chain.onBlock` — STF has not run yet, validators slice +
+    ///     latest_block_header + latest_justified are byte-identical to
+    ///     `pre_state` at this moment, and using the local clone removes
+    ///     dependency on the live state-map pointer for the duration of
+    ///     the unlocked window.
+    ///   - `apply_raw_block` (STF) runs entirely on the local clone.
+    ///   - `hashTreeRoot` over the constructed block is pure CPU on local
+    ///     data.
+    ///   - All counter / histogram updates during the unlocked window go
+    ///     through atomic-backed metrics primitives.
+    ///
+    /// Phase 3 (locked) handles `states.put` + `forkChoice.onBlock` +
+    /// `updateHead` so a competing thread's `onBlock` for the same root —
+    /// extremely unlikely (we just generated this block, hash unique) —
+    /// would surface as a forkchoice error rather than corrupting state.
+    pub fn produceBlock(
+        self: *Self,
+        opts: BlockProductionParams,
+        external_mutex: ?*std.Thread.Mutex,
+    ) !ProducedBlock {
         // Block building total time timer
         const block_building_timer = zeam_metrics.lean_block_building_time_seconds.start();
         errdefer {
             _ = block_building_timer.observe();
             zeam_metrics.metrics.lean_block_building_failures_total.incr();
         }
-        // dump the vote tracker, letting this stay here commented for handy debugging activation
-        // var iterator = self.forkChoice.attestations.iterator();
-        // while (iterator.next()) |entry| {
-        //     var latest_new: []const u8 = "null";
-        //     if (entry.value_ptr.latestNew) |latest_new_in| {
-        //         if (latest_new_in.attestation) |latest_new_att| {
-        //             latest_new = try latest_new_att.message.toJsonString(self.allocator);
-        //         }
-        //     }
-        //     self.logger.warn("validator id={d} vote is={s}", .{ entry.key_ptr.*, latest_new });
-        // }
 
+        // ---------------- Phase 1 (locked) ----------------
         // right now with integrated validator into node produceBlock is always gurranteed to be
         // called post ticking the chain to the correct time, but once validator is separated
         // one must make the forkchoice tick to the right time if there is a race condition
@@ -469,56 +495,95 @@ pub const BeamChain = struct {
         const post_state = post_state_opt.?;
         try types.sszClone(self.allocator, types.BeamState, pre_state.*, post_state);
 
-        const payload_agg_timer = zeam_metrics.lean_block_building_payload_aggregation_time_seconds.start();
-        const proposal_atts = try self.forkChoice.getProposalAttestations(pre_state, opts.slot, opts.proposer_index, parent_root);
-        _ = payload_agg_timer.observe();
+        // ---------------- Phase 2 (unlocked) ----------------
+        // After this point and until the matching re-lock, every read goes
+        // through `post_state` (local clone) or forkchoice's internal RwLock.
+        // No code below the unlock and above the re-lock may mutate
+        // chain-level state (chain.states, chain.root_to_slot_cache, etc.).
+        if (external_mutex) |m| m.unlock();
+        const compute_timer = zeam_metrics.zeam_chain_produceblock_compute_unlocked_seconds.start();
 
-        var agg_attestations = proposal_atts.attestations;
-        var agg_att_cleanup = true;
-        errdefer if (agg_att_cleanup) {
-            for (agg_attestations.slice()) |*att| att.deinit();
-            agg_attestations.deinit();
+        const ComputeResult = struct {
+            block: types.BeamBlock,
+            block_root: [32]u8,
+            attestation_signatures: types.AttestationSignatures,
+            num_agg_sigs: u64,
+            total_attestations_in_agg: u64,
         };
 
-        var attestation_signatures = proposal_atts.signatures;
-        var agg_sig_cleanup = true;
-        errdefer if (agg_sig_cleanup) {
-            for (attestation_signatures.slice()) |*sig| sig.deinit();
-            attestation_signatures.deinit();
-        };
+        const compute_result: anyerror!ComputeResult = compute: {
+            const payload_agg_timer = zeam_metrics.lean_block_building_payload_aggregation_time_seconds.start();
+            const proposal_atts_or_err = self.forkChoice.getProposalAttestations(post_state, opts.slot, opts.proposer_index, parent_root);
+            _ = payload_agg_timer.observe();
+            const proposal_atts = proposal_atts_or_err catch |err| break :compute err;
 
-        // Record aggregated signature metrics
-        const num_agg_sigs = attestation_signatures.len();
-        zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_total.incrBy(num_agg_sigs);
+            var agg_attestations = proposal_atts.attestations;
+            var agg_att_cleanup = true;
+            errdefer if (agg_att_cleanup) {
+                for (agg_attestations.slice()) |*att| att.deinit();
+                agg_attestations.deinit();
+            };
 
-        var total_attestations_in_agg: u64 = 0;
-        for (agg_attestations.constSlice()) |agg_att| {
-            const bits_len = agg_att.aggregation_bits.len();
-            for (0..bits_len) |i| {
-                if (agg_att.aggregation_bits.get(i) catch false) {
-                    total_attestations_in_agg += 1;
+            var attestation_signatures = proposal_atts.signatures;
+            var agg_sig_cleanup = true;
+            errdefer if (agg_sig_cleanup) {
+                for (attestation_signatures.slice()) |*sig| sig.deinit();
+                attestation_signatures.deinit();
+            };
+
+            const num_agg_sigs = attestation_signatures.len();
+            var total_attestations_in_agg: u64 = 0;
+            for (agg_attestations.constSlice()) |agg_att| {
+                const bits_len = agg_att.aggregation_bits.len();
+                for (0..bits_len) |i| {
+                    if (agg_att.aggregation_bits.get(i) catch false) {
+                        total_attestations_in_agg += 1;
+                    }
                 }
             }
-        }
-        zeam_metrics.metrics.lean_pq_sig_attestations_in_aggregated_signatures_total.incrBy(total_attestations_in_agg);
 
-        // keeping for later when execution will be integrated into lean
-        // const timestamp = self.config.genesis.genesis_time + opts.slot * params.SECONDS_PER_SLOT;
+            var block = types.BeamBlock{
+                .slot = opts.slot,
+                .proposer_index = opts.proposer_index,
+                .parent_root = parent_root,
+                .state_root = undefined,
+                .body = types.BeamBlockBody{
+                    // .execution_payload_header = .{ .timestamp = timestamp },
+                    .attestations = agg_attestations,
+                },
+            };
+            agg_att_cleanup = false; // Ownership moved to block.body.attestations
+            errdefer block.deinit();
 
-        var block = types.BeamBlock{
-            .slot = opts.slot,
-            .proposer_index = opts.proposer_index,
-            .parent_root = parent_root,
-            .state_root = undefined,
-            .body = types.BeamBlockBody{
-                // .execution_payload_header = .{ .timestamp = timestamp },
-                .attestations = agg_attestations,
-            },
+            // STF on the local clone.
+            stf.apply_raw_block(self.allocator, post_state, &block, self.block_building_logger, &self.root_to_slot_cache) catch |err| {
+                break :compute err;
+            };
+
+            // hashTreeRoot of the now-final block.
+            var block_root: [32]u8 = undefined;
+            zeam_utils.hashTreeRoot(types.BeamBlock, block, &block_root, self.allocator) catch |err| {
+                break :compute err;
+            };
+
+            agg_sig_cleanup = false; // ownership moves to ComputeResult
+            break :compute ComputeResult{
+                .block = block,
+                .block_root = block_root,
+                .attestation_signatures = attestation_signatures,
+                .num_agg_sigs = num_agg_sigs,
+                .total_attestations_in_agg = total_attestations_in_agg,
+            };
         };
-        agg_att_cleanup = false; // Ownership moved to block.body.attestations
-        errdefer block.deinit();
 
-        agg_sig_cleanup = false; // Ownership moved to attestation_signatures
+        _ = compute_timer.observe();
+        if (external_mutex) |m| m.lock();
+
+        const result = compute_result catch |err| return err;
+        var block = result.block;
+        const block_root = result.block_root;
+        var attestation_signatures = result.attestation_signatures;
+        errdefer block.deinit();
         errdefer {
             for (attestation_signatures.slice()) |*sig_group| {
                 sig_group.deinit();
@@ -526,23 +591,21 @@ pub const BeamChain = struct {
             attestation_signatures.deinit();
         }
 
+        // Phase-2 metrics emitted under re-acquired lock so they are
+        // ordered with respect to other counter updates.
+        zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_total.incrBy(result.num_agg_sigs);
+        zeam_metrics.metrics.lean_pq_sig_attestations_in_aggregated_signatures_total.incrBy(result.total_attestations_in_agg);
+
         const block_str = try block.toJsonString(self.allocator);
         defer self.allocator.free(block_str);
-
         self.logger.debug("node-{d}::going for block production opts={f} raw block={s}", .{ self.nodeId, opts, block_str });
-
-        // 2. apply STF to get post state & update post state root & cache it
-        try stf.apply_raw_block(self.allocator, post_state, &block, self.block_building_logger, &self.root_to_slot_cache);
 
         const block_str_2 = try block.toJsonString(self.allocator);
         defer self.allocator.free(block_str_2);
-
         self.logger.debug("applied raw block opts={f} raw block={s}", .{ opts, block_str_2 });
 
-        // 3. cache state to save recompute while adding the block on publish
-        var block_root: [32]u8 = undefined;
-        try zeam_utils.hashTreeRoot(types.BeamBlock, block, &block_root, self.allocator);
-
+        // ---------------- Phase 3 (locked) ----------------
+        // Cache state to save recompute while adding the block on publish.
         try self.states.put(block_root, post_state);
         post_state_opt = null;
 
@@ -554,15 +617,9 @@ pub const BeamChain = struct {
             }
         };
 
-        // 4. Advance fork choice to this block's slot so the block is not rejected as FutureSlot
-        // PS: this isn't required because forkchoice is already ticked before validator's oninterval is called
-        // which then leads to block production call
-        //
-        // try self.forkChoice.onInterval(block.slot * constants.INTERVALS_PER_SLOT, false);
-
-        // 5. Add the block to directly forkchoice as this proposer will next need to construct its vote
-        //   note - attestations packed in the block are already in the knownVotes so we don't need to re-import
-        //   them in the forkchoice
+        // Add the block directly to forkchoice; this proposer will next need
+        // to construct its vote. Attestations packed in the block are already
+        // in knownVotes so we don't need to re-import them.
         _ = try self.forkChoice.onBlock(block, post_state, .{
             .currentSlot = block.slot,
             .blockDelayMs = 0,
@@ -3124,7 +3181,7 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
     var produced = try beam_chain.produceBlock(.{
         .slot = proposal_slot,
         .proposer_index = proposal_slot % num_validators,
-    });
+    }, null);
     defer produced.deinit();
 
     // The block should contain attestation entries for both att_data since both
@@ -3155,4 +3212,86 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
     // Only the known attestation is included in the block
     try std.testing.expect(unseen_count == 0);
     try std.testing.expect(known_count > 0);
+}
+
+test "produceBlock preserves caller-held external_mutex on entry/exit (issue #786)" {
+    // Lock-invariant regression test for the phase 2c hoist: chain.produceBlock
+    // unlocks `external_mutex` for proposal-attestation aggregation + STF +
+    // block hash and re-acquires before forkchoice mutation. Asserts the
+    // contract "lock held on entry == lock held on exit" on the success
+    // path. (The phase-1 error paths share the same shape as the phase-1
+    // checks already covered by the chain.onBlock lock-invariant test.)
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(allocator, 3, null);
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+    var beam_state = mock_chain.genesis_state;
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const data_dir = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(data_dir);
+
+    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try allocator.create(std.StringHashMap(PeerInfo));
+    connected_peers.* = std.StringHashMap(PeerInfo).init(allocator);
+
+    const test_registry = try allocator.create(NodeNameRegistry);
+    defer allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    // Import slots 1 and 2 so getProposalHead returns a known head.
+    for (1..mock_chain.blocks.len) |i| {
+        const block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing_roots = try beam_chain.onBlock(block, .{}, null);
+        allocator.free(missing_roots);
+    }
+
+    // Tick forkchoice to slot 3 so produceBlock for slot 3 succeeds.
+    const proposal_slot: types.Slot = 3;
+    try beam_chain.forkChoice.onInterval(proposal_slot * constants.INTERVALS_PER_SLOT, false);
+
+    var mutex: std.Thread.Mutex = .{};
+
+    const num_validators: u64 = @intCast(mock_chain.genesis_config.numValidators());
+    mutex.lock();
+    var produced = try beam_chain.produceBlock(.{
+        .slot = proposal_slot,
+        .proposer_index = proposal_slot % num_validators,
+    }, &mutex);
+    defer produced.deinit();
+    // tryLock must fail — the lock must still be held.
+    try std.testing.expect(!mutex.tryLock());
+    mutex.unlock();
+    try std.testing.expect(mutex.tryLock());
+    mutex.unlock();
 }

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1317,7 +1317,10 @@ pub const BeamNode = struct {
             if (self.validator) |*validator| {
                 // we also tick validator per interval in case it would
                 // need to sync its future duties when its an independent validator
-                var validator_output = validator.onInterval(interval) catch |e| {
+                // Pass our mutex so chain.produceBlock can release it for the
+                // CPU-bound aggregation + STF window during block proposal
+                // (issue #786 phase 2c).
+                var validator_output = validator.onInterval(interval, &self.mutex) catch |e| {
                     self.logger.err("error ticking validator to time(intervals)={d} err={any}", .{ interval, e });
                     return e;
                 };
@@ -2393,7 +2396,7 @@ test "Node: publishBlock persists locally produced blocks for blocks-by-root syn
     const produced_block = try node.chain.produceBlock(.{
         .slot = slot,
         .proposer_index = validator_ids[0],
-    });
+    }, null);
     const produced_root = produced_block.blockRoot;
 
     const proposer_signature = try ctx.key_manager.signBlockRoot(

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1315,20 +1315,38 @@ pub const BeamNode = struct {
             }
 
             if (self.validator) |*validator| {
-                // we also tick validator per interval in case it would
-                // need to sync its future duties when its an independent validator
-                // Pass our mutex so chain.produceBlock can release it for the
-                // CPU-bound aggregation + STF window during block proposal
-                // (issue #786 phase 2c).
-                var validator_output = validator.onInterval(interval, &self.mutex) catch |e| {
-                    self.logger.err("error ticking validator to time(intervals)={d} err={any}", .{ interval, e });
-                    return e;
-                };
+                // We also tick the validator per interval so it can sync
+                // future duties when running as an independent validator.
+                //
+                // Phase 2c (issue #786): chain.produceBlock releases its
+                // caller's mutex for the CPU-bound aggregation + STF window
+                // and re-acquires before forkchoice mutation. The contract
+                // is "lock held on entry == lock held on exit", so we MUST
+                // acquire `self.mutex` before invoking validator.onInterval
+                // and release after — the surrounding `acquireMutex("onInterval")`
+                // guard above has already gone out of scope.
+                //
+                // The validator output dispatch (publish*) runs OUTSIDE this
+                // fresh mutex acquisition: each publish helper performs its
+                // own network.publish (which would otherwise stall every
+                // libp2p worker waiting on BeamNode.mutex) and the chain
+                // mutations they make pass `null` for external_mutex (the
+                // caller does not hold the lock there).
+                var validator_output_opt: ?validatorClient.ValidatorClientOutput = null;
+                defer if (validator_output_opt) |*output| output.deinit();
+                {
+                    var validator_guard = self.acquireMutex("validator.onInterval");
+                    defer validator_guard.unlock();
+                    validator_output_opt = validator.onInterval(interval, &self.mutex) catch |e| {
+                        self.logger.err("error ticking validator to time(intervals)={d} err={any}", .{ interval, e });
+                        return e;
+                    };
+                }
 
-                if (validator_output) |*output| {
-                    defer output.deinit();
+                if (validator_output_opt) |*output| {
                     for (output.gossip_messages.items) |gossip_msg| {
-                        // Process based on message type
+                        // Process based on message type. publish* helpers run
+                        // without BeamNode.mutex held — see note above.
                         switch (gossip_msg) {
                             .block => |signed_block| {
                                 self.publishBlock(signed_block) catch |e| {

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -81,13 +81,20 @@ pub const ValidatorClient = struct {
         };
     }
 
-    pub fn onInterval(self: *Self, time_intervals: usize) !?ValidatorClientOutput {
+    pub fn onInterval(
+        self: *Self,
+        time_intervals: usize,
+        external_mutex: ?*std.Thread.Mutex,
+    ) !?ValidatorClientOutput {
         const slot = @divFloor(time_intervals, constants.INTERVALS_PER_SLOT);
         const interval = time_intervals % constants.INTERVALS_PER_SLOT;
 
         // if a new slot interval may be do a proposal
         switch (interval) {
-            0 => return self.maybeDoProposal(slot),
+            // Block production releases `external_mutex` around the heavy
+            // CPU window (proposal-attestation aggregation + STF) — see
+            // issue #786 phase 2c.
+            0 => return self.maybeDoProposal(slot, external_mutex),
             1 => return self.mayBeDoAttestation(slot),
             2 => return null,
             3 => return null,
@@ -107,7 +114,11 @@ pub const ValidatorClient = struct {
         }
     }
 
-    pub fn maybeDoProposal(self: *Self, slot: usize) !?ValidatorClientOutput {
+    pub fn maybeDoProposal(
+        self: *Self,
+        slot: usize,
+        external_mutex: ?*std.Thread.Mutex,
+    ) !?ValidatorClientOutput {
         if (self.getSlotProposer(slot)) |slot_proposer_id| {
             // Check if chain is synced before producing a block
             const sync_status = self.chain.getSyncStatus();
@@ -134,7 +145,7 @@ pub const ValidatorClient = struct {
             }
 
             self.logger.debug("constructing block for slot={d} proposer={d}", .{ slot, slot_proposer_id });
-            const produced_block = try self.chain.produceBlock(.{ .slot = slot, .proposer_index = slot_proposer_id });
+            const produced_block = try self.chain.produceBlock(.{ .slot = slot, .proposer_index = slot_proposer_id }, external_mutex);
             self.logger.info("produced block for slot={d} proposer={d} with root={x}", .{ slot, slot_proposer_id, &produced_block.blockRoot });
 
             // Sign block root with proposer's proposal key


### PR DESCRIPTION
**Stacked on #799 (phase 2b), which is stacked on #798 (phase 2a).** Targets `fix/issue-786-gossip-attestation-off-mutex` so review can merge sequentially. Will retarget to `main` once #798 + #799 land.

Phase 2c follow-up to #786. Releases `BeamNode.mutex` during the CPU-heavy phase of `chain.produceBlock` — proposal-attestation aggregation + STF + block hash.

## Devnet motivation

| metric | sum | count | mean |
|--------|-----|-------|------|
| `lean_block_building_time_seconds` | 12.4s | 15 | **826ms** |
| `lean_block_building_payload_aggregation_time_seconds` | 12.07s | 15 | 805ms |

97% of block-building time is the aggregation step. Today this runs under `BeamNode.mutex` on the i=0 onInterval thread — single-handedly stalls 1+ libxev tick per proposal slot.

## Design

Same three-phase lock-dance as #798 / #799. Caller passes `external_mutex: ?*std.Thread.Mutex`; chain releases after Phase-1 state clone, runs Phase-2 unlocked, re-acquires for Phase-3 chain mutation.

| Phase | Locked? | Work |
|-------|---------|------|
| 1 | ✓ held | `getProposalHead`, `states.get(parent_root)`, sszClone parent → `post_state` |
| 2 | ✗ released | `getProposalAttestations(post_state)`, `apply_raw_block(post_state, &block)`, `hashTreeRoot(block)`, `block.toJsonString` |
| 3 | ✓ re-acquired | `states.put`, `forkChoice.onBlock`, `updateHead`, success metrics |

## Edge cases addressed

| Concern | Resolution |
|---------|-----------|
| Parent state pruned during unlocked window | `post_state` is a local sszClone; no live state-map pointer used. Validators / latest_block_header / latest_justified are byte-identical to `pre_state` at clone time (STF has not run yet) |
| Forkchoice mutation during unlocked window | `getProposalAttestations` takes `forkchoice.mutex.lockShared()` internally. Concurrent gossip-block / `storeAggregatedPayload` paths take RwLock-write — reads serialize correctly even with outer BeamNode.mutex released |
| Concurrent same-slot proposal | Cannot happen by design — single proposer per slot per validator set; validator only fires once per slot |
| Forkchoice errors in Phase 3 | `forkChoice.onBlock` may surface errors (e.g. unexpected race). errdefer fires lock-held; no resource leak |
| Counter / histogram thread-safety | `Counter.incr` / `Histogram.observe` use atomic RMW (verified upstream in #798/#799 reviews). Counters incremented during unlocked phase are collected into `ComputeResult` and emitted in Phase 3 to keep ordering with other counter updates |
| `errdefer` ordering | post_state cleanup, agg_attestations / attestation_signatures cleanup, block.deinit, forkchoice rollback all fire on appropriate paths. `agg_att_cleanup` / `agg_sig_cleanup` flags transition through phases with the same shape as the previous code |
| Phase-1 error paths (MissingPreState, allocator failure, sszClone failure) | All return BEFORE any unlock — caller's invariant trivially preserved |
| Test setups not under outer mutex | `null` passed → unlock/re-lock no-ops, behaviour identical to pre-PR |
| Locally-produced block publishing path | Already uses precomputed `postState` (#798 path) — no verify+STF runs there. No change needed |

## Changes

### `pkgs/node/src/chain.zig`
- `produceBlock` rewritten with three-phase lock-dance. Doc comment spells out the thread-safety contract.
- `pre_state` no longer passed to the unlocked phase — `post_state` (local clone) is used as the validator/checkpoint snapshot.
- Counter increments (`lean_pq_sig_aggregated_signatures_total`, `lean_pq_sig_attestations_in_aggregated_signatures_total`) collected in Phase 2 and emitted in Phase 3.

### `pkgs/node/src/validator_client.zig`
- `onInterval(time_intervals, external_mutex)` and `maybeDoProposal(slot, external_mutex)` thread the parameter through to `chain.produceBlock`.
- `mayBeDoAttestation` left unchanged (`lean_pq_sig_attestation_signing_time_seconds` ~12ms mean — small relative to 826ms block-build).

### `pkgs/node/src/node.zig`
- `BeamNode.onInterval` passes `&self.mutex` to `validator.onInterval`. Locally-produced-block publishing (`chain.onBlock` with `postState` precomputed via #798) keeps `null`.

### `pkgs/metrics/src/lib.zig`
- New `zeam_chain_produceblock_compute_unlocked_seconds` histogram (BlockBuildingTimeHistogram buckets) records the unlocked-window duration per `produceBlock` call. Lets operators see exactly how much of `lean_block_building_time_seconds` moved off the mutex.

### Tests
- Existing `produceBlock - greedy selection by latest slot ...` test passes `null`.
- New `produceBlock preserves caller-held external_mutex on entry/exit` regression test asserts `mutex.tryLock()` returns false after a successful `produceBlock` call.

## Out of scope (still tracked for #786)

- `chain.aggregate` / `maybeAggregateOnInterval` (i=2 aggregator path, ~700ms when this node is an aggregator) — needs careful state-pointer lifetime handling across the unlocked window. Phase 2d.
- `processPendingBlocks` (interval-replay path) — phase 2d.
- `forkchoice.onAttestation` per-validator loop inside `chain.onBlock` commit phase — small per-iteration but adds up. Phase 2e if metrics still show contention.

## Test plan
- [x] `zig build all` — clean rebuild, EXIT=0.
- [x] `zig build test` — all existing unit tests pass + new lock-invariant test.
- [x] Lock-invariant test asserts mutex held on success path return.
- [ ] Devnet: confirm `zeam_node_mutex_hold_time_seconds{site="onInterval"}` p99 + sum drop on aggregator nodes (block proposal slots no longer stall ticks).
- [ ] Devnet: confirm `zeam_chain_produceblock_compute_unlocked_seconds` populates with magnitudes consistent with the existing 826ms-mean baseline.
- [ ] Devnet: confirm `lean_tick_interval_duration_seconds` mean drops below ~1.0s under aggregator workload (was ~1.24s).