### PR TITLE
node,chain: thread external_mutex through processPendingBlocks; wrap aggregator dispatch (#786 phase 2d)

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -289,7 +289,14 @@ pub const BeamChain = struct {
     /// reached their slot.  Called from onInterval after advancing the clock.
     /// Returns a slice of all missing attestation roots encountered while
     /// processing queued blocks; the caller owns and must free the slice.
-    pub fn processPendingBlocks(self: *Self) []types.Root {
+    ///
+    /// `external_mutex` (issue #786 phase 2d): forwarded to each inner
+    /// `self.onBlock` call so the verify + STF window of replayed pending
+    /// blocks runs unlocked. The pending_blocks queue itself is mutated only
+    /// under the outer mutex (gossip path appends here too), so replays and
+    /// appends remain serialized correctly even though `onBlock` releases
+    /// the lock between its own phases.
+    pub fn processPendingBlocks(self: *Self, external_mutex: ?*std.Thread.Mutex) []types.Root {
         var all_missing_roots: std.ArrayListUnmanaged(types.Root) = .empty;
         const fc_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
         var i: usize = 0;
@@ -311,14 +318,17 @@ pub const BeamChain = struct {
                     .{ queued_slot, &block_root, fc_time },
                 );
 
-                // Pending-block replay runs inside `BeamNode.onInterval`, which
-                // already holds the BeamNode mutex. Releasing it here would
-                // require interval ordering protection that is not currently
-                // in place. Pass null until a follow-up PR addresses the
-                // tick-replay path. Pending-block replay is rare in practice.
+                // Forward `external_mutex` so each replay's verify + STF
+                // window runs unlocked (issue #786 phase 2d). The
+                // `pending_blocks` slice itself is only mutated under
+                // BeamNode.mutex, so the loop's index/len bookkeeping
+                // remains coherent across the inner unlock/relock. New
+                // appends from concurrent `chain.onGossip.block` paths
+                // land at the tail and are picked up on the next
+                // iteration's `i < self.pending_blocks.items.len` check.
                 const missing_roots = self.onBlock(queued_block, .{
                     .blockRoot = block_root,
-                }, null) catch |err| {
+                }, external_mutex) catch |err| {
                     self.logger.err("queued block slot={d} root=0x{x}: processing failed: {any}", .{ queued_slot, &block_root, err });
                     continue;
                 };

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1297,7 +1297,11 @@ pub const BeamNode = struct {
 
                 // Replay blocks that were queued waiting for the forkchoice clock to advance,
                 // then fetch any attestation head roots that were missing during replay.
-                const pending_missing_roots = self.chain.processPendingBlocks();
+                // Pass &self.mutex so each inner replay's verify + STF window
+                // runs unlocked (issue #786 phase 2d). The current scope holds
+                // `acquireMutex("onInterval")` so the contract "lock held on
+                // entry/exit" is preserved across the inner lock dance.
+                const pending_missing_roots = self.chain.processPendingBlocks(&self.mutex);
                 defer self.allocator.free(pending_missing_roots);
                 if (pending_missing_roots.len > 0) {
                     self.fetchBlockByRoots(pending_missing_roots, 0) catch |err| {
@@ -1385,11 +1389,36 @@ pub const BeamNode = struct {
             }
 
             if (interval_in_slot == 2) {
-                if (self.chain.maybeAggregateOnInterval(interval) catch |e| {
-                    self.logger.err("error producing aggregations at slot={d} interval={d}: {any}", .{ slot, interval, e });
-                    return e;
-                }) |aggregations| {
+                // Phase 2d (issue #786): wrap aggregator's i=2 dispatch in a
+                // fresh BeamNode.mutex acquisition. Pre-PR this code path
+                // ran without the mutex held, racing chain.states / forkchoice
+                // mutations from concurrent libp2p workers. Holding the mutex
+                // here serializes correctly. `chain.maybeAggregateOnInterval`
+                // does not currently hoist its FFI-heavy aggregation step off
+                // the lock — see commit message for the deferred work — so
+                // for now this serializes a ~700ms aggregator window against
+                // libp2p workers when running as an aggregator. Acceptable
+                // trade for correctness; phase 2e can hoist if devnet shows
+                // the regression matters.
+                //
+                // The validator-output dispatch above also publishes via
+                // `publishAggregation` which calls
+                // `chain.onGossipAggregatedAttestation(.., null)` — that path
+                // remains unchanged.
+                var maybe_aggregations: ?[]types.SignedAggregatedAttestation = null;
+                {
+                    var aggregator_guard = self.acquireMutex("maybeAggregateOnInterval");
+                    defer aggregator_guard.unlock();
+                    maybe_aggregations = self.chain.maybeAggregateOnInterval(interval) catch |e| {
+                        self.logger.err("error producing aggregations at slot={d} interval={d}: {any}", .{ slot, interval, e });
+                        return e;
+                    };
+                }
+                if (maybe_aggregations) |aggregations| {
                     defer self.allocator.free(aggregations);
+                    // Publish runs without BeamNode.mutex (mirrors validator
+                    // output dispatch above) so that network.publish does not
+                    // stall libp2p workers behind a socket round-trip.
                     self.publishProducedAggregations(aggregations) catch |e| {
                         self.logger.err("error producing/publishing aggregations at slot={d} interval={d}: {any}", .{ slot, interval, e });
                         return e;


### PR DESCRIPTION
**Stacked on #800 (phase 2c) → #799 (phase 2b) → #798 (phase 2a).** Targets the 2c branch so review can merge sequentially. Will retarget to `main` as the stack lands.

Two cleanup items left over from phases 2a–2c.

## 1. processPendingBlocks: thread external_mutex

`chain.processPendingBlocks` was the last call site that explicitly passed `null` to `chain.onBlock` despite running under BeamNode.mutex (the inner `acquireMutex("onInterval")` block in `BeamNode.onInterval`). Each replayed block carried the full ~77ms onBlock cost under the lock.

This PR threads `external_mutex: ?*std.Thread.Mutex` through `processPendingBlocks` and forwards it to each inner `self.onBlock` call. Replay loop now releases the lock for each verify + STF window.

### Edge cases covered

| Concern | Resolution |
|---------|-----------|
| `pending_blocks` slice mutated mid-loop | Mutated only under BeamNode.mutex (gossip-path appends). `while (i < self.pending_blocks.items.len)` re-reads len each iteration; concurrent appends during the inner unlock-window land at the tail |
| Concurrent `processPendingBlocks` invocations | `onInterval` driven by a single libxev thread → cannot overlap |
| Same-root competing import during unlock window | `onBlock`'s same-root dedup (#798) returns early on `forkChoice.hasBlock(block_root) == true` |
| Loop index correctness across `orderedRemove` | Index `i` not incremented after remove (intentional pre-PR shape); after re-acquire, items[i] is the next-original-i+1; len updated. No regression |

## 2. Aggregator dispatch: wrap in fresh BeamNode.mutex

`BeamNode.onInterval` called `chain.maybeAggregateOnInterval` WITHOUT the BeamNode mutex held — **pre-existing race** against libp2p worker threads (which acquire BeamNode.mutex on gossip / req-resp paths). `maybeAggregateOnInterval` reads `is_aggregator_enabled`, sync status, then calls `forkchoice.aggregate` which mutates internal payload maps.

Fix: wrap the call in a fresh `acquireMutex("maybeAggregateOnInterval")` block, mirroring the phase 2c `validator.onInterval` wrapper. `publishProducedAggregations` stays OUTSIDE the lock for the same reason as validator-output dispatch — `network.publish` runs without BeamNode.mutex to avoid stalling libp2p workers on socket round-trips.

### Trade-off (acknowledged)

This serializes the ~700ms aggregator window (`lean_committee_signatures_aggregation_time_seconds`) under BeamNode.mutex, which is a **perf regression for aggregator nodes specifically**. Worth flagging:

- Pre-PR: race against gossip workers, but no mutex hold → other paths fast.
- Post-PR: race fixed, but ~700ms aggregator hold per i=2 → other paths blocked during that window.

Phase 2e can hoist the FFI-heavy `forkchoice.aggregateUnlocked` step off the lock. Gated on devnet measurement of whether the regression matters in practice.

## Remaining work after this PR

- **Phase 2e**: hoist `forkchoice.aggregateUnlocked` off the mutex. Requires sorting out `state.validators` lifetime across the unlocked window — `computeAggregatedSignatures` dereferences validators inside the heavy step. Either snapshot validator pubkeys (similar to onGossipAttestation pattern) or document state-pruning invariant for head's state.
- **Phase 2f**: `forkchoice.onAttestation` per-validator loop inside `chain.onBlock` commit phase. Cheap per iteration; only worth hoisting if metrics still show significant aggregate hold time on commit.

## Test plan
- [x] `zig build all` — clean rebuild, EXIT=0.
- [x] `zig build test` — 144 tests pass.
- [x] `zig build simtest` — passes.
- [ ] Devnet aggregator: confirm `zeam_node_mutex_hold_time_seconds{site="maybeAggregateOnInterval"}` shows the trade-off. If unacceptable, prioritize phase 2e.
- [ ] Devnet: confirm `zeam_chain_onblock_compute_unlocked_seconds` populates also for replayed pending blocks (counts should rise on nodes that receive future-slot gossip).