### PR TITLE
sim,test: single-node stress harness + metrics audit (slice b of #803)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -441,6 +441,49 @@ pub fn build(b: *Builder) !void {
 
     const test_step = b.step("test", "Run zeam core tests");
 
+    // ---------------------------------------------------------------
+    // Single-node ingestion stress harness (issue #803 slice b).
+    //
+    // Run with `zig build stress` (or `zig build stress -Doptimize=Debug`).
+    // Configurable via env vars:
+    //   ZEAM_STRESS_DURATION_SECS  default 1800 (30 min, design-doc r3 merge gate)
+    //   ZEAM_STRESS_NUM_BLOCKS     default 6
+    //   ZEAM_STRESS_GOSSIP_THREADS default 3
+    //   ZEAM_STRESS_RPC_THREADS    default 4
+    //   ZEAM_STRESS_ATTN_THREADS   default 2
+    //   ZEAM_STRESS_BORROW_THREADS default 2
+    //   ZEAM_STRESS_CACHE_THREADS  default 1
+    //   ZEAM_STRESS_WATCHDOG_SECS  default 60
+    // ---------------------------------------------------------------
+    const stress_exe = b.addExecutable(.{
+        .name = "zeam-stress",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("pkgs/node/src/stress.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    stress_exe.root_module.addImport("xev", xev);
+    stress_exe.root_module.addImport("ssz", ssz);
+    stress_exe.root_module.addImport("@zeam/utils", zeam_utils);
+    stress_exe.root_module.addImport("@zeam/params", zeam_params);
+    stress_exe.root_module.addImport("@zeam/types", zeam_types);
+    stress_exe.root_module.addImport("@zeam/configs", zeam_configs);
+    stress_exe.root_module.addImport("@zeam/state-transition", zeam_state_transition);
+    stress_exe.root_module.addImport("@zeam/network", zeam_network);
+    stress_exe.root_module.addImport("@zeam/database", zeam_database);
+    stress_exe.root_module.addImport("@zeam/metrics", zeam_metrics);
+    stress_exe.root_module.addImport("@zeam/api", zeam_api);
+    stress_exe.root_module.addImport("@zeam/key-manager", zeam_key_manager);
+    stress_exe.root_module.addImport("@zeam/xmss", zeam_xmss);
+    stress_exe.root_module.addImport("@zeam/thread-pool", zeam_thread_pool);
+    addRustGlueLib(b, stress_exe, target, prover);
+    stress_exe.step.dependOn(&build_rust_lib_steps.step);
+    const run_stress = b.addRunArtifact(stress_exe);
+    if (b.args) |args| run_stress.addArgs(args);
+    const stress_step = b.step("stress", "Run single-node ingestion stress harness (issue #803 slice b)");
+    stress_step.dependOn(&run_stress.step);
+
     // CLI integration tests (separate target) - always create this test target
     const cli_integration_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -484,6 +484,31 @@ pub fn build(b: *Builder) !void {
     const stress_step = b.step("stress", "Run single-node ingestion stress harness (issue #803 slice b)");
     stress_step.dependOn(&run_stress.step);
 
+    // -----------------------------------------------------------------
+    // `stress-quick`: short-form stress harness wired into `zig build
+    // test`. The full 30-min run is operator-driven; this 30s run is
+    // what CI executes on every PR so the slice-(a)/(b) merge gate
+    // actually has automated enforcement, not just a PR-comment
+    // attestation. The quick run uses the same code paths as the full
+    // run and will fail CI on:
+    //   * any `MissingPreState` (states-map race),
+    //   * any unexpected `chain.onBlock` error in gossip-flood,
+    //   * any `recordFatal` from coherence checks (BlockCache,
+    //     borrow-reader, watchdog),
+    //   * worker error counters non-zero in the summary epilogue.
+    // 30s is long enough for several thousand ops on each worker
+    // without putting the test job over budget.
+    //
+    // Override knobs are intentionally NOT wired here — CI exercises
+    // the same defaults a developer sees with `zig build stress-quick`,
+    // which is the point.
+    const run_stress_quick = b.addRunArtifact(stress_exe);
+    run_stress_quick.setEnvironmentVariable("ZEAM_STRESS_DURATION_SECS", "30");
+    run_stress_quick.setEnvironmentVariable("ZEAM_STRESS_WATCHDOG_SECS", "15");
+    const stress_quick_step = b.step("stress-quick", "Run a 30s stress harness (CI gate, slice b)");
+    stress_quick_step.dependOn(&run_stress_quick.step);
+    test_step.dependOn(&run_stress_quick.step);
+
     // CLI integration tests (separate target) - always create this test target
     const cli_integration_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -131,6 +131,16 @@ pub const BeamChain = struct {
     // and aggregation duties for subnets the node is already subscribed to,
     // matching the hot-standby model documented in leanEthereum/leanSpec#636.
     is_aggregator_enabled: std.atomic.Value(bool),
+    /// Counter incremented every time `statesCommitKeepExisting` lands
+    /// on the duplicate / kept-existing branch (i.e. the entry was
+    /// already in `states` when the second writer arrived). Used by the
+    /// concurrent re-import test to assert that the race surface was
+    /// actually exercised — without this, a test that imports the same
+    /// blocks twice would silently pass even if one importer was
+    /// completely starved.
+    ///
+    /// Lock-free monotonic counter; safe to read from any thread.
+    states_kept_existing_count: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
     // Cached finalized state loaded from database (separate from states map to avoid affecting pruning)
     cached_finalized_state: ?*types.BeamState = null,
     // Cache for validator public keys to avoid repeated SSZ deserialization during signature verification.
@@ -425,6 +435,9 @@ pub const BeamChain = struct {
             gop.value_ptr.* = state_ptr;
             break :blk state_ptr;
         };
+        if (gop.found_existing) {
+            _ = self.states_kept_existing_count.fetchAdd(1, .monotonic);
+        }
         return .{
             .borrow = BorrowedState{
                 .state = effective_ptr,
@@ -3969,17 +3982,29 @@ test "chain.onBlock: two-thread concurrent import of same block — no UAF, cohe
     }
 }
 
-test "chain: reorg under attestation pressure — forkchoice settles, no duplicate work" {
-    // Slice (b) cross-thread test scenario: two onBlock threads race the
-    // import of overlapping forks while an attestation thread spams
-    // mixed-validity attestations targeting both forks. The contract
-    // under test:
+test "chain: concurrent re-import pressure — kept_existing path race + attestation spam" {
+    // Slice (b) cross-thread test scenario: two onBlock threads race
+    // the import of the SAME block sequence in opposite orders
+    // (forward 1..N, reverse N..1) while an attestation thread spams
+    // mixed-validity attestations. This is NOT a reorg test — we
+    // never build a divergent fork. What we exercise is the
+    // statesCommitKeepExisting / kept_existing path under contention:
+    // whichever importer wins the race for a given block populates
+    // `states`; the loser then takes the kept_existing branch and
+    // frees its redundantly-computed post-state. (A real reorg test
+    // would need genMockChain to expose a fork-from-shared-parent
+    // helper; not in scope for slice (b).)
     //
-    //   * Forkchoice settles on a single head after all imports complete.
-    //   * No panic / UAF in the attestation pool (events_lock + forkchoice
-    //     attestation map are concurrently mutated).
-    //   * statesGet on the eventual head root succeeds and the slot is
-    //     coherent with one of the imported chain tips.
+    // The contract under test:
+    //
+    //   * Forkchoice settles on a single head after all imports finish.
+    //   * No panic / UAF in the attestation pool (events_lock +
+    //     forkchoice attestation map are concurrently mutated).
+    //   * statesGet on the eventual head root succeeds and the slot
+    //     is coherent with one of the imported chain tips.
+    //   * The kept_existing branch is actually exercised
+    //     (`states_kept_existing_count` strictly increases) — without
+    //     this, the test would silently pass on a serialized run.
     //
     // Iteration count is modest (50) so the whole test stays under ~30s
     // in Debug. Each iteration builds a fresh BeamChain, imports the
@@ -3991,11 +4016,7 @@ test "chain: reorg under attestation pressure — forkchoice settles, no duplica
     const arena = arena_allocator.allocator();
 
     // 4-block mock chain shared across all iterations as the import
-    // template. We don't actually fork — the "reorg pressure" comes from
-    // both onBlock threads racing to import the SAME blocks (kept_existing
-    // path), which exercises the same statesCommitKeepExisting +
-    // forkchoice-confirm interleaving as a true reorg without the
-    // scaffolding cost of building a real divergent chain.
+    // template. We don't fork — see the test header for the rationale.
     const mock_chain = try stf.genMockChain(arena, 4, null);
     var zeam_logger_config = zeam_utils.getTestLoggerConfig();
 
@@ -4163,10 +4184,24 @@ test "chain: reorg under attestation pressure — forkchoice settles, no duplica
         for (mock_chain.blockRoots[1..]) |r| {
             try std.testing.expect(beam_chain.forkChoice.hasBlock(r));
         }
-        // Both importers must have made at least 1 successful import
-        // each (pre-imports happen on a fresh chain so kept_existing
-        // splits between the two threads).
-        try std.testing.expect(ctx.imports_a.load(.monotonic) + ctx.imports_b.load(.monotonic) >= mock_chain.blocks.len - 1);
+        // The forward importer is deterministic on a fresh chain (each
+        // parent is in `states` by the time we reach the next block),
+        // so it MUST contribute every block. Use strict equality so a
+        // future regression that breaks the forward path can't be
+        // masked by the reverse importer's contributions.
+        try std.testing.expectEqual(
+            @as(u32, @intCast(mock_chain.blocks.len - 1)),
+            ctx.imports_a.load(.monotonic),
+        );
+        // The kept_existing race surface MUST have been exercised at
+        // least once during this iteration. This is the actual
+        // assertion that distinguishes "two threads ran in parallel"
+        // from "two threads serialized". The reverse importer's
+        // success count is inherently racy (it depends on whether the
+        // forward importer has populated states[block-1] yet) so we
+        // assert via the kept_existing counter rather than
+        // imports_b.
+        try std.testing.expect(beam_chain.states_kept_existing_count.load(.monotonic) > 0);
         // Head's slot is finite and not in the future relative to last
         // imported slot.
         try std.testing.expect(head.slot <= last_slot);
@@ -4185,8 +4220,21 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
     // Slice (b) cross-thread test scenario: while a writer thread imports
     // blocks and advances finalization (via onBlockFollowup), an
     // HTTP-API-shaped reader thread loops over chain.statesGet +
-    // cloneAndRelease for both finalized and non-finalized roots. The
-    // contract under test:
+    // cloneAndRelease for both finalized and non-finalized roots.
+    //
+    // NOTE on iteration semantics: the writer's first pass over
+    // blocks 1..N is the only pass that actually advances
+    // finalization. Subsequent passes hit `kept_existing` in
+    // statesCommitKeepExisting and onBlockFollowup is then a no-op
+    // for finalization. The outer `iters` loop therefore exists to
+    // give the readers enough wall-clock to race against the *first*
+    // pass and to exercise the kept_existing-vs-statesGet contention
+    // afterwards — it is NOT 20 independent finalization advances.
+    // The `>0` finalized-observation assertion below ensures we
+    // actually hit the racing window at least once; otherwise the
+    // test would pass even if finalization never advanced.
+    //
+    // The contract under test:
     //
     //   * No UAF in the reader: every cloneAndRelease either returns a
     //     coherent state or null (entry pruned away during the borrow
@@ -4196,6 +4244,9 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
     //   * No deadlock: the test must complete in well under 30s.
     //   * latest_finalized as observed via forkChoice.getLatestFinalized
     //     never goes backwards across reader observations.
+    //   * At least one reader observation saw `latest_finalized.slot > 0`
+    //     (proves finalization actually advanced during the race window;
+    //     guards against a regression that silently never finalizes).
     var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
@@ -4261,6 +4312,11 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
         reader_null: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
         reader_torn: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
         finalized_regression: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        /// Maximum `latest_finalized.slot` observed by any reader
+        /// across the whole run. Asserting this is `>0` guards
+        /// against a regression where finalization silently never
+        /// advances during the race window.
+        max_observed_finalized_slot: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
         start: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
         ready: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     };
@@ -4331,6 +4387,20 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
                     _ = ctx.finalized_regression.fetchAdd(1, .monotonic);
                 }
                 last_finalized_slot = lf.slot;
+                // Track the highest finalized slot any reader has
+                // observed (compare-and-swap loop; `max` is not yet
+                // a built-in atomic op).
+                var prev_max = ctx.max_observed_finalized_slot.load(.monotonic);
+                while (lf.slot > prev_max) {
+                    if (ctx.max_observed_finalized_slot.cmpxchgWeak(
+                        prev_max,
+                        lf.slot,
+                        .monotonic,
+                        .monotonic,
+                    )) |actual| {
+                        prev_max = actual;
+                    } else break;
+                }
             }
         }
     };
@@ -4359,4 +4429,10 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
     // Sanity: at least some successful reads happened (otherwise the
     // race window collapsed and the test proves nothing).
     try std.testing.expect(ctx.reader_ok.load(.monotonic) > 100);
+    // Critical: the readers must have actually observed finalization
+    // advance to a non-zero slot during the race window. Without this
+    // assertion the test would pass on a regression that silently
+    // failed to finalize — the no-torn-read + no-regression checks
+    // would still trivially hold on a chain stuck at genesis.
+    try std.testing.expect(ctx.max_observed_finalized_slot.load(.monotonic) > 0);
 }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -3968,3 +3968,395 @@ test "chain.onBlock: two-thread concurrent import of same block — no UAF, cohe
         try std.testing.expect(beam_chain.forkChoice.hasBlock(block_root));
     }
 }
+
+test "chain: reorg under attestation pressure — forkchoice settles, no duplicate work" {
+    // Slice (b) cross-thread test scenario: two onBlock threads race the
+    // import of overlapping forks while an attestation thread spams
+    // mixed-validity attestations targeting both forks. The contract
+    // under test:
+    //
+    //   * Forkchoice settles on a single head after all imports complete.
+    //   * No panic / UAF in the attestation pool (events_lock + forkchoice
+    //     attestation map are concurrently mutated).
+    //   * statesGet on the eventual head root succeeds and the slot is
+    //     coherent with one of the imported chain tips.
+    //
+    // Iteration count is modest (50) so the whole test stays under ~30s
+    // in Debug. Each iteration builds a fresh BeamChain, imports the
+    // shared mock chain, and then concurrently re-imports + spams
+    // attestations. The slow part is XMSS attestation signing; we limit
+    // attestation messages per iteration to keep runtime sane.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    // 4-block mock chain shared across all iterations as the import
+    // template. We don't actually fork — the "reorg pressure" comes from
+    // both onBlock threads racing to import the SAME blocks (kept_existing
+    // path), which exercises the same statesCommitKeepExisting +
+    // forkchoice-confirm interleaving as a true reorg without the
+    // scaffolding cost of building a real divergent chain.
+    const mock_chain = try stf.genMockChain(arena, 4, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const ITERS: usize = 50;
+    var iter: usize = 0;
+    while (iter < ITERS) : (iter += 1) {
+        const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+        const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+        const chain_config = configs.ChainConfig{
+            .id = configs.Chain.custom,
+            .genesis = mock_chain.genesis_config,
+            .spec = .{
+                .preset = params.Preset.mainnet,
+                .name = spec_name,
+                .fork_digest = fork_digest,
+                .attestation_committee_count = 1,
+                .max_attestations_data = 16,
+            },
+        };
+
+        var beam_state: types.BeamState = undefined;
+        try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+        defer beam_state.deinit();
+
+        var tmp_dir = std.testing.tmpDir(.{});
+        defer tmp_dir.cleanup();
+        var path_buf: [128]u8 = undefined;
+        const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+        var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+        defer db.deinit();
+
+        const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+        defer std.testing.allocator.destroy(connected_peers);
+        connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+        defer connected_peers.deinit();
+
+        const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+        defer std.testing.allocator.destroy(test_registry);
+        test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+        defer test_registry.deinit();
+
+        var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+            .config = chain_config,
+            .anchorState = &beam_state,
+            .nodeId = 21,
+            .logger_config = &zeam_logger_config,
+            .db = db,
+            .node_registry = test_registry,
+        }, connected_peers);
+        defer beam_chain.deinit();
+
+        // Advance forkchoice clock past the last block's slot so block
+        // imports are not FutureSlot-rejected and attestations are not
+        // FutureSlot either.
+        const last_slot = mock_chain.blocks[mock_chain.blocks.len - 1].block.slot;
+        try beam_chain.forkChoice.onInterval((last_slot + 4) * constants.INTERVALS_PER_SLOT, false);
+
+        const Ctx = struct {
+            chain: *BeamChain,
+            blocks: []types.SignedBlock,
+            block_roots: []types.Root,
+            attn_iters: usize,
+            // counters
+            imports_a: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+            imports_b: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+            attn_ok: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+            // start barrier
+            start: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+            ready: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+            fatal_msg: [128]u8 = undefined,
+            fatal_set: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        };
+
+        const Worker = struct {
+            fn waitStart(ctx: *Ctx) void {
+                _ = ctx.ready.fetchAdd(1, .acq_rel);
+                while (ctx.start.load(.acquire) == 0) std.Thread.yield() catch {};
+            }
+            // Forward import 1..N
+            fn importerForward(ctx: *Ctx) void {
+                waitStart(ctx);
+                for (1..ctx.blocks.len) |i| {
+                    const missing = ctx.chain.onBlock(ctx.blocks[i], .{ .pruneForkchoice = false }) catch continue;
+                    ctx.chain.allocator.free(missing);
+                    _ = ctx.imports_a.fetchAdd(1, .monotonic);
+                }
+            }
+            // Reverse import N..1 — different order = different
+            // interleavings of forkchoice insert vs kept_existing.
+            fn importerReverse(ctx: *Ctx) void {
+                waitStart(ctx);
+                var i: usize = ctx.blocks.len;
+                while (i > 1) {
+                    i -= 1;
+                    const missing = ctx.chain.onBlock(ctx.blocks[i], .{ .pruneForkchoice = false }) catch continue;
+                    ctx.chain.allocator.free(missing);
+                    _ = ctx.imports_b.fetchAdd(1, .monotonic);
+                }
+            }
+            fn attestationSpammer(ctx: *Ctx, key_manager: *keymanager.KeyManager) void {
+                waitStart(ctx);
+                const allocator = ctx.chain.allocator;
+                var i: usize = 0;
+                while (i < ctx.attn_iters) : (i += 1) {
+                    const slot_idx = 1 + (i % (ctx.blocks.len - 1));
+                    const target_root = ctx.block_roots[slot_idx];
+                    const target_slot: types.Slot = ctx.blocks[slot_idx].block.slot;
+                    const source_idx = if (slot_idx > 1) slot_idx - 1 else 0;
+                    const validator_id: usize = i % 4;
+                    const message = types.Attestation{
+                        .validator_id = @intCast(validator_id),
+                        .data = .{
+                            .slot = target_slot,
+                            .head = .{ .root = target_root, .slot = target_slot },
+                            .source = .{ .root = ctx.block_roots[source_idx], .slot = ctx.blocks[source_idx].block.slot },
+                            .target = .{ .root = target_root, .slot = target_slot },
+                        },
+                    };
+                    const signature = key_manager.signAttestation(&message, allocator) catch continue;
+                    const valid_attestation = types.SignedAttestation{
+                        .validator_id = message.validator_id,
+                        .message = message.data,
+                        .signature = signature,
+                    };
+                    const subnet_id = types.computeSubnetId(
+                        @intCast(valid_attestation.validator_id),
+                        ctx.chain.config.spec.attestation_committee_count,
+                    ) catch continue;
+                    const gossip = networks.AttestationGossip{
+                        .subnet_id = @intCast(subnet_id),
+                        .message = valid_attestation,
+                    };
+                    ctx.chain.onGossipAttestation(gossip) catch continue;
+                    _ = ctx.attn_ok.fetchAdd(1, .monotonic);
+                }
+            }
+        };
+
+        var key_manager = try keymanager.getTestKeyManager(std.testing.allocator, 4, mock_chain.blocks.len);
+        defer key_manager.deinit();
+
+        var ctx = Ctx{
+            .chain = &beam_chain,
+            .blocks = mock_chain.blocks,
+            .block_roots = mock_chain.blockRoots,
+            .attn_iters = 30,
+        };
+
+        var t_a = try std.Thread.spawn(.{}, Worker.importerForward, .{&ctx});
+        var t_b = try std.Thread.spawn(.{}, Worker.importerReverse, .{&ctx});
+        var t_c = try std.Thread.spawn(.{}, Worker.attestationSpammer, .{ &ctx, &key_manager });
+
+        while (ctx.ready.load(.acquire) < 3) std.Thread.yield() catch {};
+        ctx.start.store(1, .release);
+
+        t_a.join();
+        t_b.join();
+        t_c.join();
+
+        // Forkchoice must have settled on a single head.
+        const head = beam_chain.forkChoice.getHead();
+        // The head must be one of the imported block roots (or genesis
+        // if every import failed, which would itself be a bug). At
+        // minimum every block root must be observable in the chain.
+        for (mock_chain.blockRoots[1..]) |r| {
+            try std.testing.expect(beam_chain.forkChoice.hasBlock(r));
+        }
+        // Both importers must have made at least 1 successful import
+        // each (pre-imports happen on a fresh chain so kept_existing
+        // splits between the two threads).
+        try std.testing.expect(ctx.imports_a.load(.monotonic) + ctx.imports_b.load(.monotonic) >= mock_chain.blocks.len - 1);
+        // Head's slot is finite and not in the future relative to last
+        // imported slot.
+        try std.testing.expect(head.slot <= last_slot);
+        // statesGet on the head root must succeed.
+        var head_borrow = beam_chain.statesGet(head.blockRoot) orelse {
+            try std.testing.expect(false);
+            unreachable;
+        };
+        const owned = try head_borrow.cloneAndRelease(std.testing.allocator);
+        owned.deinit();
+        std.testing.allocator.destroy(owned);
+    }
+}
+
+test "chain: finalization race — onBlockFollowup + statesGet from API-shaped reader" {
+    // Slice (b) cross-thread test scenario: while a writer thread imports
+    // blocks and advances finalization (via onBlockFollowup), an
+    // HTTP-API-shaped reader thread loops over chain.statesGet +
+    // cloneAndRelease for both finalized and non-finalized roots. The
+    // contract under test:
+    //
+    //   * No UAF in the reader: every cloneAndRelease either returns a
+    //     coherent state or null (entry pruned away during the borrow
+    //     opportunity window — acceptable, the reader retries).
+    //   * No torn read: every observed slot is one of the imported
+    //     slots (or 0 for genesis).
+    //   * No deadlock: the test must complete in well under 30s.
+    //   * latest_finalized as observed via forkChoice.getLatestFinalized
+    //     never goes backwards across reader observations.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 6, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+    var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 22,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    const last_slot = mock_chain.blocks[mock_chain.blocks.len - 1].block.slot;
+    try beam_chain.forkChoice.onInterval((last_slot + 4) * constants.INTERVALS_PER_SLOT, false);
+
+    const Ctx = struct {
+        chain: *BeamChain,
+        blocks: []types.SignedBlock,
+        block_roots: []types.Root,
+        iters: usize,
+        writer_done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        reader_ok: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        reader_null: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        reader_torn: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        finalized_regression: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        start: std.atomic.Value(u8) = std.atomic.Value(u8).init(0),
+        ready: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    };
+
+    const Worker = struct {
+        fn waitStart(ctx: *Ctx) void {
+            _ = ctx.ready.fetchAdd(1, .acq_rel);
+            while (ctx.start.load(.acquire) == 0) std.Thread.yield() catch {};
+        }
+        // Writer: import blocks 1..N, calling onBlockFollowup after
+        // each. onBlockFollowup is what drives processFinalizationAdvancement.
+        fn writer(ctx: *Ctx) void {
+            waitStart(ctx);
+            var i: usize = 0;
+            while (i < ctx.iters) : (i += 1) {
+                for (1..ctx.blocks.len) |k| {
+                    const missing = ctx.chain.onBlock(ctx.blocks[k], .{ .pruneForkchoice = false }) catch continue;
+                    ctx.chain.allocator.free(missing);
+                    // Drive followup so finalization advances on the
+                    // canonical chain. signedBlock parameter is unused
+                    // by current impl (per source).
+                    ctx.chain.onBlockFollowup(false, null);
+                }
+            }
+            ctx.writer_done.store(true, .release);
+        }
+        // Reader: HTTP-API-shaped pattern — statesGet on a random known
+        // root, cloneAndRelease, sanity-check the slot. Loop until
+        // writer signals done. Also tracks latest_finalized monotonicity.
+        fn reader(ctx: *Ctx) void {
+            waitStart(ctx);
+            var prng = std.Random.DefaultPrng.init(0x517A715A);
+            const rand = prng.random();
+            var last_finalized_slot: types.Slot = 0;
+            const allocator = ctx.chain.allocator;
+            while (!ctx.writer_done.load(.acquire)) {
+                const idx = rand.uintLessThan(usize, ctx.block_roots.len);
+                const root = ctx.block_roots[idx];
+                if (ctx.chain.statesGet(root)) |b| {
+                    var borrow = b;
+                    const owned = borrow.cloneAndRelease(allocator) catch {
+                        continue;
+                    };
+                    defer {
+                        owned.deinit();
+                        allocator.destroy(owned);
+                    }
+                    var coherent = owned.slot == 0;
+                    if (!coherent) {
+                        for (ctx.blocks) |bl| {
+                            if (bl.block.slot == owned.slot) {
+                                coherent = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (coherent) {
+                        _ = ctx.reader_ok.fetchAdd(1, .monotonic);
+                    } else {
+                        _ = ctx.reader_torn.fetchAdd(1, .monotonic);
+                    }
+                } else {
+                    _ = ctx.reader_null.fetchAdd(1, .monotonic);
+                }
+                // Monotonicity check on latest_finalized.
+                const lf = ctx.chain.forkChoice.getLatestFinalized();
+                if (lf.slot < last_finalized_slot) {
+                    _ = ctx.finalized_regression.fetchAdd(1, .monotonic);
+                }
+                last_finalized_slot = lf.slot;
+            }
+        }
+    };
+
+    var ctx = Ctx{
+        .chain = &beam_chain,
+        .blocks = mock_chain.blocks,
+        .block_roots = mock_chain.blockRoots,
+        .iters = 20,
+    };
+
+    var t_w = try std.Thread.spawn(.{}, Worker.writer, .{&ctx});
+    var t_r1 = try std.Thread.spawn(.{}, Worker.reader, .{&ctx});
+    var t_r2 = try std.Thread.spawn(.{}, Worker.reader, .{&ctx});
+
+    while (ctx.ready.load(.acquire) < 3) std.Thread.yield() catch {};
+    ctx.start.store(1, .release);
+
+    t_w.join();
+    t_r1.join();
+    t_r2.join();
+
+    // Contract: no torn reads, no finalization regressions.
+    try std.testing.expectEqual(@as(u32, 0), ctx.reader_torn.load(.monotonic));
+    try std.testing.expectEqual(@as(u32, 0), ctx.finalized_regression.load(.monotonic));
+    // Sanity: at least some successful reads happened (otherwise the
+    // race window collapsed and the test proves nothing).
+    try std.testing.expect(ctx.reader_ok.load(.monotonic) > 100);
+}

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -1136,6 +1136,77 @@ pub const BorrowedState = struct {
 
 const testing = std.testing;
 
+test "LockTimer: acquired+released emit zeam_lock_{wait,hold}_seconds in /metrics output" {
+    // Locks in the contract that LockTimer.acquired/released actually
+    // wire through to the per-resource histogram families exposed at
+    // /metrics. Slice-(a) review point: the file:line audit of the
+    // metric wiring is reviewable by humans but regresses silently if
+    // someone removes the `.observe(...)` call. This test calls
+    // `start().acquired().released()` once and then asserts the
+    // serialized scrape body contains both histogram series names plus
+    // at least one observed-bucket line tagged with the lock + site
+    // labels we used.
+    //
+    // The metrics module is process-global (`g_initialized` guard); we
+    // call `init` here unconditionally because it is a no-op on the
+    // second call. Other tests in this binary may have already
+    // populated counters — we therefore search for our specific
+    // (lock, site) label tuple, not just the bare metric name, so we
+    // don't depend on the test-order or mistake an unrelated
+    // observation for ours.
+    //
+    // We pass `std.heap.page_allocator` rather than
+    // `testing.allocator` so the (process-global) metrics state
+    // outlives this test. If we used the test allocator, every
+    // subsequent test in the binary that triggers a histogram
+    // hashmap grow (e.g. via `LockTimer.released()` from a chain
+    // test) would free the old buckets through an allocator whose
+    // arena has already been torn down — the DebugAllocator catches
+    // this as `reached unreachable` in its bucket-free assertion.
+    // The page allocator has no per-test lifetime, so the metrics
+    // hashmap can grow safely from any later test. The trade-off is
+    // that this test's allocator footprint is not tracked by the
+    // testing harness; that footprint is bounded by the histogram
+    // bucket we add (single (lock, site) pair) so it is acceptable.
+    try zeam_metrics.init(std.heap.page_allocator);
+
+    var t = LockTimer.start("locktimer_test_lock", "locktimer_test_site");
+    t.acquired();
+    t.released();
+
+    var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer.deinit();
+    try zeam_metrics.writeMetrics(&alloc_writer.writer);
+    const body = alloc_writer.writer.buffered();
+
+    // The histogram families themselves must be advertised.
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_lock_wait_seconds") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_lock_hold_seconds") != null);
+
+    // And at least one bucket line for our specific (lock, site)
+    // label tuple must be present — proving the histogram was
+    // *observed*, not just declared.
+    //
+    // The Prometheus exposition format from the metrics library
+    // emits HistogramVec lines as e.g.:
+    //
+    //   zeam_lock_wait_seconds_bucket{le="0.001",lock="...",site="..."} N
+    //   zeam_lock_wait_seconds_count{lock="...",site="..."} N
+    //   zeam_lock_wait_seconds_sum{lock="...",site="..."} f
+    //
+    // The `_count` line is the most direct proof the histogram was
+    // observed at all (it is incremented once per `observe()` call),
+    // and it does not include the `le=` bucket attribute, which keeps
+    // this assertion robust to bucket-set changes. We additionally
+    // search for the (lock, site) label pair as a substring to verify
+    // those labels reached the output — their order may differ from
+    // call site to call site so we do separate substring checks.
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_lock_wait_seconds_count") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_lock_hold_seconds_count") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "lock=\"locktimer_test_lock\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "site=\"locktimer_test_site\"") != null);
+}
+
 test "LockedMap: ctor + get/put/remove + count" {
     var lm = LockedMap(u32, u32).init(testing.allocator);
     defer lm.deinit();

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -170,6 +170,10 @@ const StressCtx = struct {
     /// Configured stall threshold echoed back in seconds for log/fatal
     /// messages. Stored separately so we don't divide an i128 in the hot path.
     watchdog_stall_secs: u64,
+    /// Highest block slot in the pre-imported chain. Used by
+    /// `borrowReaderWorker` for an O(1) coherence bound on observed
+    /// post-state slots; see the worker for rationale.
+    last_imported_slot: types.Slot,
     stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     // op counters
@@ -387,19 +391,24 @@ fn borrowReaderWorker(ctx: *StressCtx, thread_id: usize) void {
             _ = ctx.borrow_ops.fetchAdd(1, .monotonic);
             continue;
         };
-        // Coherence sanity: owned slot must be one of the known slots
-        // OR genesis slot 0. Anything else flags a torn read.
-        var coherent = owned.slot == 0;
-        if (!coherent) {
-            for (ctx.blocks) |b| {
-                if (b.block.slot == owned.slot) {
-                    coherent = true;
-                    break;
-                }
-            }
-        }
-        if (!coherent) {
-            ctx.recordFatal("borrow reader: incoherent slot={d}", .{owned.slot});
+        // Coherence sanity: O(1) bound check. The post-state's slot
+        // must lie within `[0, last_imported_slot]` — the chain has
+        // never advanced past the last block we pre-imported, and a
+        // negative / wraparound slot would indicate a torn read.
+        //
+        // Earlier versions of this check linear-scanned `ctx.blocks`
+        // for an exact slot match per iteration. That had two
+        // problems: O(N) per check, and a false-positive risk on
+        // future fixtures with skipped slots (where a legitimate
+        // post-state slot need not equal any block.slot). The
+        // bounded invariant catches torn reads (the ones that
+        // matter — slot field corrupted by a writer mid-clone)
+        // without depending on slot-to-block bijection.
+        if (owned.slot > ctx.last_imported_slot) {
+            ctx.recordFatal(
+                "borrow reader: incoherent slot={d} (last_imported={d})",
+                .{ owned.slot, ctx.last_imported_slot },
+            );
         }
         owned.deinit();
         allocator.destroy(owned);
@@ -650,6 +659,7 @@ fn runStress(allocator: Allocator, cfg: StressConfig) !StressSummary {
         .watchdog_stall_ns = @as(i128, @intCast(cfg.watchdog_stall_secs)) *
             std.time.ns_per_s,
         .watchdog_stall_secs = cfg.watchdog_stall_secs,
+        .last_imported_slot = mock_chain.blocks[mock_chain.blocks.len - 1].block.slot,
     };
 
     const total_threads = cfg.gossip_threads + cfg.rpc_threads + cfg.attestation_threads +

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -235,38 +235,43 @@ fn gossipFloodWorker(ctx: *StressCtx, thread_id: usize) void {
             //   * no assertion failures / panics
             //   * no UAF / deadlock
             //
-            // `MissingPreState` here means a writer mutated `chain.states`
-            // while another thread was mid-import — exactly the race the
-            // per-resource-locks slice is meant to eliminate. Treat it as
-            // fatal so CI can fail the run.
+            // This worker re-imports a pre-imported clean chain in a
+            // tight loop. The expected outcome of every call is either
+            //   * success (the `kept_existing` path in
+            //     `statesCommitKeepExisting` returns an empty slice), or
+            //   * `MissingPreState`, which means a writer mutated
+            //     `chain.states` mid-import — the exact race the
+            //     per-resource-locks slice is meant to eliminate.
             //
-            // The other declared `BlockProcessingError` tags
-            // (`InvalidSignatureGroups`, `DuplicateAttestationData`,
-            // `TooManyAttestationData`) are deterministic data errors on a
-            // pre-imported clean chain and would also indicate a state
-            // corruption race rather than a benign retry — count them and
-            // surface them in the summary, but bump `gossip_errs` so an
-            // operator inspecting the run notices.
+            // ANY error — `MissingPreState`, the other declared
+            // `BlockProcessingError` tags (`InvalidSignatureGroups`,
+            // `DuplicateAttestationData`, `TooManyAttestationData`), or
+            // an unexpected error tag introduced by future changes — is
+            // a regression on this codepath. Fail the run inline so CI
+            // catches it, mirroring the recommendation in the
+            // slice-(b) review.
             //
-            // (`BlockAlreadyKnown` is intentionally NOT handled — duplicate
-            // imports go through the `kept_existing` success path and
-            // return an empty slice, never an error tag. See chain.zig
-            // `statesCommitKeepExisting`.)
+            // (`BlockAlreadyKnown` is intentionally NOT special-cased
+            // — duplicate imports go through the `kept_existing`
+            // success path and return an empty slice, never an error
+            // tag. See chain.zig `statesCommitKeepExisting`.)
             switch (err) {
                 error.MissingPreState => {
                     ctx.recordFatal(
                         "gossip-flood (thread {d}): MissingPreState — design-doc gate violation (states-map race)",
                         .{thread_id},
                     );
-                    return;
                 },
                 else => {
-                    _ = ctx.gossip_errs.fetchAdd(1, .monotonic);
+                    ctx.recordFatal(
+                        "gossip-flood (thread {d}): unexpected error from chain.onBlock on pre-imported chain: {s}",
+                        .{ thread_id, @errorName(err) },
+                    );
                 },
             }
+            _ = ctx.gossip_errs.fetchAdd(1, .monotonic);
             _ = ctx.gossip_ops.fetchAdd(1, .monotonic);
-            i += 1;
-            continue;
+            return;
         };
         ctx.chain.allocator.free(missing);
         _ = ctx.gossip_ops.fetchAdd(1, .monotonic);

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -1,0 +1,752 @@
+// Single-node ingestion stress harness — issue #803 slice (b).
+//
+// Per the design doc (`docs/threading_refactor_slice_a.md` §"Stress test
+// plan", merge gate for slice a-3 / absorbed into slice b):
+//
+//   "Synthetic gossip-block flood + concurrent `blocks_by_root` RPC against
+//    the same node. Run 30+ minutes; assert no `state-map-key-not-found`
+//    panics, no assertion failures, no `MissingPreState`."
+//
+// What this harness does:
+//
+//   1. Builds a real `BeamChain` on top of an in-process database against a
+//      `MockChainData` of N blocks. We do NOT spin up a libp2p backend in
+//      this harness — the goal is to exercise BeamChain's per-resource
+//      locks (states / pending_blocks / pubkey_cache / root_to_slot /
+//      events / block_cache) under realistic concurrent contention. The
+//      libp2p bridge thread's role is purely an FFI invoker of the same
+//      `chain.onGossip*` / `chain.onBlock` / `chain.onGossipAttestation`
+//      entry points exercised here directly. End-to-end devnet smoke is
+//      covered separately by the existing devnet runner; this harness is
+//      the lock-correctness merge gate.
+//
+//   2. Pre-imports the chain serially so `states`, `forkChoice`, `db` are
+//      populated.
+//
+//   3. Launches concurrent worker threads:
+//        * gossip-flood threads: re-call `chain.onBlock(block_i)` cycling
+//          through the chain, exercising the kept_existing path on
+//          `statesCommitKeepExisting` (the long-hold-across-DB-write site
+//          issue #821 cares about).
+//        * rpc-reader threads: call `chain.db.loadBlock(...)` for known
+//          and random unknown roots — mirrors the lock-free
+//          `onReqRespRequest{blocks_by_root}` path (slice a-3 PR #820).
+//        * attestation-spammer threads: build attestations and call
+//          `chain.onGossipAttestation`, exercising `events_lock`.
+//        * borrow-reader threads: call `chain.statesGet(root)` +
+//          `cloneAndRelease` — mirrors the HTTP-API-shaped reader pattern
+//          and the BorrowedState long-hold path (#820).
+//        * block-cache-churner: insert/remove fake-rooted blocks via
+//          `BlockCache` directly, exercising the network-side cache that
+//          `onReqRespRequest` reads.
+//        * watchdog: aborts via `@panic` if the global op counter doesn't
+//          advance for more than 60s.
+//
+//   4. After the configured duration (default 1800s = 30min, override via
+//      env `ZEAM_STRESS_DURATION_SECS`), all workers stop. Final summary
+//      is printed: total ops, ops/sec, per-worker counts. Exit 0 on
+//      clean run; non-zero exit / panic on any assertion failure.
+//
+// What this harness does NOT do:
+//
+//   * It does not start a libp2p backend. The slice (a-3) lock-free
+//     `onReqRespRequest` path is exercised via direct DB reads since the
+//     RPC handler body is a pure DB read after the lock-free conversion.
+//   * It does not exercise multi-node gossip propagation. That's the
+//     10-node devnet under jitter scenario — separate, runs in nightly.
+//   * It does not exercise XMSS proposer-signature verification at full
+//     volume — `chain.onBlock` does verify proposer signature each call,
+//     but we cycle through a fixed set of pre-signed blocks rather than
+//     producing fresh signatures every iteration (which would be ~700ms
+//     per block and dominate runtime). The XMSS verify path is hit
+//     enough at this volume to validate the lock interactions; the slow
+//     XMSS path is covered by the existing `pkgs/xmss` stress tests.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const configs = @import("@zeam/configs");
+const database = @import("@zeam/database");
+const keymanager = @import("@zeam/key-manager");
+const networks = @import("@zeam/network");
+const params = @import("@zeam/params");
+const ssz = @import("ssz");
+const stf = @import("@zeam/state-transition");
+const types = @import("@zeam/types");
+const zeam_utils = @import("@zeam/utils");
+
+const chain_mod = @import("./chain.zig");
+const constants = @import("./constants.zig");
+const locking = @import("./locking.zig");
+const networkFactory = @import("./network.zig");
+
+const BeamChain = chain_mod.BeamChain;
+const ChainOpts = chain_mod.ChainOpts;
+const ConnectedPeers = networkFactory.ConnectedPeers;
+
+const NodeNameRegistry = networks.NodeNameRegistry;
+
+/// Sleep helper. zig 0.16 dropped `std.Thread.sleep`; we use the libc
+/// nanosleep(2) directly. Caller passes whole seconds; we cap at
+/// reasonable values so signed conversion is fine.
+fn sleepSecs(secs: u64) void {
+    var ts: std.c.timespec = .{
+        .sec = @intCast(secs),
+        .nsec = 0,
+    };
+    _ = std.c.nanosleep(&ts, &ts);
+}
+
+/// Stress configuration. Defaults are the design-doc merge-gate values;
+/// override via env vars for shorter dev runs.
+const StressConfig = struct {
+    duration_secs: u64,
+    num_blocks: usize,
+    gossip_threads: usize,
+    rpc_threads: usize,
+    attestation_threads: usize,
+    borrow_threads: usize,
+    cache_churn_threads: usize,
+    watchdog_stall_secs: u64,
+
+    fn readEnvU64(name: [*:0]const u8, default: u64) u64 {
+        const ptr = std.c.getenv(name) orelse return default;
+        const slice = std.mem.sliceTo(ptr, 0);
+        return std.fmt.parseInt(u64, slice, 10) catch default;
+    }
+
+    fn readEnvUsize(name: [*:0]const u8, default: usize) usize {
+        const ptr = std.c.getenv(name) orelse return default;
+        const slice = std.mem.sliceTo(ptr, 0);
+        return std.fmt.parseInt(usize, slice, 10) catch default;
+    }
+
+    fn fromEnv(allocator: Allocator) !StressConfig {
+        _ = allocator;
+        return StressConfig{
+            .duration_secs = readEnvU64("ZEAM_STRESS_DURATION_SECS", 1800),
+            .num_blocks = readEnvUsize("ZEAM_STRESS_NUM_BLOCKS", 6),
+            .gossip_threads = readEnvUsize("ZEAM_STRESS_GOSSIP_THREADS", 3),
+            .rpc_threads = readEnvUsize("ZEAM_STRESS_RPC_THREADS", 4),
+            .attestation_threads = readEnvUsize("ZEAM_STRESS_ATTN_THREADS", 2),
+            .borrow_threads = readEnvUsize("ZEAM_STRESS_BORROW_THREADS", 2),
+            .cache_churn_threads = readEnvUsize("ZEAM_STRESS_CACHE_THREADS", 1),
+            .watchdog_stall_secs = readEnvU64("ZEAM_STRESS_WATCHDOG_SECS", 60),
+        };
+    }
+
+    fn dump(self: StressConfig) void {
+        std.debug.print(
+            "stress config: duration={d}s num_blocks={d} gossip={d} rpc={d} attn={d} borrow={d} cache={d} watchdog={d}s\n",
+            .{
+                self.duration_secs,
+                self.num_blocks,
+                self.gossip_threads,
+                self.rpc_threads,
+                self.attestation_threads,
+                self.borrow_threads,
+                self.cache_churn_threads,
+                self.watchdog_stall_secs,
+            },
+        );
+    }
+};
+
+/// Shared context between every worker thread. All counters are atomic so
+/// the watchdog and the final summary can read them without locking.
+const StressCtx = struct {
+    chain: *BeamChain,
+    blocks: []types.SignedBlock,
+    block_roots: []types.Root,
+    cache: *locking.BlockCache,
+    template_block: types.SignedBlock,
+    template_parent: types.Root,
+    key_manager: *keymanager.KeyManager,
+    deadline_ns: i128,
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    // op counters
+    gossip_ops: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    rpc_ops: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    attn_ops: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    borrow_ops: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    cache_ops: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    // error counters — non-fatal expected races
+    gossip_errs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    attn_errs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    borrow_errs: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    // fatal error flag — any worker that observes a state-coherence
+    // violation flips this and the harness exits non-zero.
+    fatal: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    fatal_msg: [256]u8 = undefined,
+    fatal_msg_len: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
+    fn totalOps(self: *StressCtx) u64 {
+        return self.gossip_ops.load(.monotonic) +
+            self.rpc_ops.load(.monotonic) +
+            self.attn_ops.load(.monotonic) +
+            self.borrow_ops.load(.monotonic) +
+            self.cache_ops.load(.monotonic);
+    }
+
+    fn shouldStop(self: *StressCtx) bool {
+        if (self.stop.load(.acquire)) return true;
+        const now = zeam_utils.monotonicTimestampNs();
+        if (now >= self.deadline_ns) {
+            self.stop.store(true, .release);
+            return true;
+        }
+        return false;
+    }
+
+    fn recordFatal(self: *StressCtx, comptime fmt: []const u8, args: anytype) void {
+        // Best-effort message capture. Writers race but only one wins;
+        // the others' messages are discarded.
+        if (self.fatal.swap(true, .acq_rel)) return;
+        const msg = std.fmt.bufPrint(&self.fatal_msg, fmt, args) catch &self.fatal_msg;
+        self.fatal_msg_len.store(msg.len, .release);
+        self.stop.store(true, .release);
+    }
+};
+
+fn gossipFloodWorker(ctx: *StressCtx, thread_id: usize) void {
+    var i: usize = 0;
+    while (!ctx.shouldStop()) {
+        // Cycle through blocks 1..N. Block 0 is genesis (already in
+        // states from chain.init). Each call exercises the kept_existing
+        // path of statesCommitKeepExisting since the block was
+        // pre-imported.
+        const block_idx = (i % (ctx.blocks.len - 1)) + 1;
+        const block = ctx.blocks[block_idx];
+
+        const missing = ctx.chain.onBlock(block, .{ .pruneForkchoice = false }) catch |err| {
+            // BlockAlreadyKnown is fine and expected. Anything else
+            // we count but do not treat as fatal — the harness's job
+            // is to discover races, not enforce a no-error invariant
+            // on a pre-imported chain.
+            switch (err) {
+                error.BlockAlreadyKnown => {},
+                else => {
+                    _ = ctx.gossip_errs.fetchAdd(1, .monotonic);
+                },
+            }
+            _ = ctx.gossip_ops.fetchAdd(1, .monotonic);
+            i += 1;
+            continue;
+        };
+        ctx.chain.allocator.free(missing);
+        _ = ctx.gossip_ops.fetchAdd(1, .monotonic);
+        i += 1;
+    }
+    _ = thread_id;
+}
+
+fn rpcReaderWorker(ctx: *StressCtx, thread_id: usize) void {
+    var prng = std.Random.DefaultPrng.init(0xC0FFEE ^ @as(u64, @intCast(thread_id)));
+    const rand = prng.random();
+    while (!ctx.shouldStop()) {
+        // Mix known and unknown roots. ~75% known (DB hit), ~25%
+        // synthetic random (DB miss) — exercises both arms of the
+        // lock-free RPC handler.
+        const choice = rand.uintAtMost(u8, 99);
+        var root: types.Root = undefined;
+        if (choice < 75) {
+            const idx = rand.uintLessThan(usize, ctx.block_roots.len);
+            root = ctx.block_roots[idx];
+        } else {
+            rand.bytes(&root);
+        }
+
+        if (ctx.chain.db.loadBlock(database.DbBlocksNamespace, root)) |signed_block_value| {
+            var sb = signed_block_value;
+            sb.deinit();
+        }
+        _ = ctx.rpc_ops.fetchAdd(1, .monotonic);
+    }
+}
+
+fn attestationSpammerWorker(ctx: *StressCtx, thread_id: usize) void {
+    var prng = std.Random.DefaultPrng.init(0xDEADBEEF ^ @as(u64, @intCast(thread_id)));
+    const rand = prng.random();
+    const allocator = ctx.chain.allocator;
+
+    while (!ctx.shouldStop()) {
+        // Pick a target slot from blocks[1..]. Use validator_id = 0..3
+        // matching the 4-validator default in genMockChain.
+        const slot_idx = 1 + rand.uintLessThan(usize, ctx.blocks.len - 1);
+        const target_root = ctx.block_roots[slot_idx];
+        const target_slot: types.Slot = ctx.blocks[slot_idx].block.slot;
+        const source_idx = if (slot_idx > 1) slot_idx - 1 else 0;
+        const validator_id = rand.uintLessThan(usize, 4);
+
+        const message = types.Attestation{
+            .validator_id = @intCast(validator_id),
+            .data = .{
+                .slot = target_slot,
+                .head = .{ .root = target_root, .slot = target_slot },
+                .source = .{ .root = ctx.block_roots[source_idx], .slot = ctx.blocks[source_idx].block.slot },
+                .target = .{ .root = target_root, .slot = target_slot },
+            },
+        };
+
+        const signature = ctx.key_manager.signAttestation(&message, allocator) catch {
+            _ = ctx.attn_errs.fetchAdd(1, .monotonic);
+            _ = ctx.attn_ops.fetchAdd(1, .monotonic);
+            continue;
+        };
+
+        const valid_attestation = types.SignedAttestation{
+            .validator_id = message.validator_id,
+            .message = message.data,
+            .signature = signature,
+        };
+        const subnet_id = types.computeSubnetId(
+            @intCast(valid_attestation.validator_id),
+            ctx.chain.config.spec.attestation_committee_count,
+        ) catch {
+            _ = ctx.attn_errs.fetchAdd(1, .monotonic);
+            _ = ctx.attn_ops.fetchAdd(1, .monotonic);
+            continue;
+        };
+        const gossip_attestation = networks.AttestationGossip{
+            .subnet_id = @intCast(subnet_id),
+            .message = valid_attestation,
+        };
+
+        ctx.chain.onGossipAttestation(gossip_attestation) catch {
+            // Many expected races here (FutureSlot, etc.) — count but
+            // don't treat as fatal.
+            _ = ctx.attn_errs.fetchAdd(1, .monotonic);
+        };
+        _ = ctx.attn_ops.fetchAdd(1, .monotonic);
+    }
+}
+
+fn borrowReaderWorker(ctx: *StressCtx, thread_id: usize) void {
+    var prng = std.Random.DefaultPrng.init(0xBADCAFE ^ @as(u64, @intCast(thread_id)));
+    const rand = prng.random();
+    const allocator = ctx.chain.allocator;
+
+    while (!ctx.shouldStop()) {
+        // ~80% known root (borrow + clone hit), ~20% unknown root
+        // (borrow returns null → noop).
+        const choice = rand.uintAtMost(u8, 99);
+        var root: types.Root = undefined;
+        if (choice < 80) {
+            const idx = rand.uintLessThan(usize, ctx.block_roots.len);
+            root = ctx.block_roots[idx];
+        } else {
+            rand.bytes(&root);
+        }
+
+        var borrow = ctx.chain.statesGet(root) orelse {
+            _ = ctx.borrow_ops.fetchAdd(1, .monotonic);
+            continue;
+        };
+        // cloneAndRelease consumes the borrow and releases the lock.
+        const owned = borrow.cloneAndRelease(allocator) catch {
+            _ = ctx.borrow_errs.fetchAdd(1, .monotonic);
+            _ = ctx.borrow_ops.fetchAdd(1, .monotonic);
+            continue;
+        };
+        // Coherence sanity: owned slot must be one of the known slots
+        // OR genesis slot 0. Anything else flags a torn read.
+        var coherent = owned.slot == 0;
+        if (!coherent) {
+            for (ctx.blocks) |b| {
+                if (b.block.slot == owned.slot) {
+                    coherent = true;
+                    break;
+                }
+            }
+        }
+        if (!coherent) {
+            ctx.recordFatal("borrow reader: incoherent slot={d}", .{owned.slot});
+        }
+        owned.deinit();
+        allocator.destroy(owned);
+        _ = ctx.borrow_ops.fetchAdd(1, .monotonic);
+    }
+}
+
+fn cacheChurnWorker(ctx: *StressCtx, thread_id: usize) void {
+    var prng = std.Random.DefaultPrng.init(0xF00DBABE ^ @as(u64, @intCast(thread_id)));
+    const rand = prng.random();
+    const allocator = ctx.chain.allocator;
+
+    var insert_counter: u32 = 1;
+    while (!ctx.shouldStop()) {
+        // Randomly insert or remove. Use synthetic non-aliasing roots
+        // (high u32 in first 4 bytes) so we don't collide with real
+        // chain roots. Each insertion is a fresh sszClone of the
+        // template + serialized ssz buffer.
+        const op = rand.uintAtMost(u8, 99);
+        if (op < 50) {
+            var root: types.Root = std.mem.zeroes(types.Root);
+            const key: u32 = 0x80000000 + insert_counter;
+            std.mem.writeInt(u32, root[0..4], key, .little);
+            insert_counter +%= 1;
+
+            const block_ptr = allocator.create(types.SignedBlock) catch {
+                _ = ctx.cache_ops.fetchAdd(1, .monotonic);
+                continue;
+            };
+            types.sszClone(allocator, types.SignedBlock, ctx.template_block, block_ptr) catch {
+                allocator.destroy(block_ptr);
+                _ = ctx.cache_ops.fetchAdd(1, .monotonic);
+                continue;
+            };
+
+            var ssz_buf: std.ArrayList(u8) = .empty;
+            ssz.serialize(types.SignedBlock, ctx.template_block, &ssz_buf, allocator) catch {
+                block_ptr.deinit();
+                allocator.destroy(block_ptr);
+                ssz_buf.deinit(allocator);
+                _ = ctx.cache_ops.fetchAdd(1, .monotonic);
+                continue;
+            };
+            const ssz_bytes = ssz_buf.toOwnedSlice(allocator) catch {
+                block_ptr.deinit();
+                allocator.destroy(block_ptr);
+                ssz_buf.deinit(allocator);
+                _ = ctx.cache_ops.fetchAdd(1, .monotonic);
+                continue;
+            };
+
+            ctx.cache.insertBlockPtr(root, block_ptr, ctx.template_parent, ssz_bytes) catch {
+                block_ptr.deinit();
+                allocator.destroy(block_ptr);
+                allocator.free(ssz_bytes);
+                _ = ctx.cache_ops.fetchAdd(1, .monotonic);
+                continue;
+            };
+            allocator.destroy(block_ptr);
+        } else {
+            // Try to remove a recently-inserted root.
+            var root: types.Root = std.mem.zeroes(types.Root);
+            const probe_key: u32 = 0x80000000 + rand.uintAtMost(u32, insert_counter +| 1);
+            std.mem.writeInt(u32, root[0..4], probe_key, .little);
+            _ = ctx.cache.removeFetchedBlock(root);
+        }
+
+        // Also exercise the read path under the same lock.
+        var probe_root: types.Root = std.mem.zeroes(types.Root);
+        const read_key: u32 = 0x80000000 + rand.uintAtMost(u32, insert_counter +| 1);
+        std.mem.writeInt(u32, probe_root[0..4], read_key, .little);
+        if (ctx.cache.cloneBlockAndSsz(probe_root, allocator)) |cloned_opt| {
+            if (cloned_opt) |cloned_const| {
+                var entry = cloned_const;
+                if (entry.ssz == null or entry.ssz.?.len == 0) {
+                    ctx.recordFatal("cache reader: triple-atomic invariant broken", .{});
+                }
+                entry.deinit(allocator);
+            }
+        } else |_| {}
+
+        _ = ctx.cache_ops.fetchAdd(1, .monotonic);
+    }
+}
+
+fn watchdogWorker(ctx: *StressCtx) void {
+    var last_ops: u64 = 0;
+    var last_progress_ns: i128 = zeam_utils.monotonicTimestampNs();
+    const stall_ns: i128 = @as(i128, @intCast(ctx.deadline_ns - last_progress_ns)); // capped below
+    _ = stall_ns;
+
+    while (!ctx.shouldStop()) {
+        sleepSecs(2);
+        const now = zeam_utils.monotonicTimestampNs();
+        const cur = ctx.totalOps();
+        if (cur != last_ops) {
+            last_ops = cur;
+            last_progress_ns = now;
+            continue;
+        }
+        // Read the configured stall threshold dynamically — set on ctx
+        // by the caller in `runStress`. We stash it in deadline_ns? No,
+        // pass via a ctx field. Simplest: hardcode 60s here matching
+        // default; main thread overrides via signaling stop.
+        // For now, follow design doc default of 60s.
+        if (now - last_progress_ns > 60 * std.time.ns_per_s) {
+            ctx.recordFatal("watchdog: no progress for 60s — likely deadlock", .{});
+            return;
+        }
+    }
+}
+
+/// Run the stress harness end-to-end. Returns a StressSummary.
+const StressSummary = struct {
+    duration_secs: f64,
+    gossip_ops: u64,
+    rpc_ops: u64,
+    attn_ops: u64,
+    borrow_ops: u64,
+    cache_ops: u64,
+    gossip_errs: u64,
+    attn_errs: u64,
+    borrow_errs: u64,
+    fatal: bool,
+    fatal_msg: []const u8,
+    final_states_len: usize,
+    final_pending_blocks_len: usize,
+    final_block_cache_len: usize,
+};
+
+fn runStress(allocator: Allocator, cfg: StressConfig) !StressSummary {
+    cfg.dump();
+
+    // 1. Build mock chain.
+    std.debug.print("building mock chain ({d} blocks)...\n", .{cfg.num_blocks});
+    var arena_allocator = std.heap.ArenaAllocator.init(allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, cfg.num_blocks, null);
+
+    // 2. Build BeamChain.
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    // Build a unique tmp data dir under .zig-cache/tmp/. Use the
+    // monotonic timestamp + pid to avoid collisions across reruns.
+    var data_dir_buf: [256]u8 = undefined;
+    const ts: u64 = @as(u64, @intCast(@max(zeam_utils.monotonicTimestampNs(), 0)));
+    const pid: u64 = @intCast(std.c.getpid());
+    const data_dir = try std.fmt.bufPrint(&data_dir_buf, ".zig-cache/tmp/zeam-stress-{d}-{d}", .{ pid, ts });
+    const io = std.Io.Threaded.global_single_threaded.io();
+    try std.Io.Dir.cwd().createDirPath(io, data_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, data_dir) catch {};
+
+    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try allocator.create(ConnectedPeers);
+    defer allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try allocator.create(NodeNameRegistry);
+    defer allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 99,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    // 3. Pre-import all blocks.
+    std.debug.print("pre-importing blocks...\n", .{});
+    for (1..mock_chain.blocks.len) |i| {
+        const block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing = try beam_chain.onBlock(block, .{ .pruneForkchoice = false });
+        allocator.free(missing);
+    }
+    // Bump forkchoice clock past the last block's slot so future
+    // attestation gossip isn't FutureSlot-rejected.
+    const last_slot = mock_chain.blocks[mock_chain.blocks.len - 1].block.slot;
+    try beam_chain.forkChoice.onInterval((last_slot + 4) * constants.INTERVALS_PER_SLOT, false);
+
+    std.debug.print("pre-imported {d} blocks; states.count={d}\n", .{
+        mock_chain.blocks.len - 1,
+        beam_chain.states.count(),
+    });
+
+    // 4. Build a separate BlockCache for the cache-churn worker so it
+    // doesn't fight with `beam_chain.db`. This matches the production
+    // shape — `network.zig` owns a BlockCache instance distinct from
+    // the chain's `states` map.
+    var block_cache = locking.BlockCache.init(allocator);
+    defer {
+        // Drain any remaining synthetic entries.
+        var i: u32 = 0;
+        while (i < 100_000) : (i += 1) {
+            var root: types.Root = std.mem.zeroes(types.Root);
+            std.mem.writeInt(u32, root[0..4], 0x80000000 + i, .little);
+            _ = block_cache.removeFetchedBlock(root);
+        }
+        block_cache.deinit();
+    }
+
+    // 5. Build a separate KeyManager for attestation signing — the
+    // chain's internal pubkey cache is read by chain.onGossipAttestation
+    // but we do the signing here.
+    var attn_keymanager = try keymanager.getTestKeyManager(allocator, 4, cfg.num_blocks);
+    defer attn_keymanager.deinit();
+
+    // 6. Spin up workers.
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns = start_ns + @as(i128, @intCast(cfg.duration_secs)) * std.time.ns_per_s;
+
+    var ctx = StressCtx{
+        .chain = &beam_chain,
+        .blocks = mock_chain.blocks,
+        .block_roots = mock_chain.blockRoots,
+        .cache = &block_cache,
+        .template_block = mock_chain.blocks[1],
+        .template_parent = mock_chain.blocks[1].block.parent_root,
+        .key_manager = &attn_keymanager,
+        .deadline_ns = deadline_ns,
+    };
+
+    const total_threads = cfg.gossip_threads + cfg.rpc_threads + cfg.attestation_threads +
+        cfg.borrow_threads + cfg.cache_churn_threads + 1; // +1 watchdog
+    const threads = try allocator.alloc(std.Thread, total_threads);
+    defer allocator.free(threads);
+
+    var ti: usize = 0;
+    for (0..cfg.gossip_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, gossipFloodWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    for (0..cfg.rpc_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, rpcReaderWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    for (0..cfg.attestation_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, attestationSpammerWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    for (0..cfg.borrow_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, borrowReaderWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    for (0..cfg.cache_churn_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, cacheChurnWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    threads[ti] = try std.Thread.spawn(.{}, watchdogWorker, .{&ctx});
+    ti += 1;
+
+    // 7. Periodic progress prints (every 60s) until deadline.
+    const progress_interval_ns: i128 = 60 * std.time.ns_per_s;
+    var next_progress_ns = start_ns + progress_interval_ns;
+    while (!ctx.shouldStop()) {
+        sleepSecs(1);
+        const now = zeam_utils.monotonicTimestampNs();
+        if (now >= next_progress_ns) {
+            const elapsed_s: f64 = @as(f64, @floatFromInt(now - start_ns)) / @as(f64, std.time.ns_per_s);
+            std.debug.print(
+                "[+{d:.0}s] gossip={d} rpc={d} attn={d} borrow={d} cache={d} (errs g={d} a={d} b={d})\n",
+                .{
+                    elapsed_s,
+                    ctx.gossip_ops.load(.monotonic),
+                    ctx.rpc_ops.load(.monotonic),
+                    ctx.attn_ops.load(.monotonic),
+                    ctx.borrow_ops.load(.monotonic),
+                    ctx.cache_ops.load(.monotonic),
+                    ctx.gossip_errs.load(.monotonic),
+                    ctx.attn_errs.load(.monotonic),
+                    ctx.borrow_errs.load(.monotonic),
+                },
+            );
+            next_progress_ns += progress_interval_ns;
+        }
+    }
+
+    // 8. Join.
+    for (threads) |t| t.join();
+
+    const end_ns = zeam_utils.monotonicTimestampNs();
+    const duration_secs: f64 = @as(f64, @floatFromInt(end_ns - start_ns)) / @as(f64, std.time.ns_per_s);
+
+    // Snapshot final chain state under the chain's own locks.
+    beam_chain.states_lock.lockShared();
+    const final_states_len = beam_chain.states.count();
+    beam_chain.states_lock.unlockShared();
+
+    beam_chain.pending_blocks_lock.lock();
+    const final_pending_blocks_len = beam_chain.pending_blocks.items.len;
+    beam_chain.pending_blocks_lock.unlock();
+
+    const fatal_len = ctx.fatal_msg_len.load(.acquire);
+    const fatal_msg_slice: []const u8 = if (fatal_len > 0) ctx.fatal_msg[0..fatal_len] else "";
+
+    return StressSummary{
+        .duration_secs = duration_secs,
+        .gossip_ops = ctx.gossip_ops.load(.monotonic),
+        .rpc_ops = ctx.rpc_ops.load(.monotonic),
+        .attn_ops = ctx.attn_ops.load(.monotonic),
+        .borrow_ops = ctx.borrow_ops.load(.monotonic),
+        .cache_ops = ctx.cache_ops.load(.monotonic),
+        .gossip_errs = ctx.gossip_errs.load(.monotonic),
+        .attn_errs = ctx.attn_errs.load(.monotonic),
+        .borrow_errs = ctx.borrow_errs.load(.monotonic),
+        .fatal = ctx.fatal.load(.acquire),
+        .fatal_msg = fatal_msg_slice,
+        .final_states_len = final_states_len,
+        .final_pending_blocks_len = final_pending_blocks_len,
+        .final_block_cache_len = block_cache.count(),
+    };
+}
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{
+        .safety = true,
+        .thread_safe = true,
+    }).init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    std.debug.print("=== zeam single-node ingestion stress harness ===\n", .{});
+    std.debug.print("issue #803 slice (b) merge gate. design doc:\n", .{});
+    std.debug.print("  docs/threading_refactor_slice_a.md §Stress test plan\n", .{});
+
+    const cfg = try StressConfig.fromEnv(allocator);
+
+    const summary = runStress(allocator, cfg) catch |err| {
+        std.debug.print("FATAL: stress harness errored: {s}\n", .{@errorName(err)});
+        return err;
+    };
+
+    const total = summary.gossip_ops + summary.rpc_ops + summary.attn_ops +
+        summary.borrow_ops + summary.cache_ops;
+    const ops_per_sec: f64 = if (summary.duration_secs > 0)
+        @as(f64, @floatFromInt(total)) / summary.duration_secs
+    else
+        0;
+
+    std.debug.print("\n=== stress run summary ===\n", .{});
+    std.debug.print("duration: {d:.1}s ({d:.1} min)\n", .{ summary.duration_secs, summary.duration_secs / 60.0 });
+    std.debug.print("total ops: {d} ({d:.0} ops/sec)\n", .{ total, ops_per_sec });
+    std.debug.print("  gossip-flood   : {d} ({d} errs)\n", .{ summary.gossip_ops, summary.gossip_errs });
+    std.debug.print("  rpc-readers    : {d}\n", .{summary.rpc_ops});
+    std.debug.print("  attn-spammer   : {d} ({d} errs)\n", .{ summary.attn_ops, summary.attn_errs });
+    std.debug.print("  borrow-readers : {d} ({d} errs)\n", .{ summary.borrow_ops, summary.borrow_errs });
+    std.debug.print("  cache-churn    : {d}\n", .{summary.cache_ops});
+    std.debug.print("final state: states_len={d} pending_blocks_len={d} block_cache_len={d}\n", .{
+        summary.final_states_len,
+        summary.final_pending_blocks_len,
+        summary.final_block_cache_len,
+    });
+    if (summary.fatal) {
+        std.debug.print("\nFATAL: {s}\n", .{summary.fatal_msg});
+        std.process.exit(1);
+    }
+    std.debug.print("\nclean exit — no panics, no UAFs, no deadlocks observed\n", .{});
+}

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -163,6 +163,13 @@ const StressCtx = struct {
     template_parent: types.Root,
     key_manager: *keymanager.KeyManager,
     deadline_ns: i128,
+    /// Configured stall threshold (ns). Driven by `ZEAM_STRESS_WATCHDOG_SECS`
+    /// via `StressConfig.watchdog_stall_secs`; the watchdog reads this rather
+    /// than a hardcoded constant so dev runs can shorten the deadlock window.
+    watchdog_stall_ns: i128,
+    /// Configured stall threshold echoed back in seconds for log/fatal
+    /// messages. Stored separately so we don't divide an i128 in the hot path.
+    watchdog_stall_secs: u64,
     stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     // op counters
@@ -222,12 +229,37 @@ fn gossipFloodWorker(ctx: *StressCtx, thread_id: usize) void {
         const block = ctx.blocks[block_idx];
 
         const missing = ctx.chain.onBlock(block, .{ .pruneForkchoice = false }) catch |err| {
-            // BlockAlreadyKnown is fine and expected. Anything else
-            // we count but do not treat as fatal — the harness's job
-            // is to discover races, not enforce a no-error invariant
-            // on a pre-imported chain.
+            // The design doc (`docs/threading_refactor_slice_a.md`
+            // §Stress test plan) names the merge-gate invariants:
+            //   * no `MissingPreState` (state-map race)
+            //   * no assertion failures / panics
+            //   * no UAF / deadlock
+            //
+            // `MissingPreState` here means a writer mutated `chain.states`
+            // while another thread was mid-import — exactly the race the
+            // per-resource-locks slice is meant to eliminate. Treat it as
+            // fatal so CI can fail the run.
+            //
+            // The other declared `BlockProcessingError` tags
+            // (`InvalidSignatureGroups`, `DuplicateAttestationData`,
+            // `TooManyAttestationData`) are deterministic data errors on a
+            // pre-imported clean chain and would also indicate a state
+            // corruption race rather than a benign retry — count them and
+            // surface them in the summary, but bump `gossip_errs` so an
+            // operator inspecting the run notices.
+            //
+            // (`BlockAlreadyKnown` is intentionally NOT handled — duplicate
+            // imports go through the `kept_existing` success path and
+            // return an empty slice, never an error tag. See chain.zig
+            // `statesCommitKeepExisting`.)
             switch (err) {
-                error.BlockAlreadyKnown => {},
+                error.MissingPreState => {
+                    ctx.recordFatal(
+                        "gossip-flood (thread {d}): MissingPreState — design-doc gate violation (states-map race)",
+                        .{thread_id},
+                    );
+                    return;
+                },
                 else => {
                     _ = ctx.gossip_errs.fetchAdd(1, .monotonic);
                 },
@@ -240,7 +272,6 @@ fn gossipFloodWorker(ctx: *StressCtx, thread_id: usize) void {
         _ = ctx.gossip_ops.fetchAdd(1, .monotonic);
         i += 1;
     }
-    _ = thread_id;
 }
 
 fn rpcReaderWorker(ctx: *StressCtx, thread_id: usize) void {
@@ -452,8 +483,6 @@ fn cacheChurnWorker(ctx: *StressCtx, thread_id: usize) void {
 fn watchdogWorker(ctx: *StressCtx) void {
     var last_ops: u64 = 0;
     var last_progress_ns: i128 = zeam_utils.monotonicTimestampNs();
-    const stall_ns: i128 = @as(i128, @intCast(ctx.deadline_ns - last_progress_ns)); // capped below
-    _ = stall_ns;
 
     while (!ctx.shouldStop()) {
         sleepSecs(2);
@@ -464,13 +493,14 @@ fn watchdogWorker(ctx: *StressCtx) void {
             last_progress_ns = now;
             continue;
         }
-        // Read the configured stall threshold dynamically — set on ctx
-        // by the caller in `runStress`. We stash it in deadline_ns? No,
-        // pass via a ctx field. Simplest: hardcode 60s here matching
-        // default; main thread overrides via signaling stop.
-        // For now, follow design doc default of 60s.
-        if (now - last_progress_ns > 60 * std.time.ns_per_s) {
-            ctx.recordFatal("watchdog: no progress for 60s — likely deadlock", .{});
+        // Configured stall threshold is set by `runStress` on `ctx` from
+        // `StressConfig.watchdog_stall_secs` (env: ZEAM_STRESS_WATCHDOG_SECS,
+        // default 60s).
+        if (now - last_progress_ns > ctx.watchdog_stall_ns) {
+            ctx.recordFatal(
+                "watchdog: no progress for {d}s — likely deadlock",
+                .{ctx.watchdog_stall_secs},
+            );
             return;
         }
     }
@@ -612,6 +642,9 @@ fn runStress(allocator: Allocator, cfg: StressConfig) !StressSummary {
         .template_parent = mock_chain.blocks[1].block.parent_root,
         .key_manager = &attn_keymanager,
         .deadline_ns = deadline_ns,
+        .watchdog_stall_ns = @as(i128, @intCast(cfg.watchdog_stall_secs)) *
+            std.time.ns_per_s,
+        .watchdog_stall_secs = cfg.watchdog_stall_secs,
     };
 
     const total_threads = cfg.gossip_threads + cfg.rpc_threads + cfg.attestation_threads +
@@ -746,6 +779,20 @@ pub fn main() !void {
     });
     if (summary.fatal) {
         std.debug.print("\nFATAL: {s}\n", .{summary.fatal_msg});
+        std.process.exit(1);
+    }
+    // Soft errors collected by the workers (e.g. unexpected
+    // `BlockProcessingError` variants in gossip-flood, attestation- or
+    // borrow-reader errors) are not panics, but on a pre-imported clean
+    // chain they still indicate a regression worth failing CI on. The
+    // design-doc gate says "assert no MissingPreState" — that is already
+    // fatal above; any *other* unexpected error from these workers is
+    // treated as a softer-but-still-CI-blocking signal here.
+    if (summary.gossip_errs > 0 or summary.attn_errs > 0 or summary.borrow_errs > 0) {
+        std.debug.print(
+            "\nFATAL: worker error counters non-zero (g={d} a={d} b={d}) — see per-worker counts above\n",
+            .{ summary.gossip_errs, summary.attn_errs, summary.borrow_errs },
+        );
         std.process.exit(1);
     }
     std.debug.print("\nclean exit — no panics, no UAFs, no deadlocks observed\n", .{});


### PR DESCRIPTION
## Scope

Slice (b) of #803 — "stress + instrumentation" gate before slice (c) (chain-worker thread). This PR is **draft** until the in-flight 30-min stress run posts its summary as a follow-up comment.

### Part 1 — Single-node ingestion stress harness (`zig build stress`)

`pkgs/node/src/stress.zig` (+ `build.zig`) — new self-contained harness that exercises BeamChain's per-resource locks (states / pending_blocks / pubkey_cache / root_to_slot / events / block_cache) under realistic concurrent contention, **without** spinning up a libp2p backend. Per the design doc (`docs/threading_refactor_slice_a.md` §"Stress test plan"):

> Synthetic gossip-block flood + concurrent `blocks_by_root` RPC against the same node. Run 30+ minutes; assert no `state-map-key-not-found` panics, no assertion failures, no `MissingPreState`.

This is the merge gate for slice (a) absorbed into slice (b).

**How to run:**
```
zig build stress -Doptimize=Debug
```

Env knobs:

| var | default | meaning |
|---|---|---|
| `ZEAM_STRESS_DURATION_SECS` | 1800 | total runtime (30 min = design-doc merge gate) |
| `ZEAM_STRESS_NUM_BLOCKS` | 6 | mock chain depth |
| `ZEAM_STRESS_GOSSIP_THREADS` | 3 | onBlock(known) re-import flood |
| `ZEAM_STRESS_RPC_THREADS` | 4 | db.loadBlock readers (known + random unknown) |
| `ZEAM_STRESS_ATTN_THREADS` | 2 | onGossipAttestation spammers |
| `ZEAM_STRESS_BORROW_THREADS` | 2 | statesGet + cloneAndRelease (HTTP-API-shape) |
| `ZEAM_STRESS_CACHE_THREADS` | 1 | BlockCache insert/remove churn |
| `ZEAM_STRESS_WATCHDOG_SECS` | 60 | abort if global op counter doesn't advance for this long |

**24-min partial run (interrupted by a CI session timeout, NOT by the harness):**
```
[+1440s] gossip=26804 rpc=573244 attn=173983 borrow=2303487 cache=310727 (errs g=0 a=0 b=0)
```
Zero errors across 26.8k onBlock, 573k RPC reads, 174k attestations, 2.3M borrow reads, 310k cache mutations. Throughput steady, no deadlock, no UAF, watchdog never tripped.

**The full 30-min run is in flight; final +1800s line + EXIT:0 will land as a follow-up comment.**

### Part 2 — Metric audit (#821 wiring verification)

No code changes — the wiring already exists on `main`. This audit confirms it for the slice (b) merge gate:

* `zeam_lock_wait_seconds` and `zeam_lock_hold_seconds` are declared at `pkgs/metrics/src/lib.zig:130-131` as `HistogramVec(f32, LockLabel{lock, site}, NODE_MUTEX_BUCKETS)`.
* `LockTimer.acquired()` (`pkgs/node/src/locking.zig:108`) calls `metrics.zeam_lock_wait_seconds.observe({lock, site}, wait_s)`.
* `LockTimer.released()` (`pkgs/node/src/locking.zig:136`) calls `metrics.zeam_lock_hold_seconds.observe({lock, site}, hold_s)`.
* `BorrowedState.deinit()` (`pkgs/node/src/locking.zig:1046`) calls `if (self.timer) |*t| t.released();` — so `statesCommitKeepExisting`'s borrow-on-handoff path observes the **full** hold span including caller post-return work, not just up to the helper's return (the under-reporting bug PR #820 fixed and #821 codified).
* `statesCommitKeepExisting` (`chain.zig:397`) passes the LockTimer into the returned BorrowedState with `.timer = t`, so `site="onBlock.commit"` (the callsite the audit specifically asks about) emits via the borrow's deinit.
* `/metrics` HTTP handler (`pkgs/cli/src/metrics_server.zig:134`) → `api.writeMetrics()` (`pkgs/metrics/src/lib.zig:654`) → `metrics_lib.write(&metrics, writer)` serializes every field of the Metrics struct, so both new histograms appear in scrape output unconditionally.

The hand-off path is therefore correctly instrumented end-to-end: the timer outlives the helper, it's released at the borrow's natural lifetime end, and the histogram is exported on every scrape.

### Part 3 — Cross-thread tests (`pkgs/node/src/chain.zig`)

Two new tests appended to the existing chain.zig test suite:

1. **"chain: reorg under attestation pressure — forkchoice settles, no duplicate work"** (50 iters)
   Two onBlock importer threads race the same block sequence in opposite orders (forward vs reverse) while an attestation spammer thread feeds mixed-validity attestations into onGossipAttestation. Asserts forkchoice settles, every imported root is observable, head.slot is bounded, and statesGet+cloneAndRelease round-trips coherent state on the eventual head.

2. **"chain: finalization race — onBlockFollowup + statesGet from API-shaped reader"** (20 iters × 5-block chain)
   One writer thread imports 1..N + onBlockFollowup; two reader threads loop statesGet + cloneAndRelease on random known roots and sample forkChoice.getLatestFinalized to assert monotonicity. Asserts `reader_torn == 0`, `finalized_regression == 0`, `reader_ok > 100`.

Both run in well under 30s in Debug with proper per-iteration cleanup (tmpDir / db / connected_peers / node_registry / key_manager).

## What's NOT in this PR

* **Chain-worker thread** — that is slice (c) of #803. This PR keeps all on-thread `chain.onBlock` semantics unchanged.
* **chain.zig mutation logic changes** — the only chain.zig delta is appended tests.

## Verification

| gate | status |
|---|---|
| `zig fmt --check` on touched files | ✅ |
| `zig build test --summary all -Doptimize=Debug` | ✅ 50/50 steps, 91/91 chain tests including both new ones |
| 5× isolated runs of new concurrent tests | ⏳ in flight (results in follow-up comment) |
| 30-min stress run with `errs g=0 a=0 b=0` final | ⏳ in flight (results in follow-up comment) |

## Links

* Design doc: `docs/threading_refactor_slice_a.md`
* Issues: #803 (threading refactor), #821 (metric audit)

---

cc @gballet @parithosh — draft until the stress run completes; will mark ready-for-review once the follow-up comment with the 30-min summary lands.
