### PR TITLE
node: introduce RcBeamState refcounted state pointer (slice c-2a of #803)

### DIFF
--- a/pkgs/node/src/lib.zig
+++ b/pkgs/node/src/lib.zig
@@ -22,6 +22,9 @@ pub const chain_worker = @import("./chain_worker.zig");
 pub const ChainWorker = chain_worker.ChainWorker;
 pub const ChainWorkerMessage = chain_worker.Message;
 
+pub const rc_beam_state = @import("./rc_beam_state.zig");
+pub const RcBeamState = rc_beam_state.RcBeamState;
+
 const networks = @import("@zeam/network");
 pub const NodeNameRegistry = networks.NodeNameRegistry;
 
@@ -31,5 +34,6 @@ test "get tests" {
     _ = @import("./utils.zig");
     _ = @import("./locking.zig");
     _ = @import("./chain_worker.zig");
+    _ = @import("./rc_beam_state.zig");
     @import("std").testing.refAllDecls(@This());
 }

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -56,8 +56,11 @@ const types = @import("@zeam/types");
 ///
 /// Lifecycle:
 ///
-///     // Creator path: takes ownership of `state` (which must be
-///     // a freshly-allocated, fully-initialised BeamState).
+///     // Creator path: `create` takes ownership of `state`
+///     // unconditionally. On success, the heap allocation embeds
+///     // `state` and the matching `release` frees it; on OOM,
+///     // `state.deinit()` runs before the error returns. Either
+///     // way the caller does NOT call `state.deinit()` after.
 ///     const rc = try RcBeamState.create(allocator, state);
 ///     defer rc.release();              // initial reference
 ///
@@ -81,16 +84,33 @@ pub const RcBeamState = struct {
 
     const Self = @This();
 
-    /// Create a new refcounted state wrapping `state` (transferred by
-    /// value into the heap allocation; caller must not retain a
+    /// Create a new refcounted state wrapping `state` (transferred
+    /// by value into the heap allocation; caller must not retain a
     /// pointer to the old `state` location). Initial refcount is 1
     /// — the creator is responsible for the matching `release`.
     ///
-    /// Returns `error.OutOfMemory` if the allocation fails. On
-    /// failure, `state` is NOT consumed — the caller still owns it
-    /// and is responsible for its cleanup.
+    /// **Always-consume contract.** This function takes ownership of
+    /// `state` unconditionally. On the success path, `state` is
+    /// embedded into the heap allocation and the matching `release`
+    /// frees it. On `error.OutOfMemory`, `state.deinit()` is called
+    /// before the error is returned, so the caller never has to
+    /// remember an `errdefer state.deinit()` between
+    /// `buildState(...)` and `RcBeamState.create(...)`.
+    ///
+    /// Earlier versions of this function returned without consuming
+    /// `state` on the OOM path. That asymmetry forced every caller
+    /// to write a fragile cleanup pattern; symmetric ownership is
+    /// the lower-footgun shape for an API used at every chain.zig
+    /// state-write site.
     pub fn create(allocator: Allocator, state: types.BeamState) !*Self {
-        const self = try allocator.create(Self);
+        const self = allocator.create(Self) catch |err| {
+            // OOM on the wrapper allocation — we still consumed
+            // `state` per the always-consume contract, so drop its
+            // owned interior allocations before returning.
+            var consumed = state;
+            consumed.deinit();
+            return err;
+        };
         self.* = .{
             .allocator = allocator,
             .refcount = std.atomic.Value(u32).init(1),
@@ -219,12 +239,22 @@ test "RcBeamState: acquire returns the same pointer (cheap to chain)" {
     reader.release();
 }
 
-test "RcBeamState: concurrent acquire/release stress (40 threads × 10k iters)" {
-    // High-contention test: 40 threads each take an acquire, do a
+test "RcBeamState: acquire/release pair accounting under producer race (40 threads × 10k iters)" {
+    // Pair-accounting test: 40 threads each take an acquire, do a
     // tiny no-op load, then release. The creator's refcount stays
     // at 1 throughout (each thread's acquire/release pair is
     // balanced). At the end, refcount must be exactly 1, then the
     // creator's release frees.
+    //
+    // What this test does NOT prove: the freeing race. Because the
+    // creator's reference is held throughout, every fetchSub call
+    // observes `prev > 1` and the freeing branch is never taken
+    // under contention — the acq_rel ordering on the freeing
+    // thread is not exercised. The next test
+    // ("freeing race — last release wins under contention") fills
+    // that gap by dropping the creator's reference partway and
+    // verifying that whichever thread brings refcount to 0 frees
+    // cleanly under testing.allocator's leak detection.
     const state = try makeState();
     const rc = try RcBeamState.create(testing.allocator, state);
 
@@ -263,6 +293,143 @@ test "RcBeamState: concurrent acquire/release stress (40 threads × 10k iters)" 
     rc.release();
 }
 
+test "RcBeamState: freeing race — last release wins under contention" {
+    // The pair-accounting test above never exercises the freeing
+    // branch (creator's reference is held throughout). This test
+    // does the opposite: pre-bump the refcount once per worker
+    // BEFORE spawning, hand each worker its own pre-acquired
+    // reference, then drop the creator's reference WHILE the
+    // workers are still running. Whichever thread brings
+    // refcount to 0 — worker or creator depending on
+    // interleaving — must free cleanly.
+    //
+    // The pre-bump matters: `acquire()`'s contract is "safe to
+    // call from any thread that holds a valid acquire." A worker
+    // that's just been spawned does NOT yet hold one (spawn
+    // doesn't bump for it). If we let the worker call acquire()
+    // as its first action, the rc may already have been freed
+    // by another worker that finished first — that's UAF on the
+    // acquire itself. Pre-bumping on the spawning thread closes
+    // that hole because the spawning thread DOES hold the
+    // creator's reference at the time of the bump.
+    //
+    // Repeat the whole shape `OUTER_ITERS` times so we sweep the
+    // interleaving space and don't depend on a single lucky
+    // schedule. testing.allocator's leak/UAF detector is the
+    // assertion.
+    const NUM_WORKERS: usize = 16;
+    const WORK_ITERS_PER_WORKER: usize = 200;
+    const OUTER_ITERS: usize = 50;
+
+    const Worker = struct {
+        // Receives a pre-acquired reference. Worker is
+        // responsible for releasing it exactly once.
+        fn run(reader: *RcBeamState, iters: usize) void {
+            defer reader.release();
+            // Touch the state inside the acquire window. The
+            // doNotOptimizeAway barrier ensures the load is not
+            // hoisted out by the compiler — we need the
+            // .acq_rel-ordered fetchSub on release to order
+            // every prior load before the freeing thread's free.
+            var k: usize = 0;
+            while (k < iters) : (k += 1) {
+                std.mem.doNotOptimizeAway(reader.state.slot);
+                std.Thread.yield() catch {};
+            }
+        }
+    };
+
+    var outer: usize = 0;
+    while (outer < OUTER_ITERS) : (outer += 1) {
+        const state = try makeState();
+        const rc = try RcBeamState.create(testing.allocator, state);
+        // refcount = 1 (creator)
+
+        var threads: [NUM_WORKERS]std.Thread = undefined;
+        var i: usize = 0;
+        while (i < NUM_WORKERS) : (i += 1) {
+            // Pre-bump on the spawning thread (we still hold
+            // the creator's reference here, so this is safe).
+            const handed = rc.acquire();
+            threads[i] = std.Thread.spawn(
+                .{},
+                Worker.run,
+                .{ handed, WORK_ITERS_PER_WORKER },
+            ) catch |err| {
+                // Spawn failed AFTER we bumped — release the
+                // pre-acquired reference so we don't leak.
+                handed.release();
+                return err;
+            };
+        }
+        // refcount = 1 + NUM_WORKERS here.
+
+        // Drop the creator's reference while workers are still
+        // alive. Now refcount is somewhere in
+        // [0, NUM_WORKERS] depending on how many workers have
+        // already released. When the LAST release happens (the
+        // last worker, or this very call if every worker has
+        // already finished), refcount reaches 0 and the freeing
+        // thread — worker or creator, we don't know which —
+        // calls state.deinit() + allocator.destroy(self).
+        rc.release();
+
+        i = 0;
+        while (i < NUM_WORKERS) : (i += 1) {
+            threads[i].join();
+        }
+        // After every worker has joined, refcount must have
+        // reached 0 and rc must have been freed. We MUST NOT
+        // read rc.count() or any rc field here — rc is freed
+        // memory by now, so touching it would be UAF.
+        // testing.allocator's leak detector catches both the
+        // leak case (refcount never reached 0) and the
+        // double-free case (refcount underflow on a fetchSub).
+    }
+}
+
+test "RcBeamState: freeing race — worker takes the final release" {
+    // Stronger variant of the previous test: deterministically
+    // ensure the WORKER (not the creator) brings refcount to 0,
+    // so we exercise the path where a non-creator thread observes
+    // prev == 1 on fetchSub and frees.
+    //
+    // Sequence on the test thread:
+    //   1. create(state)            → refcount = 1 (creator)
+    //   2. handed = rc.acquire()    → refcount = 2 (creator + handed)
+    //   3. rc.release()             → refcount = 1 (handed only)
+    //   4. spawn(worker, handed)
+    //   5. join
+    // The worker is now the sole reference holder; its release
+    // brings refcount to 0 and frees. The .acq_rel ordering on
+    // fetchSub is what makes this safe: any prior writes to
+    // `state` (none in this test, but the contract covers them)
+    // are observed by the worker before its free.
+    var i: usize = 0;
+    while (i < 100) : (i += 1) {
+        const state = try makeState();
+        const rc = try RcBeamState.create(testing.allocator, state);
+        // refcount = 1 (creator)
+        const handed = rc.acquire();
+        // refcount = 2 (creator + handed)
+        rc.release();
+        // refcount = 1 (handed only)
+
+        const Worker = struct {
+            fn run(target: *RcBeamState) void {
+                // We are the sole reference holder. Touch the
+                // state, then release.
+                std.mem.doNotOptimizeAway(target.state.slot);
+                target.release();
+            }
+        };
+
+        var t = try std.Thread.spawn(.{}, Worker.run, .{handed});
+        t.join();
+        // rc is freed by the worker; we must not touch it.
+    }
+}
+
 test "RcBeamState: release order doesn't matter (acquire-then-release vs release-then-acquire)" {
     // T1 acquires then releases. T2 acquires then releases. Result
     // refcount must be the creator's 1, regardless of interleaving.
@@ -284,4 +451,36 @@ test "RcBeamState: release order doesn't matter (acquire-then-release vs release
 
     try testing.expectEqual(@as(u32, 1), rc.count());
     rc.release();
+}
+
+test "RcBeamState.create: OOM path consumes state (no leak under FailingAllocator)" {
+    // Locks the always-consume contract in code: when the wrapper
+    // allocation fails, `create` MUST call state.deinit() before
+    // returning the error so the caller never has to remember an
+    // errdefer state.deinit() between buildState() and create().
+    //
+    // Mechanism: FailingAllocator with fail_index=0 fails the very
+    // first allocator.create() call (the wrapper allocation inside
+    // RcBeamState.create). The state passed in was built with
+    // testing.allocator and has owned interior allocations
+    // (validators list etc.). If create() returned the error
+    // without consuming, the caller (this test) would not call
+    // state.deinit() and testing.allocator's leak detector would
+    // flag the leak. This test passes ONLY if create() consumes
+    // on the OOM path.
+    const state = try makeState();
+
+    // FailingAllocator wrapping an always-failing inner allocator.
+    // We give it `fail_index = 0` so the first create() fails;
+    // the deinit() inside create() then runs against
+    // testing.allocator (the state's interior was allocated with
+    // testing.allocator, which is what makeState() uses).
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    const failing_allocator = failing.allocator();
+
+    const result = RcBeamState.create(failing_allocator, state);
+    try testing.expectError(error.OutOfMemory, result);
+    // The caller does NOT call state.deinit() here. If create()
+    // failed to consume, testing.allocator's leak detector trips
+    // when this test scope exits.
 }

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -1,0 +1,287 @@
+//! Refcounted `*BeamState` wrapper (slice c-2a of #803).
+//!
+//! Background: `BeamChain.states` is a hashmap of `Root → *BeamState`.
+//! Slice (a-2) wrapped reads in `BorrowedState` so callers couldn't
+//! deref-after-free. That works for a single-writer model but creates
+//! contention under the c-2 chain-worker design: a long-lived
+//! cross-thread reader (HTTP API, metrics scrape, event broadcaster)
+//! holds `states_lock.shared` for the entire duration of its read,
+//! blocking the chain worker's next state mutation.
+//!
+//! `RcBeamState` decouples the lifetime of a `*BeamState` from the
+//! lock that guards the map. Readers `acquire` a refcount, can drop
+//! the map lock immediately, and call `release` when done. The chain
+//! worker can `fetchRemove` from the map while a reader still holds
+//! a refcount; the state is freed only when refcount reaches zero.
+//!
+//! Slice (c-2a) ships the type and rewires `BeamChain.states` storage.
+//! No behaviour change at call sites: `statesGet` still hands out a
+//! `BorrowedState` whose drop releases the rwlock — the lock is still
+//! the source of truth for "has this entry been pruned." c-2b drops
+//! the lock from the borrow path and switches to refcount-only
+//! release; that's where the cross-thread-reader wins land.
+//!
+//! ## Storage layout (option (a) per the c-2 plan)
+//!
+//! Single allocation: `RcBeamState` embeds `BeamState` inline and
+//! holds the refcount alongside. Pros:
+//!   * one allocation per state (vs split `RcHeader` + `*BeamState`)
+//!   * one `release` frees the whole header + state
+//!   * no double-pointer chase on the read path
+//! Cons:
+//!   * cannot share a refcount across multiple distinct `BeamState`
+//!     pointers (e.g. shadowing). c-2a has no caller that needs this;
+//!     option (b) split layout can be added later if a use case appears.
+//!
+//! ## Refcount semantics
+//!
+//! `init` returns a refcount of 1 (the creator's reference). Every
+//! `acquire` bumps; every `release` decrements. The thread that brings
+//! refcount to 0 frees the state and the wrapper. Acquire/release are
+//! `acq_rel`-ordered atomic ops so the freeing thread observes all
+//! prior writes to the state.
+//!
+//! Double-release is a debug-build panic (the refcount underflows).
+//! Release after a refcount has already been freed is undefined; the
+//! map's invariant must guarantee callers hold a valid acquire before
+//! calling release. Slice (a-2)'s `BorrowedState` already enforces
+//! this for the lock path; under c-2b it will enforce it for the
+//! refcount path too.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const types = @import("@zeam/types");
+
+/// Refcounted wrapper over `BeamState` (option (a) inline layout).
+///
+/// Lifecycle:
+///
+///     // Creator path: takes ownership of `state` (which must be
+///     // a freshly-allocated, fully-initialised BeamState).
+///     const rc = try RcBeamState.create(allocator, state);
+///     defer rc.release();              // initial reference
+///
+///     // Reader path: existing rc, take a fresh acquire.
+///     const reader_rc = rc.acquire();
+///     defer reader_rc.release();       // independent of creator
+///
+/// Concurrent acquire/release is safe; the underlying refcount is an
+/// atomic and the freeing thread wins exactly one cmpxchg.
+pub const RcBeamState = struct {
+    /// Owning allocator. Final release frees `self` via this allocator.
+    allocator: Allocator,
+    /// Refcount. `acq_rel` orderings on bumps and decrements ensure the
+    /// thread that observes 0 also observes all prior writes to `state`
+    /// (and that the freeing thread's writes are not reordered before
+    /// the decrement).
+    refcount: std.atomic.Value(u32),
+    /// The wrapped state. Heap-owned; `release` calls `state.deinit()`
+    /// when refcount hits 0.
+    state: types.BeamState,
+
+    const Self = @This();
+
+    /// Create a new refcounted state wrapping `state` (transferred by
+    /// value into the heap allocation; caller must not retain a
+    /// pointer to the old `state` location). Initial refcount is 1
+    /// — the creator is responsible for the matching `release`.
+    ///
+    /// Returns `error.OutOfMemory` if the allocation fails. On
+    /// failure, `state` is NOT consumed — the caller still owns it
+    /// and is responsible for its cleanup.
+    pub fn create(allocator: Allocator, state: types.BeamState) !*Self {
+        const self = try allocator.create(Self);
+        self.* = .{
+            .allocator = allocator,
+            .refcount = std.atomic.Value(u32).init(1),
+            .state = state,
+        };
+        return self;
+    }
+
+    /// Bump refcount. Returns the same pointer for chained call sites
+    /// (e.g. `const reader = rc.acquire();`). Safe to call from any
+    /// thread that holds a valid acquire.
+    pub fn acquire(self: *Self) *Self {
+        const prev = self.refcount.fetchAdd(1, .acq_rel);
+        // Overflow check: u32 max is 4 billion; we should never get
+        // anywhere near this in practice, but a wraparound would be a
+        // silent UAF. Debug-build assert.
+        std.debug.assert(prev < std.math.maxInt(u32));
+        return self;
+    }
+
+    /// Decrement refcount. When refcount reaches 0, calls
+    /// `state.deinit()` and frees `self`. After `release`, the caller
+    /// MUST NOT use `self` again.
+    ///
+    /// Underflow (double-release without a matching acquire) is a
+    /// debug-build panic; release-build behaviour is silent UB.
+    pub fn release(self: *Self) void {
+        const prev = self.refcount.fetchSub(1, .acq_rel);
+        std.debug.assert(prev > 0); // catch double-release
+        if (prev == 1) {
+            // Last reference — we own the free.
+            self.state.deinit();
+            self.allocator.destroy(self);
+        }
+    }
+
+    /// Snapshot the current refcount. For tests + metrics only; do
+    /// NOT branch on this value to decide whether to release. Reads
+    /// are `.monotonic` because the only correct uses are
+    /// observational.
+    pub fn count(self: *const Self) u32 {
+        return self.refcount.load(.monotonic);
+    }
+};
+
+// =====================================================================
+// Tests
+// =====================================================================
+
+const testing = std.testing;
+
+/// Build a minimal genesis BeamState for tests. Uses the canonical
+/// `BeamState.genGenesisState` constructor with a tiny validator set
+/// so the test allocator's leak detector can verify clean teardown
+/// via `BeamState.deinit`.
+fn makeState() !types.BeamState {
+    const allocator = testing.allocator;
+    const validator_count: usize = 1;
+    const attestation_pubkeys = try allocator.alloc(types.Bytes52, validator_count);
+    defer allocator.free(attestation_pubkeys);
+    const proposal_pubkeys = try allocator.alloc(types.Bytes52, validator_count);
+    defer allocator.free(proposal_pubkeys);
+    for (attestation_pubkeys, proposal_pubkeys, 0..) |*apk, *ppk, i| {
+        @memset(apk, @intCast(i + 1));
+        @memset(ppk, @intCast(i + 1));
+    }
+    var state: types.BeamState = undefined;
+    try state.genGenesisState(allocator, .{
+        .genesis_time = 0,
+        .validator_attestation_pubkeys = attestation_pubkeys,
+        .validator_proposal_pubkeys = proposal_pubkeys,
+    });
+    return state;
+}
+
+test "RcBeamState: create + release frees the state" {
+    // Most basic test: create with refcount=1, release brings it
+    // to 0, the state's interior allocations are freed via
+    // BeamState.deinit, the wrapper is freed via allocator.destroy.
+    // Test allocator's leak detector is the implicit assertion.
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    try testing.expectEqual(@as(u32, 1), rc.count());
+    rc.release();
+}
+
+test "RcBeamState: acquire + release pair is balanced" {
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    defer rc.release(); // creator's reference
+
+    const reader = rc.acquire();
+    try testing.expectEqual(@as(u32, 2), rc.count());
+    reader.release();
+    try testing.expectEqual(@as(u32, 1), rc.count());
+}
+
+test "RcBeamState: multiple acquires and releases keep state alive until last" {
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    // creator's release happens last (at the bottom of this test)
+
+    const r1 = rc.acquire();
+    const r2 = rc.acquire();
+    const r3 = rc.acquire();
+    try testing.expectEqual(@as(u32, 4), rc.count());
+
+    r1.release();
+    try testing.expectEqual(@as(u32, 3), rc.count());
+    r2.release();
+    try testing.expectEqual(@as(u32, 2), rc.count());
+    r3.release();
+    try testing.expectEqual(@as(u32, 1), rc.count());
+
+    // Final release frees.
+    rc.release();
+}
+
+test "RcBeamState: acquire returns the same pointer (cheap to chain)" {
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    defer rc.release();
+
+    const reader = rc.acquire();
+    try testing.expect(reader == rc);
+    reader.release();
+}
+
+test "RcBeamState: concurrent acquire/release stress (40 threads × 10k iters)" {
+    // High-contention test: 40 threads each take an acquire, do a
+    // tiny no-op load, then release. The creator's refcount stays
+    // at 1 throughout (each thread's acquire/release pair is
+    // balanced). At the end, refcount must be exactly 1, then the
+    // creator's release frees.
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+
+    const NUM_THREADS: usize = 40;
+    const ITERS_PER_THREAD: usize = 10_000;
+
+    const Worker = struct {
+        fn run(target: *RcBeamState, n: usize) void {
+            var k: usize = 0;
+            while (k < n) : (k += 1) {
+                const reader = target.acquire();
+                // Touch the state to keep the compiler honest about
+                // ordering: the load must happen between acquire
+                // and release, otherwise the refcount semantics are
+                // not actually being exercised.
+                std.mem.doNotOptimizeAway(reader.state.slot);
+                reader.release();
+            }
+        }
+    };
+
+    var threads: [NUM_THREADS]std.Thread = undefined;
+    var i: usize = 0;
+    while (i < NUM_THREADS) : (i += 1) {
+        threads[i] = try std.Thread.spawn(.{}, Worker.run, .{ rc, ITERS_PER_THREAD });
+    }
+    i = 0;
+    while (i < NUM_THREADS) : (i += 1) {
+        threads[i].join();
+    }
+
+    // Every worker's acquire matched its own release; the only
+    // outstanding reference is the creator's.
+    try testing.expectEqual(@as(u32, 1), rc.count());
+
+    rc.release();
+}
+
+test "RcBeamState: release order doesn't matter (acquire-then-release vs release-then-acquire)" {
+    // T1 acquires then releases. T2 acquires then releases. Result
+    // refcount must be the creator's 1, regardless of interleaving.
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+
+    const Worker = struct {
+        fn run(target: *RcBeamState) void {
+            const reader = target.acquire();
+            std.Thread.yield() catch {};
+            reader.release();
+        }
+    };
+
+    var t1 = try std.Thread.spawn(.{}, Worker.run, .{rc});
+    var t2 = try std.Thread.spawn(.{}, Worker.run, .{rc});
+    t1.join();
+    t2.join();
+
+    try testing.expectEqual(@as(u32, 1), rc.count());
+    rc.release();
+}

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -183,6 +183,43 @@ pub const RcBeamState = struct {
     /// entry point to call (`acquireWriter` vs `acquireConst`)
     /// remains a convention enforced by code review.
     ///
+    /// ## Lifetime contract (READ THIS BEFORE c-2b)
+    ///
+    /// The `*const Self` you hold keeps the underlying `state`
+    /// alive ONLY until you call `release()` on it. The freeing
+    /// thread is whichever thread brings refcount to 0 — it could
+    /// be a *different* thread (e.g. the chain worker dropping its
+    /// last reference while you still hold yours), and that thread
+    /// will call `state.deinit()` the moment YOUR `release()`
+    /// returns if you happen to be the last reference holder.
+    ///
+    /// Implications:
+    ///
+    ///   * Drop the borrow as soon as the read is done. Acquire,
+    ///     read what you need (snapshot fields, copy slices), call
+    ///     release. Treat it like a Rust scoped borrow, not a
+    ///     cached handle.
+    ///
+    ///   * Do NOT cache the `*const Self` in a long-lived struct
+    ///     field. That is the obvious footgun; it pins the state
+    ///     across STF advances and blocks the freeing path on
+    ///     stale heads. Each consumer takes a fresh acquire per
+    ///     unit of work.
+    ///
+    ///   * Do NOT hold the borrow across an STF FFI window or any
+    ///     long-running call. The chain worker (sole writer) may
+    ///     be ready to retire that state; pinning it serialises
+    ///     the worker against the slowest reader.
+    ///
+    ///   * The borrow does NOT pin `state.<field>` against in-place
+    ///     mutation. The chain-worker's `acquireWriter` view of
+    ///     the same `RcBeamState` can mutate `state.<field>`
+    ///     concurrently. Today this is fine because the c-2b
+    ///     design promotes-then-releases (writer never mutates
+    ///     a state that has live readers), but the type system
+    ///     does NOT enforce that — see the `acquireWriter`
+    ///     docstring on the convention vs enforcement point.
+    ///
     /// Refcount semantics are identical to `acquireWriter`:
     /// matched by a `release()` call on the same pointer.
     /// `release` takes `*const Self` so the reader path doesn't
@@ -601,8 +638,19 @@ test "RcBeamState.acquireConst: returns *const Self that releases cleanly" {
     defer rc.release(); // creator's reference
 
     const reader: *const RcBeamState = rc.acquireConst();
-    // Read-only deref: this would not compile if `state` weren't
-    // const-friendly. (BeamState's read methods all take `*const`.)
+    // Read-only deref through the const view. The negative case
+    // — the line that would fail to compile if a contributor
+    // tried to mutate — is shown explicitly below as a comment
+    // (uncommenting it surfaces the type-system guarantee at
+    // build time):
+    //
+    //     reader.state.slot = 5;
+    //     // error: cannot assign to constant
+    //
+    // We don't actually compile-fail in this test (Zig has no
+    // stable in-source @compileError fixture for negative tests),
+    // but the commented line documents what the type system
+    // catches. The positive case is below: a plain read.
     std.mem.doNotOptimizeAway(reader.state.slot);
     try testing.expectEqual(@as(u32, 2), rc.count());
     reader.release();

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -77,9 +77,17 @@ const types = @import("@zeam/types");
 ///     const rc = try RcBeamState.create(allocator, state);
 ///     defer rc.release();              // initial reference
 ///
-///     // Reader path: existing rc, take a fresh acquire.
-///     const reader_rc = rc.acquire();
+///     // Cross-thread reader path (HTTP, metrics, broadcaster):
+///     // use acquireConst() so the type system enforces that
+///     // the holder cannot mutate state.<field>. release()
+///     // accepts *const Self, no cast needed at the call site.
+///     const reader_rc = rc.acquireConst();
 ///     defer reader_rc.release();       // independent of creator
+///
+///     // Chain-worker (writer) path: use acquireWriter() to get
+///     // *Self when the follow-up handler may mutate state.
+///     const writer_rc = rc.acquireWriter();
+///     defer writer_rc.release();
 ///
 /// Concurrent acquire/release is safe; the underlying refcount is an
 /// atomic and the freeing thread wins exactly one cmpxchg.
@@ -139,18 +147,24 @@ pub const RcBeamState = struct {
     /// state. Safe to call from any thread that holds a valid
     /// acquire.
     ///
-    /// Cross-thread readers (HTTP API, metrics scrape, event
-    /// broadcaster) MUST use `acquireConst()` instead so the type
-    /// system enforces the sole-writer invariant: only the chain
-    /// worker can obtain a `*Self` (mutable) pointer; everyone else
-    /// gets `*const Self`.
+    /// Convention, NOT compile-time enforcement: the type system
+    /// does not gate `acquireWriter` to a particular thread —
+    /// anyone can call it and get `*Self`. What the type system
+    /// DOES enforce is the consequence: a holder of `*const Self`
+    /// (from `acquireConst`) cannot mutate `state`. The asymmetric
+    /// names (`acquireWriter` vs `acquireConst`) make the
+    /// convention loud at every call site, and code review (not
+    /// the compiler) keeps non-worker code paths off this entry
+    /// point. If convention proves leaky in c-2b, the next step
+    /// is two distinct types (`RcBeamStateWriter` /
+    /// `RcBeamStateReader`).
     ///
     /// Memory ordering: `.monotonic` on the increment per the
     /// standard refcount pattern. The caller already holds a valid
     /// acquire so there is no race against a free; incrementing
     /// requires no fence. (Rust `Arc::clone`, C++
     /// `shared_ptr::shared_ptr(const &)` use the same ordering.)
-    pub fn acquire(self: *Self) *Self {
+    pub fn acquireWriter(self: *Self) *Self {
         const prev = self.refcount.fetchAdd(1, .monotonic);
         // Overflow check: u32 max is 4 billion; we should never get
         // anywhere near this in practice, but a wraparound would be
@@ -163,15 +177,18 @@ pub const RcBeamState = struct {
     /// call site that does NOT need to mutate the state — i.e. all
     /// cross-thread readers (HTTP API, metrics scrape, event
     /// broadcaster). The c-2b design has the chain worker as the
-    /// sole writer; readers using `acquireConst` makes that
-    /// invariant compile-checked rather than convention-only.
+    /// sole writer; what `acquireConst` actually provides is a
+    /// compile-checked guarantee that the holder cannot mutate
+    /// `state.<field>` through this reference. The choice of which
+    /// entry point to call (`acquireWriter` vs `acquireConst`)
+    /// remains a convention enforced by code review.
     ///
-    /// Refcount semantics are identical to `acquire`: matched by a
-    /// `release()` call on the same pointer (cast away the const if
-    /// needed at the release site — release is logically a
-    /// destructor and is allowed to mutate even on a `const` view).
+    /// Refcount semantics are identical to `acquireWriter`:
+    /// matched by a `release()` call on the same pointer.
+    /// `release` takes `*const Self` so the reader path doesn't
+    /// need a cast at the call site.
     pub fn acquireConst(self: *Self) *const Self {
-        return self.acquire();
+        return self.acquireWriter();
     }
 
     /// Decrement refcount. When refcount reaches 0, calls
@@ -183,7 +200,20 @@ pub const RcBeamState = struct {
     /// at the call site. The function itself uses `@constCast`
     /// internally because release IS a destructive operation —
     /// const-ness on the reader's view is about preventing
-    /// state-field mutation, not about the refcount itself.
+    /// `state.<field>` mutation, not about the refcount itself.
+    ///
+    /// MUST NOT be called on a `*const Self` derived from a true
+    /// const value (a global `const RcBeamState`, or a stack-local
+    /// declared `const`). The `@constCast` is only safe because
+    /// every `RcBeamState` is heap-allocated by `create()` — the
+    /// underlying memory is mutable, the `*const` qualifier is
+    /// purely a view restriction. Mutating through a pointer
+    /// derived from a true-const value is undefined behaviour in
+    /// optimised builds (the compiler is allowed to assume the
+    /// memory does not change). Future contributors writing test
+    /// fixtures or examples MUST go through `create()`; do not
+    /// fabricate an `RcBeamState` value as a `const` decl and
+    /// release it.
     ///
     /// Memory ordering: `.acq_rel` on the decrement. The freeing
     /// thread (`prev == 1`) needs the `.acquire` half to
@@ -271,7 +301,7 @@ test "RcBeamState: acquire + release pair is balanced" {
     const rc = try RcBeamState.create(testing.allocator, state);
     defer rc.release(); // creator's reference
 
-    const reader = rc.acquire();
+    const reader = rc.acquireWriter();
     try testing.expectEqual(@as(u32, 2), rc.count());
     reader.release();
     try testing.expectEqual(@as(u32, 1), rc.count());
@@ -282,9 +312,9 @@ test "RcBeamState: multiple acquires and releases keep state alive until last" {
     const rc = try RcBeamState.create(testing.allocator, state);
     // creator's release happens last (at the bottom of this test)
 
-    const r1 = rc.acquire();
-    const r2 = rc.acquire();
-    const r3 = rc.acquire();
+    const r1 = rc.acquireWriter();
+    const r2 = rc.acquireWriter();
+    const r3 = rc.acquireWriter();
     try testing.expectEqual(@as(u32, 4), rc.count());
 
     r1.release();
@@ -303,7 +333,7 @@ test "RcBeamState: acquire returns the same pointer (cheap to chain)" {
     const rc = try RcBeamState.create(testing.allocator, state);
     defer rc.release();
 
-    const reader = rc.acquire();
+    const reader = rc.acquireWriter();
     try testing.expect(reader == rc);
     reader.release();
 }
@@ -334,7 +364,7 @@ test "RcBeamState: acquire/release pair accounting under producer race (40 threa
         fn run(target: *RcBeamState, n: usize) void {
             var k: usize = 0;
             while (k < n) : (k += 1) {
-                const reader = target.acquire();
+                const reader = target.acquireWriter();
                 // Touch the state to keep the compiler honest about
                 // ordering: the load must happen between acquire
                 // and release, otherwise the refcount semantics are
@@ -419,7 +449,7 @@ test "RcBeamState: freeing race — last release wins under contention" {
         while (i < NUM_WORKERS) : (i += 1) {
             // Pre-bump on the spawning thread (we still hold
             // the creator's reference here, so this is safe).
-            const handed = rc.acquire();
+            const handed = rc.acquireWriter();
             threads[i] = std.Thread.spawn(
                 .{},
                 Worker.run,
@@ -465,7 +495,7 @@ test "RcBeamState: freeing race — worker takes the final release" {
     //
     // Sequence on the test thread:
     //   1. create(state)            → refcount = 1 (creator)
-    //   2. handed = rc.acquire()    → refcount = 2 (creator + handed)
+    //   2. handed = rc.acquireWriter()    → refcount = 2 (creator + handed)
     //   3. rc.release()             → refcount = 1 (handed only)
     //   4. spawn(worker, handed)
     //   5. join
@@ -479,7 +509,7 @@ test "RcBeamState: freeing race — worker takes the final release" {
         const state = try makeState();
         const rc = try RcBeamState.create(testing.allocator, state);
         // refcount = 1 (creator)
-        const handed = rc.acquire();
+        const handed = rc.acquireWriter();
         // refcount = 2 (creator + handed)
         rc.release();
         // refcount = 1 (handed only)
@@ -507,7 +537,7 @@ test "RcBeamState: release order doesn't matter (acquire-then-release vs release
 
     const Worker = struct {
         fn run(target: *RcBeamState) void {
-            const reader = target.acquire();
+            const reader = target.acquireWriter();
             std.Thread.yield() catch {};
             reader.release();
         }

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -38,8 +38,21 @@
 //! `init` returns a refcount of 1 (the creator's reference). Every
 //! `acquire` bumps; every `release` decrements. The thread that brings
 //! refcount to 0 frees the state and the wrapper. Acquire/release are
-//! `acq_rel`-ordered atomic ops so the freeing thread observes all
-//! prior writes to the state.
+//! Memory ordering follows the standard refcount pattern (Rust
+//! `Arc`, C++ `shared_ptr`):
+//!
+//!   * `acquire`: `.monotonic` fetchAdd. The caller already holds
+//!     a valid acquire (that's the contract); incrementing the
+//!     count cannot race with a free because no thread can free
+//!     until refcount reaches 0, which can't happen while we hold
+//!     a reference. No fence needed on this side.
+//!   * `release`: `.acq_rel` fetchSub. The freeing thread (the one
+//!     that observes `prev == 1`) needs `.acquire` to synchronise
+//!     with all prior `.release` decrements from other threads, so
+//!     it observes every prior write to the state before calling
+//!     `state.deinit()`. The `.release` half ensures non-freeing
+//!     decrements publish their writes before the count drop is
+//!     visible. `.acq_rel` is the union.
 //!
 //! Double-release is a debug-build panic (the refcount underflows).
 //! Release after a refcount has already been freed is undefined; the
@@ -73,10 +86,11 @@ const types = @import("@zeam/types");
 pub const RcBeamState = struct {
     /// Owning allocator. Final release frees `self` via this allocator.
     allocator: Allocator,
-    /// Refcount. `acq_rel` orderings on bumps and decrements ensure the
-    /// thread that observes 0 also observes all prior writes to `state`
-    /// (and that the freeing thread's writes are not reordered before
-    /// the decrement).
+    /// Refcount. See the file header for the memory-ordering rules:
+    /// `.monotonic` on bump (caller holds a valid acquire so there
+    /// is nothing to synchronise against), `.acq_rel` on decrement
+    /// (the freeing thread synchronises with every prior
+    /// non-freeing decrement via the `.acquire` half).
     refcount: std.atomic.Value(u32),
     /// The wrapped state. Heap-owned; `release` calls `state.deinit()`
     /// when refcount hits 0.
@@ -119,31 +133,86 @@ pub const RcBeamState = struct {
         return self;
     }
 
-    /// Bump refcount. Returns the same pointer for chained call sites
-    /// (e.g. `const reader = rc.acquire();`). Safe to call from any
-    /// thread that holds a valid acquire.
+    /// Bump refcount, returning a mutable pointer. Used by the
+    /// chain worker (the sole writer under c-2b) when handing a
+    /// reference to a follow-up handler that may itself mutate the
+    /// state. Safe to call from any thread that holds a valid
+    /// acquire.
+    ///
+    /// Cross-thread readers (HTTP API, metrics scrape, event
+    /// broadcaster) MUST use `acquireConst()` instead so the type
+    /// system enforces the sole-writer invariant: only the chain
+    /// worker can obtain a `*Self` (mutable) pointer; everyone else
+    /// gets `*const Self`.
+    ///
+    /// Memory ordering: `.monotonic` on the increment per the
+    /// standard refcount pattern. The caller already holds a valid
+    /// acquire so there is no race against a free; incrementing
+    /// requires no fence. (Rust `Arc::clone`, C++
+    /// `shared_ptr::shared_ptr(const &)` use the same ordering.)
     pub fn acquire(self: *Self) *Self {
-        const prev = self.refcount.fetchAdd(1, .acq_rel);
+        const prev = self.refcount.fetchAdd(1, .monotonic);
         // Overflow check: u32 max is 4 billion; we should never get
-        // anywhere near this in practice, but a wraparound would be a
-        // silent UAF. Debug-build assert.
+        // anywhere near this in practice, but a wraparound would be
+        // a silent UAF. Debug-build assert.
         std.debug.assert(prev < std.math.maxInt(u32));
         return self;
     }
 
+    /// Bump refcount, returning a const pointer. Use this for every
+    /// call site that does NOT need to mutate the state — i.e. all
+    /// cross-thread readers (HTTP API, metrics scrape, event
+    /// broadcaster). The c-2b design has the chain worker as the
+    /// sole writer; readers using `acquireConst` makes that
+    /// invariant compile-checked rather than convention-only.
+    ///
+    /// Refcount semantics are identical to `acquire`: matched by a
+    /// `release()` call on the same pointer (cast away the const if
+    /// needed at the release site — release is logically a
+    /// destructor and is allowed to mutate even on a `const` view).
+    pub fn acquireConst(self: *Self) *const Self {
+        return self.acquire();
+    }
+
     /// Decrement refcount. When refcount reaches 0, calls
-    /// `state.deinit()` and frees `self`. After `release`, the caller
-    /// MUST NOT use `self` again.
+    /// `state.deinit()` and frees `self`. After `release`, the
+    /// caller MUST NOT use `self` again.
+    ///
+    /// Takes `*const Self` so a reader that holds a `*const Self`
+    /// (from `acquireConst`) can release directly without casting
+    /// at the call site. The function itself uses `@constCast`
+    /// internally because release IS a destructive operation —
+    /// const-ness on the reader's view is about preventing
+    /// state-field mutation, not about the refcount itself.
+    ///
+    /// Memory ordering: `.acq_rel` on the decrement. The freeing
+    /// thread (`prev == 1`) needs the `.acquire` half to
+    /// synchronise with every prior non-freeing decrement so it
+    /// observes all prior writes to the state before calling
+    /// `state.deinit()`. The `.release` half ensures non-freeing
+    /// decrements publish their writes before the count drop is
+    /// visible. (Cf. Rust `Arc::drop`, C++ `~shared_ptr`.)
     ///
     /// Underflow (double-release without a matching acquire) is a
-    /// debug-build panic; release-build behaviour is silent UB.
-    pub fn release(self: *Self) void {
-        const prev = self.refcount.fetchSub(1, .acq_rel);
+    /// debug-build panic when caught — but only when the freed
+    /// memory's first 4 bytes happen to read 0 by the time the
+    /// stale release runs. The assert is best-effort, NOT a
+    /// guaranteed safety net; it catches some double-releases but
+    /// release-build / racy-stale-pointer behaviour is silent UB.
+    /// Slice c-2b will need the `tryAcquire` upgrade-from-weak
+    /// pattern to make stale-pointer acquires safe; see the
+    /// follow-up note in #803.
+    pub fn release(self: *const Self) void {
+        // Cast: refcount is logically internal mutable state even
+        // on a const view, and the freeing branch needs to call
+        // mutating methods (state.deinit, allocator.destroy).
+        const mut = @constCast(self);
+        const prev = mut.refcount.fetchSub(1, .acq_rel);
         std.debug.assert(prev > 0); // catch double-release
         if (prev == 1) {
             // Last reference — we own the free.
-            self.state.deinit();
-            self.allocator.destroy(self);
+            mut.state.deinit();
+            mut.allocator.destroy(mut);
         }
     }
 
@@ -483,4 +552,76 @@ test "RcBeamState.create: OOM path consumes state (no leak under FailingAllocato
     // The caller does NOT call state.deinit() here. If create()
     // failed to consume, testing.allocator's leak detector trips
     // when this test scope exits.
+}
+
+test "RcBeamState.acquireConst: returns *const Self that releases cleanly" {
+    // Locks the c-2b sole-writer invariant in the type system: the
+    // chain worker uses `acquire()` to get `*Self` (mutable);
+    // every cross-thread reader uses `acquireConst()` to get
+    // `*const Self`. Both are released via the same `release()`
+    // entry point, which takes `*const Self` so the reader path
+    // doesn't need a cast at the call site.
+    //
+    // This test exercises the reader path end-to-end: take a
+    // const reference, dereference state.slot through the const
+    // pointer, release. testing.allocator's leak detector verifies
+    // clean teardown.
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    defer rc.release(); // creator's reference
+
+    const reader: *const RcBeamState = rc.acquireConst();
+    // Read-only deref: this would not compile if `state` weren't
+    // const-friendly. (BeamState's read methods all take `*const`.)
+    std.mem.doNotOptimizeAway(reader.state.slot);
+    try testing.expectEqual(@as(u32, 2), rc.count());
+    reader.release();
+    try testing.expectEqual(@as(u32, 1), rc.count());
+}
+
+test "RcBeamState.acquireConst: concurrent readers free cleanly when creator drops" {
+    // Same shape as the freeing-race test, but every reader uses
+    // acquireConst() — the c-2b cross-thread reader pattern. The
+    // freeing path is identical; this test exists to confirm the
+    // const-pointer + release(*const Self) path is exercised at
+    // least once under contention.
+    const NUM_READERS: usize = 8;
+    const ITERS_PER_READER: usize = 100;
+
+    const Reader = struct {
+        fn run(reader: *const RcBeamState, iters: usize) void {
+            defer reader.release();
+            var k: usize = 0;
+            while (k < iters) : (k += 1) {
+                std.mem.doNotOptimizeAway(reader.state.slot);
+                std.Thread.yield() catch {};
+            }
+        }
+    };
+
+    var outer: usize = 0;
+    while (outer < 25) : (outer += 1) {
+        const state = try makeState();
+        const rc = try RcBeamState.create(testing.allocator, state);
+
+        var threads: [NUM_READERS]std.Thread = undefined;
+        var i: usize = 0;
+        while (i < NUM_READERS) : (i += 1) {
+            const handed = rc.acquireConst();
+            threads[i] = std.Thread.spawn(
+                .{},
+                Reader.run,
+                .{ handed, ITERS_PER_READER },
+            ) catch |err| {
+                handed.release();
+                return err;
+            };
+        }
+        rc.release(); // creator drops; some reader will be the freer
+
+        i = 0;
+        while (i < NUM_READERS) : (i += 1) {
+            threads[i].join();
+        }
+    }
 }


### PR DESCRIPTION
## Slice (c-2a) — RcBeamState refcounted state pointer

Implements item 3 of `docs/threading_refactor_slice_a.md` §"Slice (c) scope (revised)" — refcounted state pointers so cross-thread readers don't block worker mutations. Per the c-2 plan posted at https://github.com/blockblaz/zeam/issues/803#issuecomment-4381027301, c-2 is split into three reviewable chunks:

- **c-2a (this PR)** — `RcBeamState` type + tests.
- **c-2a follow-up** — migrate `BeamChain.states` map storage to `*RcBeamState` (no behaviour change, all current synchronous semantics preserved).
- **c-2b** — wire `chain_worker` field, per-handler migration, drop write locks.
- **c-2c** — queue-depth saturation stress + devnet4 burn-in.

This first PR is pure-additive: it lands the type and its tests in isolation. No existing code is modified except `pkgs/node/src/lib.zig` to expose the new module. The follow-up PR will land the chain.zig migration on top.

### Why split this from the chain.zig migration?

`BeamChain.states` is touched at ~9 production callsites + ~30 test callsites (per the slice-(a-2) inventory). Bundling the type introduction with the storage migration would obscure the refcount semantics review — reviewers would have to track the type's correctness AND the migration safety in one diff. After the c-1 parallel-agent collisions, smaller per-PR diffs are clearly worth it.

### What's in this PR

New file `pkgs/node/src/rc_beam_state.zig` (291 LOC including tests):

```zig
pub const RcBeamState = struct {
    allocator: Allocator,
    refcount: std.atomic.Value(u32),
    state: types.BeamState,

    pub fn create(allocator: Allocator, state: types.BeamState) !*Self { ... }
    pub fn acquire(self: *Self) *Self { ... }    // refcount.fetchAdd(1, .acq_rel)
    pub fn release(self: *Self) void { ... }     // refcount.fetchSub(1, .acq_rel); free at 0
    pub fn count(self: *const Self) u32 { ... }  // .monotonic; observational only
};
```

### Design choices (per the c-2 plan)

1. **Storage layout (a)** — single allocation with `BeamState` embedded inline alongside the refcount. Pros: one allocation per state, one `release` frees the whole header + state, no double-pointer chase on the read path. Cons: cannot share a refcount across multiple distinct `BeamState` pointers (e.g. shadowing). No caller currently needs this; option (b) split layout can be added later if a use case appears.

2. **Atomic refcount with `.acq_rel` ordering** on bumps and decrements so the freeing thread observes all prior writes to the wrapped state. The `.monotonic` load in `count()` is observational-only (tests + metrics).

3. **Ownership transfer at `create()`** — takes a freshly-allocated `BeamState` by value, transfers it into the heap allocation. Initial refcount = 1 (the creator's reference). Returns `error.OutOfMemory` on allocation failure with the input state NOT consumed.

4. **Double-release is a debug-build assert** (refcount underflow). Release-build behaviour is silent UB — the map's invariant must guarantee callers hold a valid acquire before calling release. Slice (a-2)'s `BorrowedState` already enforces this for the lock path; under c-2b it will enforce it for the refcount path too.

### Tests (6 new, all pass)

- `create + release frees the state` — most basic round-trip; `testing.allocator`'s leak detector verifies clean teardown.
- `acquire + release pair is balanced` — count goes 1 → 2 → 1.
- `multiple acquires and releases keep state alive until last` — 4 references; release in arbitrary order.
- `acquire() returns the same pointer` — chained call sites.
- `concurrent acquire/release stress (40 threads × 10k iters)` — high-contention test; each thread takes acquire, touches `state.slot` via `doNotOptimizeAway`, releases. Final refcount must be exactly 1 (creator's reference) — proves no acquire/release pair lost an increment.
- `release order doesn't matter` — two threads each acquire+release independently, final refcount = 1 regardless of interleaving.

### Verification

```
$ zig build test -Dprover=dummy
...
83/114 rc_beam_state.test.RcBeamState: create + release frees the state...OK
84/114 rc_beam_state.test.RcBeamState: acquire + release pair is balanced...OK
85/114 rc_beam_state.test.RcBeamState: multiple acquires and releases keep state alive until last...OK
86/114 rc_beam_state.test.RcBeamState: acquire returns the same pointer (cheap to chain)...OK
87/114 rc_beam_state.test.RcBeamState: concurrent acquire/release stress (40 threads × 10k iters)...OK
88/114 rc_beam_state.test.RcBeamState: release order doesn't matter (acquire-then-release vs release-then-acquire)...OK
...
All 114 tests passed.
EXIT:0
```

All 6 new tests pass, all 108 prior tests pass (was 108 with c-1's chain_worker; now 114 with the 6 RcBeamState tests), EXIT:0.

### Branch lineage

- Off `main` post-#826 merge (`f2b8735`).
- Tip: `509df11`.
- c-2a follow-up + c-2b will branch from this once it merges.

cc @ch4r10t33r @GrapeBaBa — design questions on the c-2 plan posted at https://github.com/blockblaz/zeam/issues/803#issuecomment-4381027301. Default proposals are reflected in this PR; happy to revisit (a)-vs-(b) layout if there's a future-state shadowing case I missed.