### PR TITLE
node: chain-worker routing + state-rwlock drop + queue-saturation stress (slice c-2b + c-2c of #803)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -509,6 +509,45 @@ pub fn build(b: *Builder) !void {
     stress_quick_step.dependOn(&run_stress_quick.step);
     test_step.dependOn(&run_stress_quick.step);
 
+    // -----------------------------------------------------------------
+    // `stress-saturation` and `stress-quick-saturation`: chain-worker
+    // queue saturation harness (slice c-2c commit 6 of #803).
+    //
+    // The full `stress-saturation` step is operator-driven (~30s
+    // default). The quick variant is wired into `zig build test` so
+    // CI catches:
+    //   * Producer-side accounting drift (attempts != ok+qfull+err).
+    //   * Backpressure regression (queue never fills — either the
+    //     producers are too slow or the queue capacity got bumped
+    //     without a corresponding bump to producer count).
+    //   * Worker-drain regression (queue fills but never drains —
+    //     classic worker-thread deadlock).
+    //   * Any unexpected `submitBlock` / `submitGossipAttestation`
+    //     error tag (today only `QueueClosed` and
+    //     `ChainWorkerDisabled` are non-`QueueFull`).
+    //
+    // Both steps reuse the same `stress_exe` artifact — the harness
+    // dispatches on `ZEAM_STRESS_MODE=saturation` set here.
+    const run_stress_saturation = b.addRunArtifact(stress_exe);
+    run_stress_saturation.setEnvironmentVariable("ZEAM_STRESS_MODE", "saturation");
+    if (b.args) |args| run_stress_saturation.addArgs(args);
+    const stress_saturation_step = b.step(
+        "stress-saturation",
+        "Run the chain-worker queue saturation harness (issue #803 slice c-2c)",
+    );
+    stress_saturation_step.dependOn(&run_stress_saturation.step);
+
+    const run_stress_quick_saturation = b.addRunArtifact(stress_exe);
+    run_stress_quick_saturation.setEnvironmentVariable("ZEAM_STRESS_MODE", "saturation");
+    run_stress_quick_saturation.setEnvironmentVariable("ZEAM_STRESS_DURATION_SECS", "10");
+    run_stress_quick_saturation.setEnvironmentVariable("ZEAM_STRESS_WATCHDOG_SECS", "15");
+    const stress_quick_saturation_step = b.step(
+        "stress-quick-saturation",
+        "Run a 10s chain-worker queue saturation harness (CI gate, slice c-2c)",
+    );
+    stress_quick_saturation_step.dependOn(&run_stress_quick_saturation.step);
+    test_step.dependOn(&run_stress_quick_saturation.step);
+
     // CLI integration tests (separate target) - always create this test target
     const cli_integration_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -75,6 +75,10 @@ pub const NodeCommand = struct {
     @"attestation-committee-count": ?u64 = null,
     @"aggregate-subnet-ids": ?[]const u8 = null,
     @"db-backend": database.Backend = .rocksdb,
+    /// Slice c-2b commit 3 of #803: route producer-side gossip
+    /// handlers through the chain-worker queue. Default `false`
+    /// preserves slice-(b) synchronous behavior.
+    @"chain-worker": bool = false,
 
     pub const __shorts__ = .{
         .help = .h,
@@ -98,6 +102,7 @@ pub const NodeCommand = struct {
         .@"attestation-committee-count" = "Number of attestation committees (subnets); overrides config.yaml ATTESTATION_COMMITTEE_COUNT",
         .@"aggregate-subnet-ids" = "Comma-separated list of subnet ids to additionally subscribe and aggregate gossip attestations (e.g. '0,1,2'); adds to automatic computation from validator ids",
         .@"db-backend" = "Database backend to use for on-disk state: 'rocksdb' (default) or 'lmdb'",
+        .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread. Off by default; the synchronous path stays in place when disabled.",
         .help = "Show help information for the node command",
     };
 };

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -94,6 +94,11 @@ pub const NodeOptions = struct {
     attestation_committee_count: ?u64 = null,
     max_attestations_data: ?u8 = null,
     db_backend: database.Backend = .rocksdb,
+    /// Slice c-2b commit 3 of #803: route producer-side gossip
+    /// handlers through the chain-worker queue. Default `false`
+    /// preserves slice-(b) synchronous behavior. Surfaced as
+    /// `--chain-worker` on the `zeam node` CLI.
+    chain_worker_enabled: bool = false,
 
     pub fn deinit(self: *NodeOptions, allocator: std.mem.Allocator) void {
         for (self.bootnodes) |b| allocator.free(b);
@@ -360,6 +365,7 @@ pub const Node = struct {
             .is_aggregator = options.is_aggregator,
             .aggregation_subnet_ids = options.aggregation_subnet_ids,
             .thread_pool = self.thread_pool,
+            .chain_worker_enabled = options.chain_worker_enabled,
         });
         errdefer self.beam_node.deinit();
 
@@ -755,6 +761,7 @@ pub fn buildStartOptions(
     opts.hash_sig_key_dir = hash_sig_key_dir;
     opts.checkpoint_sync_url = node_cmd.@"checkpoint-sync-url";
     opts.is_aggregator = node_cmd.@"is-aggregator";
+    opts.chain_worker_enabled = node_cmd.@"chain-worker";
 
     // Parse --aggregate-subnet-ids (comma-separated list of subnet ids, e.g. "0,1,2")
     // Require --is-aggregator to be set when --aggregate-subnet-ids is provided.

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -145,6 +145,11 @@ const Metrics = struct {
     lean_chain_queue_dropped_total: LeanChainQueueDroppedCounter,
     lean_chain_queue_depth: LeanChainQueueDepthGauge,
     lean_chain_worker_loop_iters_total: LeanChainWorkerLoopItersCounter,
+    // Slice c-2b commit 5 of #803: distribution of refcount values across
+    // map-resident BeamState entries at scrape time. Sampled by the chain
+    // via `recordChainStateRefcountDistribution` registered as a
+    // context-bearing scrape refresher (see `registerScrapeRefresherCtx`).
+    lean_chain_state_refcount_distribution: LeanChainStateRefcountDistributionHistogram,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
@@ -193,6 +198,14 @@ const Metrics = struct {
     const LeanChainQueueDroppedCounter = metrics_lib.CounterVec(u64, struct { queue: []const u8 });
     const LeanChainQueueDepthGauge = metrics_lib.GaugeVec(u64, struct { queue: []const u8 });
     const LeanChainWorkerLoopItersCounter = metrics_lib.Counter(u64);
+    // Refcount-distribution buckets [1, 2, 4, 8, 16, 32, +Inf]. Typical
+    // value is 1 (writer-only); transient 2-4 under reader concurrency;
+    // values >16 indicate leaked acquires (a reader forgot to release
+    // its borrow). The +Inf bucket is implicit in the Histogram's tail.
+    const LeanChainStateRefcountDistributionHistogram = metrics_lib.Histogram(
+        f32,
+        &[_]f32{ 1, 2, 4, 8, 16, 32 },
+    );
     // Fork-choice store gauge types
     const LeanGossipSignaturesGauge = metrics_lib.Gauge(u64);
     const LeanLatestNewAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
@@ -609,6 +622,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Instantaneous depth of the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
+        .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -669,6 +683,29 @@ pub fn registerScrapeRefresher(refresher: ?*const fn () void) void {
     g_scrape_refresher = refresher;
 }
 
+/// Optional context-bearing pre-scrape refresher. Slice c-2b commit 5 of
+/// #803 (lean_chain_state_refcount_distribution) needed a callback that
+/// receives a `*BeamChain` so the observer could iterate the chain's
+/// in-memory states map under its shared lock and sample each rc's
+/// refcount. The first-form `g_scrape_refresher` slot above is
+/// `void → void` (used for FFI-backed atomic counters that need no
+/// context); rather than coerce the chain into a global, we expose a
+/// parallel slot that takes an opaque pointer back to the caller. The
+/// two slots are independent and both run on every scrape (the FFI
+/// refresher first, then the context-bearing one).
+var g_scrape_refresher_ctx: ?*const fn (?*anyopaque) void = null;
+var g_scrape_refresher_ctx_ptr: ?*anyopaque = null;
+
+/// Register (or replace) a context-bearing scrape refresher. Pass `null`
+/// for `refresher` to clear (the ctx pointer is also cleared).
+pub fn registerScrapeRefresherCtx(
+    ctx: ?*anyopaque,
+    refresher: ?*const fn (?*anyopaque) void,
+) void {
+    g_scrape_refresher_ctx = refresher;
+    g_scrape_refresher_ctx_ptr = if (refresher == null) null else ctx;
+}
+
 /// Writes metrics to a writer (for Prometheus endpoint).
 pub fn writeMetrics(writer: *std.Io.Writer) !void {
     if (!g_initialized) return error.NotInitialized;
@@ -682,6 +719,10 @@ pub fn writeMetrics(writer: *std.Io.Writer) !void {
     // Pull in any externally-owned counters (e.g. Rust-side libp2p drops)
     // before serializing so each scrape returns up-to-date values.
     if (g_scrape_refresher) |refresher| refresher();
+    // Context-bearing refresher (slice c-2b commit 5 of #803): runs
+    // after the void-refresher so a future contributor can rely on
+    // ordering when the two refreshers' outputs share buckets/labels.
+    if (g_scrape_refresher_ctx) |refresher| refresher(g_scrape_refresher_ctx_ptr);
 
     try metrics_lib.write(&metrics, writer);
 }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -152,8 +152,15 @@ pub const BeamChain = struct {
     ///
     /// Lock-free monotonic counter; safe to read from any thread.
     states_kept_existing_count: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-    // Cached finalized state loaded from database (separate from states map to avoid affecting pruning)
-    cached_finalized_state: ?*types.BeamState = null,
+    // Cached finalized state loaded from database (separate from states
+    // map to avoid affecting pruning).
+    //
+    // Slice c-2b commit 4 of #803: migrated from raw `*types.BeamState`
+    // to `*RcBeamState` (Option B from the PR #828 review thread) so the
+    // cache-hit path in `getFinalizedState` can use the same
+    // tryAcquire-then-drop-lock dance as `statesGet` when chain-worker
+    // is enabled. Mutation is still gated by `events_lock`.
+    cached_finalized_state: ?*RcBeamState = null,
     // Cache for validator public keys to avoid repeated SSZ deserialization during signature verification.
     // Significantly reduces CPU overhead when processing blocks with many attestations.
     public_key_cache: xmss.PublicKeyCache,
@@ -569,10 +576,16 @@ pub const BeamChain = struct {
         }
         self.states.deinit();
 
-        // Clean up cached finalized state if present
-        if (self.cached_finalized_state) |cached_state| {
-            cached_state.deinit();
-            self.allocator.destroy(cached_state);
+        // Clean up cached finalized state if present.
+        // Slice c-2b commit 4: cached_finalized_state is an
+        // RcBeamState now — release drives state.deinit + destroy when
+        // refcount reaches 0. Under chain_worker_enabled the cache may
+        // have outstanding reader acquires; the rc keeps the underlying
+        // allocation alive until the last reader releases. (At deinit
+        // time we are single-threaded by contract, so refcount=1 in
+        // practice.)
+        if (self.cached_finalized_state) |cached_rc| {
+            cached_rc.release();
         }
 
         // Clean up public key cache
@@ -623,24 +636,65 @@ pub const BeamChain = struct {
     // release.
     // ------------------------------------------------------------------
 
-    /// Acquire the shared (read) side of `states_lock` and return a
-    /// `BorrowedState` for the requested root, or null if the state is not
-    /// in the in-memory map. Caller MUST call either `borrow.deinit()` or
-    /// `borrow.cloneAndRelease(allocator)` exactly once before the borrow
-    /// goes out of scope. Debug builds enforce one-release via
-    /// `BorrowedState.released`.
+    /// Return a `BorrowedState` for the requested root, or null if the
+    /// state is not in the in-memory map. Caller MUST call either
+    /// `borrow.deinit()` or `borrow.cloneAndRelease(allocator)` exactly
+    /// once before the borrow goes out of scope. Debug builds enforce
+    /// one-release via `BorrowedState.released`.
+    ///
+    /// Two paths, gated by chain-worker mode (slice c-2b commit 4 of #803):
+    ///
+    ///   * `chain_worker != null` (chain-worker is the sole writer to
+    ///     `BeamChain.states`): take the shared lock for the lookup,
+    ///     `tryAcquire` the rc, drop the lock, and return a
+    ///     `Backing.none` borrow whose lifetime is gated by the rc
+    ///     refcount. Cross-thread readers (HTTP API, metrics scrape,
+    ///     event broadcaster) NO LONGER hold `states_lock.shared` for
+    ///     the borrow lifetime, so a long-lived read does not block the
+    ///     chain worker's next exclusive-side mutation. This is the
+    ///     entire point of the c-2b migration.
+    ///
+    ///   * `chain_worker == null` (kill-switch / backward-compat under
+    ///     `--chain-worker=off`): keep the legacy lock-based borrow.
+    ///     The shared lock is held for the borrow lifetime; map mutation
+    ///     by the gossip/req-resp paths is gated by the exclusive side
+    ///     as before. Slice (b) semantics are preserved exactly.
     pub fn statesGet(self: *Self, root: types.Root) ?BorrowedState {
         var t = LockTimer.start("states", "statesGet");
         self.states_lock.lockShared();
         t.acquired();
         if (self.states.get(root)) |rc| {
-            // Hand the lock off to the borrow. Under c-2b commit 2
-            // the rwlock still gates lifetime: the rc lives as long
-            // as the entry is in the map AND the lock is held, so
-            // it's safe to expose `&rc.state` directly without
-            // taking an acquire. Commit 4 of this PR will drop the
-            // rwlock entirely and switch this path to
-            // `acquireConst()` + `tryAcquire()`.
+            if (self.chain_worker != null) {
+                // Lock-free read path: tryAcquire under the shared
+                // lock to defeat any concurrent free race, then drop
+                // the lock so the borrow lifetime no longer pins
+                // `states_lock`. The LockTimer ends HERE because the
+                // hold span is over; we do not hand it off to the
+                // borrow.
+                const acq = rc.tryAcquire();
+                self.states_lock.unlockShared();
+                t.released();
+                if (acq) |acquired_rc| {
+                    return BorrowedState{
+                        .state = &acquired_rc.state,
+                        .backing = .none,
+                        .acquired_rc = acquired_rc,
+                    };
+                }
+                // tryAcquire returned null: rc is in the freeing
+                // process (refcount→0 elsewhere). Today this should
+                // never happen because the only acquires today come
+                // from the worker thread itself, but the safe-by-
+                // default behavior is to report the entry as missing
+                // rather than dereference a dying allocation. The
+                // c-2b removal protocol ("remove-from-map then
+                // release") is what makes this branch theoretically
+                // reachable in the future without a UAF.
+                return null;
+            }
+            // Legacy lock-based path: hand the shared lock off to the
+            // borrow.  Backward-compat with --chain-worker=off; PR
+            // #820 / #803 kill-switch.
             return BorrowedState{
                 .state = &rc.state,
                 .backing = .{ .states_shared_rwlock = &self.states_lock },
@@ -782,6 +836,23 @@ pub const BeamChain = struct {
         root: types.Root,
         rc: *RcBeamState,
     ) !struct { borrow: BorrowedState, kept_existing: bool } {
+        // INTENTIONAL: this helper holds the EXCLUSIVE side of
+        // `states_lock` across the returned borrow even when chain-
+        // worker mode is enabled. Slice c-2b commit 4 of #803 dropped
+        // the rwlock for `statesGet` / `getFinalizedState` cache-hit
+        // borrows, but the cross-call write barrier rationale from
+        // PR #820 / #803 still applies here: the borrow lifetime
+        // spans (DB write → forkChoice.confirmBlock); both must
+        // observe the in-map pointer atomically, so unlock/reacquire
+        // is exactly the UAF race we are closing. The chain-worker
+        // is the only writer to `states` under c-2b, but that does
+        // NOT make the cross-call barrier redundant — the worker
+        // executes its own helpers serially, and the barrier is
+        // about ordering against `pruneStates` (also exclusive),
+        // which can run from the same worker between this helper's
+        // borrow handoff and the caller's last deref. Switching to
+        // a Backing.none / tryAcquire shape here would re-open
+        // exactly the issue PR #820 fixed.
         var t = LockTimer.start("states", site);
         self.states_lock.lock();
         t.acquired();
@@ -2712,12 +2783,18 @@ pub const BeamChain = struct {
     /// borrowed from the in-memory map under `BeamNode.mutex`. After (a-2)
     /// it returns a `BorrowedState` whose backing lock depends on which
     /// path produced the result:
-    ///   * In-memory map hit  → backed by `states_lock` (shared).
-    ///   * Cache hit / DB load → backed by `events_lock` (mutex), since
-    ///     `cached_finalized_state` is mutated under `events_lock` (the
-    ///     DB-load path also writes the cache field, and that write is
-    ///     guarded by the mutex). Callers MUST release the borrow exactly
-    ///     once via `deinit()` or `cloneAndRelease(allocator)`.
+    ///   * In-memory map hit  → backed by `states_lock` (shared) when
+    ///     `--chain-worker=off`; `Backing.none` (rc-only lifetime)
+    ///     when `--chain-worker=on` (slice c-2b commit 4 of #803).
+    ///   * Cache hit / DB load → backed by `events_lock` (mutex) when
+    ///     `--chain-worker=off`, since `cached_finalized_state` is
+    ///     mutated under `events_lock` (the DB-load path also writes
+    ///     the cache field, and that write is guarded by the mutex).
+    ///     When `--chain-worker=on`, the cache hit path tryAcquires the
+    ///     RcBeamState refcount and drops `events_lock` before
+    ///     returning, mirroring the lock-free path in `statesGet`.
+    /// Callers MUST release the borrow exactly once via `deinit()` or
+    /// `cloneAndRelease(allocator)`.
     ///
     /// PR description (a-2) enumerates every caller migrated under this
     /// API change — grepping `states.get` will not find them.
@@ -2760,14 +2837,42 @@ pub const BeamChain = struct {
         // the current finalized checkpoint (can happen if the cache was
         // seeded from the DB at startup before any in-memory finalization
         // happened).
-        if (self.cached_finalized_state) |cached_state| {
-            if (std.mem.eql(u8, &cached_state.latest_finalized.root, &finalized_checkpoint.root)) {
+        if (self.cached_finalized_state) |cached_rc| {
+            if (std.mem.eql(u8, &cached_rc.state.latest_finalized.root, &finalized_checkpoint.root)) {
+                if (self.chain_worker != null) {
+                    // Lock-free read path: tryAcquire under the events
+                    // lock to defeat any concurrent free race, then drop
+                    // the lock so the borrow lifetime no longer pins
+                    // `events_lock`. Tier-5 depth must be decremented
+                    // BEFORE we return because we are NOT handing off
+                    // the lock to the borrow; the next tier-5 acquire
+                    // on this thread should see depth=0.
+                    const acq = cached_rc.tryAcquire();
+                    self.events_lock.unlock();
+                    locking.leaveTier5();
+                    t_ev.released();
+                    lock_held = false;
+                    if (acq) |acquired_rc| {
+                        return BorrowedState{
+                            .state = &acquired_rc.state,
+                            .backing = .none,
+                            .acquired_rc = acquired_rc,
+                        };
+                    }
+                    // tryAcquire returned null — freeing thread won.
+                    // Today this should never happen (refcount stays
+                    // at 1 in production), but the safe-by-default
+                    // behavior is to report no entry.
+                    return null;
+                }
+                // Legacy lock-based path: hand the events_lock off to
+                // the borrow.  Backward-compat with --chain-worker=off.
                 lock_held = false; // ownership of the lock moves into the borrow
                 // tier-5 depth and LockTimer are HANDED OFF to the borrow:
                 // BorrowedState.deinit calls leaveTier5() and t.released()
                 // after unlocking. Do NOT close them here.
                 return BorrowedState{
-                    .state = cached_state,
+                    .state = &cached_rc.state,
                     .backing = .{ .events_mutex = &self.events_lock },
                     .tier5_held = true,
                     .timer = t_ev,
@@ -2776,37 +2881,61 @@ pub const BeamChain = struct {
             // Stale — fall through to DB load below.
         }
 
-        // Fallback: try to load from database. Allocate the cache slot, load,
-        // store in `cached_finalized_state`, return a borrow over it.
-        const state_ptr = self.allocator.create(types.BeamState) catch |err| {
-            self.logger.warn("failed to allocate memory for finalized state: {any}", .{err});
-            return null;
-        };
-
-        self.db.loadLatestFinalizedState(state_ptr) catch |err| {
-            self.allocator.destroy(state_ptr);
+        // Fallback: try to load from database. Allocate a BeamState
+        // value on the stack (well — a local), load into it, then
+        // hand it to RcBeamState.create which embeds it into the heap
+        // allocation (always-consume contract per c-2a).
+        var loaded_state: types.BeamState = undefined;
+        self.db.loadLatestFinalizedState(&loaded_state) catch |err| {
             self.logger.warn("finalized state not available in database: {any}", .{err});
             return null;
         };
+        // Past this line `loaded_state` owns interior allocations.
+        // RcBeamState.create takes ownership; on OOM it deinits the
+        // interior for us.
+        const new_rc = RcBeamState.create(self.allocator, loaded_state) catch |err| {
+            self.logger.warn("failed to allocate RcBeamState for finalized state: {any}", .{err});
+            return null;
+        };
 
-        // If a previous cached state is being replaced, free it now (we
-        // hold events_lock so no concurrent borrow of the old pointer can
-        // exist past this critical section).
-        if (self.cached_finalized_state) |old_cached| {
-            old_cached.deinit();
-            self.allocator.destroy(old_cached);
+        // If a previous cached state is being replaced, release the old
+        // rc now (we hold events_lock so any concurrent reader either
+        // tryAcquired before this critical section — in which case its
+        // acquire keeps the underlying allocation alive past our release
+        // — or will look it up after our store below and observe the
+        // new rc).
+        if (self.cached_finalized_state) |old_cached_rc| {
+            old_cached_rc.release();
         }
 
         // Cache in separate field (not in states map to avoid affecting pruning)
-        self.cached_finalized_state = state_ptr;
+        self.cached_finalized_state = new_rc;
 
-        self.logger.info("loaded finalized state from database at slot {d}", .{state_ptr.slot});
+        self.logger.info("loaded finalized state from database at slot {d}", .{new_rc.state.slot});
 
+        if (self.chain_worker != null) {
+            // Lock-free read path: bump the refcount we just stored and
+            // drop the lock so the borrow lifetime is gated by the
+            // refcount alone. The cache field holds one reference, the
+            // borrow holds another. tryAcquire is guaranteed to succeed
+            // here — we own the only reference and we hold events_lock.
+            const acq = new_rc.tryAcquire() orelse unreachable;
+            self.events_lock.unlock();
+            locking.leaveTier5();
+            t_ev.released();
+            lock_held = false;
+            return BorrowedState{
+                .state = &acq.state,
+                .backing = .none,
+                .acquired_rc = acq,
+            };
+        }
+        // Legacy lock-based path: hand the events_lock off to the borrow.
         lock_held = false;
         // tier-5 depth + LockTimer handed off to the borrow; deinit will
         // leaveTier5() and t.released() after unlocking.
         return BorrowedState{
-            .state = state_ptr,
+            .state = &new_rc.state,
             .backing = .{ .events_mutex = &self.events_lock },
             .tier5_held = true,
             .timer = t_ev,
@@ -5360,4 +5489,234 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
         error.ChainWorkerDisabled,
         beam_chain_off.submitBlock(off_cloned, false),
     );
+}
+
+test "chain.statesGet under chain_worker enabled returns Backing.none + acquired_rc (slice c-2b commit 4)" {
+    // Slice c-2b commit 4 of #803: when chain_worker != null, statesGet
+    // takes the lock-free path — it tryAcquires the rc under the shared
+    // lock, drops the lock, and returns a Backing.none borrow. This
+    // test verifies the contract: the borrow is Backing.none, has a
+    // non-null acquired_rc, and the rc refcount tracks acquire/release.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 2, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+    var db = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir,
+    );
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 42,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    // Start the worker so chain_worker != null (this is the
+    // --chain-worker=on runtime indicator).
+    try beam_chain.startChainWorker();
+    try std.testing.expect(beam_chain.chain_worker != null);
+
+    const target_root = mock_chain.blockRoots[0]; // genesis root, populated by init
+
+    // Snapshot refcount before the borrow.
+    beam_chain.states_lock.lockShared();
+    const rc_before = beam_chain.states.get(target_root).?;
+    const refcount_before = rc_before.count();
+    beam_chain.states_lock.unlockShared();
+    try std.testing.expectEqual(@as(u32, 1), refcount_before);
+
+    // Take a borrow.
+    var borrow = beam_chain.statesGet(target_root) orelse {
+        try std.testing.expect(false);
+        unreachable;
+    };
+
+    // Verify lock-free shape: Backing.none + non-null acquired_rc.
+    try std.testing.expect(borrow.backing == .none);
+    try std.testing.expect(borrow.acquired_rc != null);
+    try std.testing.expect(borrow.acquired_rc.? == rc_before);
+
+    // Refcount must have bumped to 2 (map=1 + borrow=1).
+    try std.testing.expectEqual(@as(u32, 2), rc_before.count());
+
+    // Drop the borrow — refcount returns to 1 (map only).
+    borrow.deinit();
+    try std.testing.expectEqual(@as(u32, 1), rc_before.count());
+}
+
+test "chain.statesGet under chain_worker enabled does not block exclusive writers (slice c-2b commit 4)" {
+    // The whole point of slice c-2b commit 4: a long-lived reader borrow
+    // must NOT block an exclusive-side mutation by the chain worker
+    // path. We hold a Backing.none borrow open across the lifetime of
+    // a writer thread that takes the exclusive lock and inserts an
+    // unrelated entry; under the old shared-held-for-borrow behavior
+    // the writer would deadlock against the reader (or rather, block
+    // until the reader released). A 1-second watchdog asserts the
+    // writer completed within bound; a regression hangs CI rather
+    // than silently passing.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 2, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+    var db = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir,
+    );
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 43,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    try beam_chain.startChainWorker();
+    try std.testing.expect(beam_chain.chain_worker != null);
+
+    const target_root = mock_chain.blockRoots[0];
+
+    // Reader: take a long-lived borrow.
+    var borrow = beam_chain.statesGet(target_root) orelse {
+        try std.testing.expect(false);
+        unreachable;
+    };
+    defer borrow.deinit();
+    try std.testing.expect(borrow.backing == .none);
+
+    // Writer: take the exclusive lock + insert an unrelated entry.
+    // Under the OLD shared-held-for-borrow behavior this would block
+    // until the reader released; under c-2b commit 4 the reader's
+    // borrow does NOT hold the lock, so the writer completes
+    // immediately.
+    const WriterCtx = struct {
+        chain: *BeamChain,
+        genesis_state: *const types.BeamState,
+        done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+        fn run(ctx: *@This()) void {
+            // Synthetic root distinct from genesis (zeroes); first byte 0xab.
+            var fake_root: types.Root = std.mem.zeroes(types.Root);
+            fake_root[0] = 0xab;
+
+            var cloned_value: types.BeamState = undefined;
+            types.sszClone(std.testing.allocator, types.BeamState, ctx.genesis_state.*, &cloned_value) catch return;
+            const new_rc = RcBeamState.create(std.testing.allocator, cloned_value) catch return;
+
+            // Take the exclusive side. With the lock-free reader this
+            // returns immediately even though a borrow is alive in the
+            // main thread.
+            ctx.chain.states_lock.lock();
+            ctx.chain.states.put(fake_root, new_rc) catch {
+                ctx.chain.states_lock.unlock();
+                new_rc.release();
+                return;
+            };
+            ctx.chain.states_lock.unlock();
+            ctx.done.store(true, .release);
+        }
+    };
+    var writer_ctx = WriterCtx{
+        .chain = &beam_chain,
+        .genesis_state = &mock_chain.genesis_state,
+    };
+    var writer_thread = try std.Thread.spawn(.{}, WriterCtx.run, .{&writer_ctx});
+
+    // Watchdog: spin for at most 1 second waiting for the writer.
+    // Under a regression (e.g. a future change re-imposing the
+    // shared-held-for-borrow shape) the writer would block on the
+    // reader's borrow and this would time out.
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns: i128 = start_ns + 1 * std.time.ns_per_s;
+    while (zeam_utils.monotonicTimestampNs() < deadline_ns) {
+        if (writer_ctx.done.load(.acquire)) break;
+        std.Thread.yield() catch {};
+    }
+    writer_thread.join();
+    try std.testing.expect(writer_ctx.done.load(.acquire));
+
+    // The reader's borrow is still valid even after the writer mutated
+    // the map: refcount kept the underlying state alive.
+    try std.testing.expectEqual(mock_chain.genesis_state.slot, borrow.state.slot);
 }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -654,6 +654,78 @@ pub const BeamChain = struct {
         return null;
     }
 
+    /// Move the value out of a heap-allocated `*BeamState` wrapper
+    /// into a freshly-`create`d `RcBeamState`, freeing the now-empty
+    /// wrapper. Centralises the value-copy + destroy + create dance
+    /// shared by `produceBlock` and `onBlock`'s owned-post_state path.
+    ///
+    /// Ownership story (single, identical at every call site):
+    ///
+    ///   * Pre-call: caller owns `post_state` (a `*BeamState`
+    ///     pointing at heap memory). The interior of the BeamState
+    ///     value (lists, slices, etc.) is also caller-owned. Caller
+    ///     has an upstream errdefer gated by `gate_consumed.* == false`
+    ///     that frees both the wrapper and the interior on early
+    ///     return.
+    ///
+    ///   * Post-call (success): the BeamState value has been moved
+    ///     into the rc; the wrapper has been freed. `gate_consumed`
+    ///     has been set to `true` so the caller's upstream errdefer
+    ///     does not fire. The caller now owns the returned
+    ///     `*RcBeamState` and must transfer it (e.g. via
+    ///     `statesPutExclusive` / `statesCommitKeepExisting`) or
+    ///     release it.
+    ///
+    ///   * Post-call (error): the wrapper has been freed (we
+    ///     destroyed it BEFORE the create attempt so an OOM cannot
+    ///     leave a wrapper-allocator leak); the BeamState value's
+    ///     interior has been consumed by `RcBeamState.create`'s
+    ///     always-consume contract. `gate_consumed` has still been
+    ///     set to `true` (BEFORE the create call) so the caller's
+    ///     upstream errdefer does NOT run — it would deref the
+    ///     freed wrapper. Net: nothing leaks, the caller's gate
+    ///     correctly suppresses the upstream cleanup, and the
+    ///     caller propagates the error.
+    ///
+    /// Why a `*bool` gate parameter rather than nulling an
+    /// `?*BeamState` (the original `produceBlock` shape)? The
+    /// `onBlock` path also distinguishes a NOT-OWNED case (caller
+    /// supplied `post_state` and we sszClone before wrapping) where
+    /// the upstream errdefer is gated by an additional
+    /// `post_state_owned` flag, not by an optional. A bool gate
+    /// matches both call sites; the optional gate did not. Pre-c-2b
+    /// the two sites used different mechanisms for identical work
+    /// (PR #828 review by @ch4r10t33r) — this helper unifies them.
+    ///
+    /// NOTE: the helper is for the OWNED case only. `onBlock`'s
+    /// caller-supplied path still does its own `sszClone` +
+    /// `RcBeamState.create` inline because the value-source there
+    /// is not a heap wrapper to free.
+    fn wrapOwnedStateIntoRc(
+        self: *Self,
+        post_state: *types.BeamState,
+        gate_consumed: *bool,
+    ) !*RcBeamState {
+        // Move the BeamState value out of the heap wrapper into a
+        // local. After this point the wrapper memory holds a stale
+        // shallow copy whose interior pointers have been logically
+        // transferred to `value`.
+        const value = post_state.*;
+        // Free the wrapper BEFORE attempting create so an OOM in
+        // create does not leave a wrapper-allocator leak. The
+        // value's interior is consumed by create's always-consume
+        // contract on either success or its own OOM path.
+        self.allocator.destroy(post_state);
+        // Set the gate BEFORE the (fallible) create call: on
+        // failure the upstream errdefer must not run (it would
+        // deref the now-freed wrapper); on success the gate stays
+        // true forever. Either way the caller's gate is correctly
+        // false ONLY for the window between heap-wrapper-allocation
+        // and this helper call.
+        gate_consumed.* = true;
+        return RcBeamState.create(self.allocator, value);
+    }
+
     /// Take the exclusive side of `states_lock` and `put` the entry.
     /// Used by produceBlock / onBlock STF commit and similar
     /// single-key writes.
@@ -1051,12 +1123,19 @@ pub const BeamChain = struct {
             self.allocator.destroy(pre_snapshot);
         }
 
-        var post_state_opt: ?*types.BeamState = try self.allocator.create(types.BeamState);
-        errdefer if (post_state_opt) |post_state_ptr| {
-            post_state_ptr.deinit();
-            self.allocator.destroy(post_state_ptr);
+        const post_state = try self.allocator.create(types.BeamState);
+        // c-2b: switched from `?*BeamState` (nulled on consume) to a
+        // bool gate to match `onBlock`'s post_state_settled shape.
+        // `wrapOwnedStateIntoRc` flips this on consume; the upstream
+        // errdefer below covers every early-return path before the
+        // wrap, including a partial sszClone that left interior
+        // allocations behind (BeamState.deinit is tolerant of
+        // partial init by design).
+        var post_state_consumed = false;
+        errdefer if (!post_state_consumed) {
+            post_state.deinit();
+            self.allocator.destroy(post_state);
         };
-        const post_state = post_state_opt.?;
         try types.sszClone(self.allocator, types.BeamState, pre_snapshot.*, post_state);
 
         const payload_agg_timer = zeam_metrics.lean_block_building_payload_aggregation_time_seconds.start();
@@ -1152,24 +1231,14 @@ pub const BeamChain = struct {
         var block_root: [32]u8 = undefined;
         try zeam_utils.hashTreeRoot(types.BeamBlock, block, &block_root, self.allocator);
 
-        // c-2b: wrap the heap-allocated post_state into an
-        // RcBeamState. RcBeamState.create takes BeamState by value
-        // and embeds it; the old heap wrapper is no longer needed,
-        // so destroy() it after the value-copy. Always-consume
-        // contract: on RcBeamState.create OOM the BeamState's
-        // interior is freed by create's own errdefer; we still
-        // need to free the old wrapper allocation that held the
-        // (now-moved-from) value.
-        const post_state_rc = blk: {
-            const value_copy = post_state.*;
-            // The wrapper allocation is no longer needed; the
-            // interior is owned by `value_copy` (struct copy is
-            // shallow but the slices/lists inside are pointers we
-            // are transferring) until create() consumes it.
-            self.allocator.destroy(post_state);
-            post_state_opt = null;
-            break :blk try RcBeamState.create(self.allocator, value_copy);
-        };
+        // c-2b: move the heap-allocated post_state into a freshly-
+        // `create`d RcBeamState via the shared helper that
+        // centralises the value-copy + destroy + create dance.
+        // Helper sets `post_state_consumed = true` BEFORE its
+        // (fallible) create call, so the upstream errdefer does
+        // not deref freed memory on OOM and does not double-free
+        // on success. PR #828 review by @ch4r10t33r.
+        const post_state_rc = try self.wrapOwnedStateIntoRc(post_state, &post_state_consumed);
         // statesPutExclusive takes ownership of the rc on success;
         // releases on its own OOM path.
         try self.statesPutExclusive("produceBlock.commit", block_root, post_state_rc);
@@ -1882,39 +1951,36 @@ pub const BeamChain = struct {
         // racing in via another thread's `onBlockFollowup` and freeing the
         // entry under us. See PR #820 / issue #803.
         // c-2b: wrap post_state in an RcBeamState before commit.
-        // If we own post_state, the rc takes its value and we must
-        // free the now-empty wrapper. If the caller supplied it,
-        // we sszClone into a fresh value and let create() consume
-        // that, leaving the caller's allocation untouched.
+        // Two paths depending on ownership:
+        //   * post_state_owned (we allocated it locally above):
+        //     route through `wrapOwnedStateIntoRc` — it does the
+        //     value-move + wrapper-destroy + create + gate-flip
+        //     dance, identical to `produceBlock`'s commit path.
+        //   * !post_state_owned (caller supplied a *BeamState we
+        //     don't own): sszClone into a fresh value, then
+        //     `RcBeamState.create` consumes that. The caller's
+        //     allocation is left untouched; nothing to free, no
+        //     gate to flip (post_state_settled stays false here
+        //     and is flipped after the commit succeeds because the
+        //     gate's errdefer is gated on `post_state_owned` too).
         //
-        // After the rc is created, the rc owns the state value
-        // (success path) or the value's interior was deinit'd by
-        // create's OOM path. Either way the original wrapper
-        // memory is no longer needed when post_state_owned. Flip
-        // post_state_settled BEFORE destroying the wrapper so the
-        // upstream errdefer at line ~1317 does not deref freed
-        // memory if a later step fails.
+        // PR #828 review by @ch4r10t33r: pre-c-2b the owned path
+        // used a different gate mechanism than `produceBlock`
+        // (post_state_settled bool vs ?*BeamState nulling); the
+        // helper unifies them.
         var post_state_rc: *RcBeamState = undefined;
         if (post_state_owned) {
-            const value = post_state.*;
-            // post_state's value has been moved into `value`; the
-            // wrapper allocation is now stale. Free it BEFORE
-            // attempting the create so that an OOM in create does
-            // not leave a wrapper-allocator leak. The interior
-            // owned by `value` is consumed by create on either
-            // path.
-            self.allocator.destroy(post_state);
-            post_state_settled = true;
-            post_state_rc = try RcBeamState.create(self.allocator, value);
+            // Helper flips `post_state_settled = true` BEFORE the
+            // create call so the upstream errdefer at line ~1712
+            // does not deref the freed wrapper if create OOMs.
+            post_state_rc = try self.wrapOwnedStateIntoRc(post_state, &post_state_settled);
         } else {
             // Caller owns post_state; clone its value into a fresh
-            // BeamState, then wrap. errdefer below covers the
-            // sszClone OOM path (interior cleanup before returning).
+            // BeamState, then wrap. Past sszClone success, `value`
+            // owns interior allocations; `RcBeamState.create`'s
+            // always-consume contract handles cleanup on OOM.
             var value: types.BeamState = undefined;
             try types.sszClone(self.allocator, types.BeamState, post_state.*, &value);
-            // Past sszClone success, value owns interior
-            // allocations. RcBeamState.create's always-consume
-            // contract handles cleanup on OOM.
             post_state_rc = try RcBeamState.create(self.allocator, value);
         }
         // statesCommitKeepExisting takes the rc on either path:

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -25,6 +25,8 @@ const tree_visualizer = @import("./tree_visualizer.zig");
 const locking = @import("./locking.zig");
 const BorrowedState = locking.BorrowedState;
 const LockTimer = locking.LockTimer;
+const rc_beam_state = @import("./rc_beam_state.zig");
+const RcBeamState = rc_beam_state.RcBeamState;
 
 const networkFactory = @import("./network.zig");
 const PeerInfo = networkFactory.PeerInfo;
@@ -101,7 +103,15 @@ pub const BeamChain = struct {
     forkChoice: fcFactory.ForkChoice,
     allocator: Allocator,
     // from finalized onwards to recent
-    states: std.AutoHashMap(types.Root, *types.BeamState),
+    /// Cached post-states keyed by block root. Migrated to
+    /// `*RcBeamState` in slice c-2b (#803): refcounted state
+    /// pointers let the chain worker (sole writer under c-2b) and
+    /// cross-thread readers (HTTP API, metrics, broadcaster)
+    /// share state without copying. Until commit 4 of this PR
+    /// drops the rwlock, `states_lock` continues to gate
+    /// concurrent map mutation — the rc handles only address
+    /// state-pointer lifetime, not map-shape mutation.
+    states: std.AutoHashMap(types.Root, *RcBeamState),
     nodeId: u32,
     // This struct needs to contain the zeam_logger_config to be able to call `maybeRotate`
     // For all other modules, we just need logger
@@ -219,14 +229,24 @@ pub const BeamChain = struct {
             .thread_pool = opts.thread_pool,
         });
 
-        var states = std.AutoHashMap(types.Root, *types.BeamState).init(allocator);
-        const cloned_anchor_state = try allocator.create(types.BeamState);
-        // Destroy outer allocation if sszClone fails (interior not yet allocated).
-        errdefer allocator.destroy(cloned_anchor_state);
-        try types.sszClone(allocator, types.BeamState, opts.anchorState.*, cloned_anchor_state);
-        // Interior fields are now allocated; deinit them if states.put fails (LIFO order).
-        errdefer cloned_anchor_state.deinit();
-        try states.put(fork_choice.head.blockRoot, cloned_anchor_state);
+        var states = std.AutoHashMap(types.Root, *RcBeamState).init(allocator);
+        // Build the anchor state on the stack via sszClone, then
+        // hand it to RcBeamState.create which embeds it into the
+        // heap allocation (and consumes it on either success or
+        // OOM — always-consume contract per c-2a).
+        var cloned_anchor_state: types.BeamState = undefined;
+        try types.sszClone(
+            allocator,
+            types.BeamState,
+            opts.anchorState.*,
+            &cloned_anchor_state,
+        );
+        // Past this line, `cloned_anchor_state` owns interior
+        // allocations. RcBeamState.create takes ownership; on OOM
+        // it will deinit them for us.
+        const anchor_rc = try RcBeamState.create(allocator, cloned_anchor_state);
+        errdefer anchor_rc.release();
+        try states.put(fork_choice.head.blockRoot, anchor_rc);
 
         var chain = Self{
             .nodeId = opts.nodeId,
@@ -274,10 +294,14 @@ pub const BeamChain = struct {
         // Clean up forkchoice resources (attestation_signatures, aggregated_payloads)
         self.forkChoice.deinit();
 
+        // Each entry holds an RcBeamState we own a reference on.
+        // release() drops the count and frees the wrapper +
+        // interior state when refcount reaches 0. Under c-2b
+        // commit 2 nothing else takes acquires on map-resident
+        // states yet, so refcount is always 1 at deinit time.
         var it = self.states.iterator();
         while (it.next()) |entry| {
-            entry.value_ptr.*.deinit();
-            self.allocator.destroy(entry.value_ptr.*);
+            entry.value_ptr.*.release();
         }
         self.states.deinit();
 
@@ -345,13 +369,16 @@ pub const BeamChain = struct {
         var t = LockTimer.start("states", "statesGet");
         self.states_lock.lockShared();
         t.acquired();
-        if (self.states.get(root)) |state| {
-            // Hand the lock off to the borrow. The borrow's deinit calls
-            // states_lock.unlockShared() AND closes the LockTimer
-            // observation — so the hold-span histogram correctly
-            // attributes the entire borrow lifetime to this site.
+        if (self.states.get(root)) |rc| {
+            // Hand the lock off to the borrow. Under c-2b commit 2
+            // the rwlock still gates lifetime: the rc lives as long
+            // as the entry is in the map AND the lock is held, so
+            // it's safe to expose `&rc.state` directly without
+            // taking an acquire. Commit 4 of this PR will drop the
+            // rwlock entirely and switch this path to
+            // `acquireConst()` + `tryAcquire()`.
             return BorrowedState{
-                .state = state,
+                .state = &rc.state,
                 .backing = .{ .states_shared_rwlock = &self.states_lock },
                 .timer = t,
             };
@@ -363,15 +390,24 @@ pub const BeamChain = struct {
         return null;
     }
 
-    /// Take the exclusive side of `states_lock` and `put` the entry. Used
-    /// by produceBlock / onBlock STF commit and similar single-key writes.
-    fn statesPutExclusive(self: *Self, comptime site: []const u8, root: types.Root, state_ptr: *types.BeamState) !void {
+    /// Take the exclusive side of `states_lock` and `put` the entry.
+    /// Used by produceBlock / onBlock STF commit and similar
+    /// single-key writes.
+    ///
+    /// Under c-2b commit 2 the helper takes `*RcBeamState` directly
+    /// (callers wrap their `*BeamState` via `RcBeamState.create`
+    /// before calling). Map ownership transfers in: on success the
+    /// map holds the rc and will release it on `deinit`. On
+    /// `map.put` OOM the helper releases `rc` so the caller never
+    /// has to clean up.
+    fn statesPutExclusive(self: *Self, comptime site: []const u8, root: types.Root, rc: *RcBeamState) !void {
         var t = LockTimer.start("states", site);
         self.states_lock.lock();
         t.acquired();
         defer t.released();
         defer self.states_lock.unlock();
-        try self.states.put(root, state_ptr);
+        errdefer rc.release();
+        try self.states.put(root, rc);
     }
 
     /// Insert under `states_lock.exclusive` if the entry is not already in
@@ -408,39 +444,42 @@ pub const BeamChain = struct {
         self: *Self,
         comptime site: []const u8,
         root: types.Root,
-        state_ptr: *types.BeamState,
+        rc: *RcBeamState,
     ) !struct { borrow: BorrowedState, kept_existing: bool } {
         var t = LockTimer.start("states", site);
         self.states_lock.lock();
         t.acquired();
-        // NOTE: NO `defer self.states_lock.unlock()` here — the exclusive
-        // lock is owned by the returned BorrowedState and released by its
-        // deinit. errdefer below covers the OOM path on `getOrPut`. The
-        // LockTimer is moved into the borrow as well so the hold-span
-        // observation closes at the deinit site, not here. PR #820.
+        // NOTE: NO `defer self.states_lock.unlock()` here — the
+        // exclusive lock is owned by the returned BorrowedState and
+        // released by its deinit. errdefer below covers the OOM path
+        // on `getOrPut`. The LockTimer is moved into the borrow as
+        // well so the hold-span observation closes at the deinit
+        // site, not here. PR #820.
         errdefer {
             self.states_lock.unlock();
             t.released();
         }
         const gop = try self.states.getOrPut(root);
-        const effective_ptr: *types.BeamState = if (gop.found_existing) blk: {
-            // Decision policy: keep the existing pointer (it's referenced
-            // elsewhere — e.g. produceBlock just inserted it before
-            // publishBlock landed here) and tell the caller to free the
-            // freshly-computed copy. We never want to invalidate a pointer
-            // that other borrows might still observe through
-            // `states_lock.shared`.
+        // After this point getOrPut succeeded; on subsequent failure
+        // we still own `rc` if not inserted, so handle both paths.
+        const effective_rc: *RcBeamState = if (gop.found_existing) blk: {
+            // Decision policy: keep the existing rc (other readers
+            // may still hold acquires on it) and release the
+            // freshly-computed copy the caller handed us. The
+            // "kept_existing" return tells the caller their rc was
+            // dropped so they don't double-release.
+            rc.release();
             break :blk gop.value_ptr.*;
         } else blk: {
-            gop.value_ptr.* = state_ptr;
-            break :blk state_ptr;
+            gop.value_ptr.* = rc;
+            break :blk rc;
         };
         if (gop.found_existing) {
             _ = self.states_kept_existing_count.fetchAdd(1, .monotonic);
         }
         return .{
             .borrow = BorrowedState{
-                .state = effective_ptr,
+                .state = &effective_rc.state,
                 .backing = .{ .states_exclusive_rwlock = &self.states_lock },
                 .timer = t,
             },
@@ -449,8 +488,12 @@ pub const BeamChain = struct {
     }
 
     /// Take the exclusive side of `states_lock` and remove the entry.
-    /// Returns the removed pointer (or null) so the caller can free it.
-    fn statesFetchRemoveExclusivePtr(self: *Self, comptime site: []const u8, root: types.Root) ?*types.BeamState {
+    /// Returns the removed `*RcBeamState` (or null) so the caller can
+    /// release it. Under c-2b the caller MUST call `.release()` on
+    /// the returned rc to drop the map's reference; if other readers
+    /// hold acquires the underlying state stays alive until the last
+    /// release.
+    fn statesFetchRemoveExclusivePtr(self: *Self, comptime site: []const u8, root: types.Root) ?*RcBeamState {
         var t = LockTimer.start("states", site);
         self.states_lock.lock();
         t.acquired();
@@ -791,14 +834,32 @@ pub const BeamChain = struct {
         var block_root: [32]u8 = undefined;
         try zeam_utils.hashTreeRoot(types.BeamBlock, block, &block_root, self.allocator);
 
-        try self.statesPutExclusive("produceBlock.commit", block_root, post_state);
-        post_state_opt = null;
+        // c-2b: wrap the heap-allocated post_state into an
+        // RcBeamState. RcBeamState.create takes BeamState by value
+        // and embeds it; the old heap wrapper is no longer needed,
+        // so destroy() it after the value-copy. Always-consume
+        // contract: on RcBeamState.create OOM the BeamState's
+        // interior is freed by create's own errdefer; we still
+        // need to free the old wrapper allocation that held the
+        // (now-moved-from) value.
+        const post_state_rc = blk: {
+            const value_copy = post_state.*;
+            // The wrapper allocation is no longer needed; the
+            // interior is owned by `value_copy` (struct copy is
+            // shallow but the slices/lists inside are pointers we
+            // are transferring) until create() consumes it.
+            self.allocator.destroy(post_state);
+            post_state_opt = null;
+            break :blk try RcBeamState.create(self.allocator, value_copy);
+        };
+        // statesPutExclusive takes ownership of the rc on success;
+        // releases on its own OOM path.
+        try self.statesPutExclusive("produceBlock.commit", block_root, post_state_rc);
 
         var forkchoice_added = false;
         errdefer if (!forkchoice_added) {
-            if (self.statesFetchRemoveExclusivePtr("produceBlock.errdefer", block_root)) |entry_ptr| {
-                entry_ptr.deinit();
-                self.allocator.destroy(entry_ptr);
+            if (self.statesFetchRemoveExclusivePtr("produceBlock.errdefer", block_root)) |rc_ptr| {
+                rc_ptr.release();
             }
         };
 
@@ -1425,20 +1486,51 @@ pub const BeamChain = struct {
         // This blocks `pruneStates` (also exclusive on `states_lock`) from
         // racing in via another thread's `onBlockFollowup` and freeing the
         // entry under us. See PR #820 / issue #803.
-        var commit = try self.statesCommitKeepExisting("onBlock.commit", fcBlock.blockRoot, post_state);
+        // c-2b: wrap post_state in an RcBeamState before commit.
+        // If we own post_state, the rc takes its value and we must
+        // free the now-empty wrapper. If the caller supplied it,
+        // we sszClone into a fresh value and let create() consume
+        // that, leaving the caller's allocation untouched.
+        //
+        // After the rc is created, the rc owns the state value
+        // (success path) or the value's interior was deinit'd by
+        // create's OOM path. Either way the original wrapper
+        // memory is no longer needed when post_state_owned. Flip
+        // post_state_settled BEFORE destroying the wrapper so the
+        // upstream errdefer at line ~1317 does not deref freed
+        // memory if a later step fails.
+        var post_state_rc: *RcBeamState = undefined;
+        if (post_state_owned) {
+            const value = post_state.*;
+            // post_state's value has been moved into `value`; the
+            // wrapper allocation is now stale. Free it BEFORE
+            // attempting the create so that an OOM in create does
+            // not leave a wrapper-allocator leak. The interior
+            // owned by `value` is consumed by create on either
+            // path.
+            self.allocator.destroy(post_state);
+            post_state_settled = true;
+            post_state_rc = try RcBeamState.create(self.allocator, value);
+        } else {
+            // Caller owns post_state; clone its value into a fresh
+            // BeamState, then wrap. errdefer below covers the
+            // sszClone OOM path (interior cleanup before returning).
+            var value: types.BeamState = undefined;
+            try types.sszClone(self.allocator, types.BeamState, post_state.*, &value);
+            // Past sszClone success, value owns interior
+            // allocations. RcBeamState.create's always-consume
+            // contract handles cleanup on OOM.
+            post_state_rc = try RcBeamState.create(self.allocator, value);
+        }
+        // statesCommitKeepExisting takes the rc on either path:
+        //   kept-existing: helper releases our rc, returns a
+        //     borrow on the in-map rc;
+        //   new-insert:    helper transfers our rc into the map.
+        // On the helper's own OOM path it releases the rc for us.
+        var commit = try self.statesCommitKeepExisting("onBlock.commit", fcBlock.blockRoot, post_state_rc);
         // Release the exclusive lock on every exit path (success or error).
         defer commit.borrow.assertReleasedOrPanic();
         defer commit.borrow.deinit();
-        if (commit.kept_existing and post_state_owned) {
-            // Existing entry kept — free the freshly-computed (and now
-            // redundant) post_state. The borrow points at the in-map
-            // pointer (a different allocation), so this free does not
-            // invalidate `commit.borrow.state`. Caller-supplied post-states
-            // (i.e. `post_state_owned == false`) belong to the caller; we
-            // don't touch them.
-            post_state.deinit();
-            self.allocator.destroy(post_state);
-        }
         // From here on use the borrow's pointer (the in-map one): if the
         // commit kept an existing entry, our `post_state` is freed and
         // unsafe to deref. The borrow keeps the in-map pointer alive for
@@ -1633,12 +1725,13 @@ pub const BeamChain = struct {
         });
 
         // We keep the canonical chain from finalized to head, so we can safely prune all non-canonical states
-        // Actually remove and deallocate the pruned states
+        // Actually remove and deallocate the pruned states (under
+        // c-2b: release the rc — the underlying state may stay
+        // alive if other readers hold acquires; freed when last
+        // release runs).
         for (roots) |root| {
             if (self.states.fetchRemove(root)) |entry| {
-                const state_ptr = entry.value;
-                state_ptr.deinit();
-                self.allocator.destroy(state_ptr);
+                entry.value.release();
                 self.logger.debug("pruned state for root 0x{x}", .{
                     &root,
                 });
@@ -2441,9 +2534,9 @@ test "process and add mock blocks into a node's chain" {
         // should have matching states in the state
         // SAFETY: test-only, single-threaded — no states_lock acquisition
         // needed (the chain under test has no concurrent mutators).
-        const block_state = beam_chain.states.get(block_root) orelse @panic("state root should have been found");
+        const block_state_rc = beam_chain.states.get(block_root) orelse @panic("state root should have been found");
         var state_root: [32]u8 = undefined;
-        try zeam_utils.hashTreeRoot(*types.BeamState, block_state, &state_root, allocator);
+        try zeam_utils.hashTreeRoot(types.BeamState, block_state_rc.state, &state_root, allocator);
         try std.testing.expect(std.mem.eql(u8, &state_root, &block.state_root));
 
         // fcstore checkpoints should match
@@ -3227,8 +3320,8 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
     // (att_data_known at slot=1) is the one that actually matters.
     // SAFETY: test-only, single-threaded — no states_lock acquisition
     // needed (the chain under test has no concurrent mutators).
-    const post_state = beam_chain.states.get(produced.blockRoot) orelse @panic("post state should exist");
-    try std.testing.expect(post_state.latest_justified.slot >= 1);
+    const post_state_rc = beam_chain.states.get(produced.blockRoot) orelse @panic("post state should exist");
+    try std.testing.expect(post_state_rc.state.latest_justified.slot >= 1);
 
     // Count how many attestation entries reference the unseen vs known block
     var unseen_count: usize = 0;
@@ -3734,11 +3827,12 @@ test "BorrowedState: cloneAndRelease vs concurrent statesFetchRemoveExclusivePtr
         // The 0-keyed root would alias genesis (zeroes); we offset by +1.
         unrelated_roots[k] = r;
 
-        const cloned_state = try std.testing.allocator.create(types.BeamState);
-        try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, cloned_state);
+        var cloned_value: types.BeamState = undefined;
+        try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &cloned_value);
+        const cloned_rc = try RcBeamState.create(std.testing.allocator, cloned_value);
         // Insert directly under exclusive lock (test-internal access).
         beam_chain.states_lock.lock();
-        try beam_chain.states.put(r, cloned_state);
+        try beam_chain.states.put(r, cloned_rc);
         beam_chain.states_lock.unlock();
     }
 
@@ -3786,9 +3880,8 @@ test "BorrowedState: cloneAndRelease vs concurrent statesFetchRemoveExclusivePtr
         fn pruner(ctx: *TestCtx) void {
             ctx.waitForStart();
             for (ctx.unrelated) |r| {
-                if (ctx.chain.statesFetchRemoveExclusivePtr("test.pruner", r)) |state_ptr| {
-                    state_ptr.deinit();
-                    std.testing.allocator.destroy(state_ptr);
+                if (ctx.chain.statesFetchRemoveExclusivePtr("test.pruner", r)) |rc_ptr| {
+                    rc_ptr.release();
                     _ = ctx.b_done.fetchAdd(1, .monotonic);
                 }
             }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -719,19 +719,73 @@ pub const BeamChain = struct {
         // on `getOrPut`. The LockTimer is moved into the borrow as
         // well so the hold-span observation closes at the deinit
         // site, not here. PR #820.
+        //
+        // Ownership: the helper takes responsibility for `rc` cleanup
+        // on every error path (mirroring `statesPutExclusive`). The
+        // `rc_owned` flag is cleared before each path that explicitly
+        // disposes of `rc` (the kept-existing release, the new-insert
+        // hand-off into the map) so the errdefer below cannot
+        // double-release. After the function returns successfully,
+        // ownership has either been transferred into the map
+        // (new-insert path) or dropped via `rc.release()`
+        // (kept-existing path) — `rc_owned` is false in both cases.
+        // Without this flag, an OOM in `states.getOrPut` would leak
+        // the freshly-`create`d rc + its heap-owned BeamState
+        // interior; the caller has no way to recover the pointer
+        // because the helper consumes it on success.
+        var rc_owned = true;
         errdefer {
             self.states_lock.unlock();
             t.released();
+            if (rc_owned) rc.release();
         }
         const gop = try self.states.getOrPut(root);
-        // After this point getOrPut succeeded; on subsequent failure
-        // we still own `rc` if not inserted, so handle both paths.
+        // After this point getOrPut succeeded; on either branch the
+        // helper now disposes of `rc` (release-or-transfer), so the
+        // errdefer must NOT double-act on it. Clear `rc_owned`
+        // BEFORE the synchronous release / map write so the cleared
+        // flag is observed even if the map write itself were ever
+        // changed to be fallible (currently `value_ptr.* = rc;` is
+        // infallible, but pinning the invariant here keeps the
+        // pattern safe under future edits).
+        rc_owned = false;
         const effective_rc: *RcBeamState = if (gop.found_existing) blk: {
             // Decision policy: keep the existing rc (other readers
             // may still hold acquires on it) and release the
             // freshly-computed copy the caller handed us. The
             // "kept_existing" return tells the caller their rc was
             // dropped so they don't double-release.
+            //
+            // Lock-hold note: when this release drops the refcount
+            // to 0 (the common case under c-2b commit 2 — the only
+            // acquires today come from the chain worker thread
+            // itself, which is the SAME thread executing this
+            // helper, so no concurrent acquire holds the rc alive),
+            // `release()` synchronously runs `state.deinit()` +
+            // `allocator.destroy(rc)` while holding
+            // `states_lock.exclusive`. For production-sized states
+            // BeamState.deinit walks every interior list/slice and
+            // is non-trivial work. Pre-c-2b the equivalent free was
+            // done by the CALLER outside the lock.
+            //
+            // The hold span is observable via
+            // `zeam_lock_hold_seconds{lock="states", site=...}` —
+            // the `site` argument differentiates `onBlock.commit`
+            // from `produceBlock.commit`, so a regression vs slice
+            // (b) baselines is visible per call site without any
+            // new instrumentation. Devnet should watch the
+            // `onBlock.commit` p99 across the slice (b)→(c-2b) cut.
+            //
+            // TODO(slice-c-2c): if the kept-existing free shows up
+            // as a hold-span regression on devnet, switch the
+            // helper to return the to-be-released rc alongside the
+            // borrow and have the caller release after dropping the
+            // lock (option (b) in the PR #828 review thread). Adds
+            // API surface but moves deinit work out of the critical
+            // section. Tracking-only until devnet has data; the
+            // single-writer assumption above means the cost is
+            // entirely allocator work, not contention with other
+            // chain mutators.
             rc.release();
             break :blk gop.value_ptr.*;
         } else blk: {
@@ -4256,6 +4310,165 @@ test "BorrowedState: cloneAndRelease vs concurrent statesFetchRemoveExclusivePtr
     const still_present = beam_chain.states.get(target_root) != null;
     beam_chain.states_lock.unlockShared();
     try std.testing.expect(still_present);
+}
+
+test "chain.statesCommitKeepExisting: getOrPut OOM releases caller rc (no leak)" {
+    // Regression for the post_state_rc leak Partha caught on PR #828:
+    // statesCommitKeepExisting flips its rc-ownership-transfer at the
+    // `getOrPut` step; if `getOrPut` itself OOMs, the helper is the
+    // ONLY place that knows about the rc (the upstream caller in
+    // onBlock has already flipped `post_state_settled = true` to keep
+    // the outer errdefer from double-freeing the now-Rc-wrapped
+    // BeamState). Without an `errdefer rc.release()` covering the
+    // OOM path, the freshly-`create`d rc + its heap-owned BeamState
+    // interior leak permanently. testing.allocator's leak detector
+    // catches the regression: this test passes ONLY when the helper
+    // releases the rc on its own OOM path.
+    //
+    // Mechanism:
+    //   1. Build a real BeamChain with testing.allocator so the chain
+    //      is fully functional and tear-down works.
+    //   2. Swap the chain's `states` map allocator with a
+    //      FailingAllocator that fails its very first allocation.
+    //      AutoHashMap exposes its allocator as a public field, so
+    //      this is a one-line swap.
+    //   3. Build a BeamState + RcBeamState the same way `onBlock`
+    //      does (sszClone the genesis state, wrap with
+    //      RcBeamState.create — both via testing.allocator so the
+    //      FailingAllocator only affects the map).
+    //   4. Pick a fresh root that is NOT already in the map (so the
+    //      getOrPut triggers a backing-array grow that fails — the
+    //      genesis root would hit the found_existing branch and not
+    //      reach the OOM site).
+    //   5. Call statesCommitKeepExisting and expect OutOfMemory. The
+    //      helper must release the caller's rc; testing.allocator
+    //      then verifies no leak at scope exit.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 2, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+
+    var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 12,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    // To make `getOrPut` actually fail under the FailingAllocator we
+    // need to FORCE a grow. After init, the states map has spare
+    // capacity (only genesis is in it), so a single insert would just
+    // land in the existing buffer with no allocation — bypassing the
+    // FailingAllocator entirely.
+    //
+    // The hash map's `unmanaged.available` field tracks remaining
+    // slots before a grow is triggered (see std/hash_map.zig
+    // `growIfNeeded`: `new_count > self.available` → grow). Set it
+    // to 0 so the very next insert MUST grow. This is white-box but
+    // it's the cleanest deterministic way to put the map in the
+    // "next insert grows" state without poking real-data invariants:
+    // we never call any other map method between this poke and the
+    // helper-under-test call, so the only thing observing
+    // `available == 0` is `growIfNeeded` itself — exactly the path
+    // we want to fail. Restore the original `available` before
+    // deinit so the chain's teardown path doesn't trip on a stale
+    // value (deinit only iterates and releases; it shouldn't matter
+    // for the iteration walk, but defensive restoration is cheap).
+    const original_available = beam_chain.states.unmanaged.available;
+    beam_chain.states.unmanaged.available = 0;
+    defer beam_chain.states.unmanaged.available = original_available;
+
+    // Now swap the states map allocator with a FailingAllocator.
+    // The next `getOrPut` of a NEW key will need to grow the backing
+    // array; the very first allocation through the FailingAllocator
+    // returns null → OutOfMemory. Restore before deinit so the chain's
+    // own teardown path uses the real allocator.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const original_states_allocator = beam_chain.states.allocator;
+    beam_chain.states.allocator = failing.allocator();
+    defer beam_chain.states.allocator = original_states_allocator;
+
+    // Build the rc the way onBlock does: clone genesis state into a
+    // fresh value, hand to RcBeamState.create. Both via
+    // testing.allocator so the FailingAllocator above only affects
+    // the states map.
+    var cloned_value: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &cloned_value);
+    const post_state_rc = try RcBeamState.create(std.testing.allocator, cloned_value);
+    // No errdefer post_state_rc.release() here — the helper under
+    // test is responsible for releasing it on its own OOM path.
+    // That IS the contract this test pins.
+
+    // A root that is NOT already in the map (genesis root WOULD be
+    // there, which would hit the found_existing branch and never
+    // reach the OOM site). Use a synthetic non-zero root distinct
+    // from any filler key.
+    var fresh_root = std.mem.zeroes(types.Root);
+    std.mem.writeInt(u64, fresh_root[0..8], 0xDEAD_BEEF_CAFE_BABE, .little);
+
+    const result = beam_chain.statesCommitKeepExisting(
+        "test.oom_regression",
+        fresh_root,
+        post_state_rc,
+    );
+    try std.testing.expectError(error.OutOfMemory, result);
+
+    // states_lock must be released — try a quick exclusive
+    // lock+unlock to prove no thread is hung on it. tryLock would be
+    // ideal but SyncRwLock doesn't expose one; a successful
+    // lock()/unlock() pair after the failed call is the same proof
+    // (any leak of the lock would deadlock here forever; CI timeout
+    // would catch that, but in practice the lock IS released by the
+    // helper's errdefer). Doing a real lock here also means the
+    // chain's deinit path doesn't have to fight a held lock.
+    beam_chain.states_lock.lock();
+    beam_chain.states_lock.unlock();
+
+    // The freshly-created rc must NOT have made it into the map
+    // (getOrPut failed before insertion). Genesis must still be the
+    // sole entry under the genesis root.
+    try std.testing.expect(beam_chain.states.get(fresh_root) == null);
 }
 
 test "chain.onBlock: two-thread concurrent import of same block — no UAF, coherent state" {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -550,6 +550,13 @@ pub const BeamChain = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        // Clear the refcount-distribution scrape refresher BEFORE any
+        // chain state is torn down so the metrics endpoint cannot call
+        // back into freed memory between deinit phases. (Idempotent:
+        // safe to call even if startChainStateRefcountObserver was
+        // never called.)
+        self.stopChainStateRefcountObserver();
+
         // Stop and free the chain-worker FIRST (before any chain
         // state the worker's handler thunks may touch is freed).
         // `stop()` is idempotent and joins the worker thread; after
@@ -964,6 +971,108 @@ pub const BeamChain = struct {
             return entry.value;
         }
         return null;
+    }
+
+    /// Sample `rc.count()` for every entry in `BeamChain.states` and
+    /// emit one observation per entry into the
+    /// `lean_chain_state_refcount_distribution` histogram. Slice c-2b
+    /// commit 5 of #803.
+    ///
+    /// Pattern: take `states_lock.shared` for the iteration only, drop
+    /// the lock before observing values (no allocations or fallible
+    /// ops happen inside the critical section). The lock hold span is
+    /// O(N) in the number of map entries; under c-2b this stays small
+    /// (≤ the un-pruned post-finalized state set, typically O(1) to O(10)).
+    ///
+    /// Infallible: any iteration failure path would silently drop the
+    /// scrape sample rather than crash the metrics endpoint. The
+    /// histogram observe() call is itself infallible (the metrics-lib
+    /// histogram type is non-vector, so no labels-allocation).
+    ///
+    /// Wired into the `/metrics` pre-scrape path via a context-bearing
+    /// scrape refresher: `BeamChain.startChainStateRefcountObserver()`
+    /// (called from `init` after the chain is at its final heap
+    /// address) registers this method against `zeam_metrics`'s
+    /// `g_scrape_refresher_ctx` slot.
+    pub fn recordChainStateRefcountDistribution(self: *Self) void {
+        // Snapshot the per-entry counts under the shared lock into a
+        // small stack buffer when possible. For larger maps we fall
+        // back to observing under the lock; the observe call is just
+        // an atomic-ish bucket increment, no allocations, no IO.
+        //
+        // The buffered-snapshot path is the safer shape: it minimizes
+        // the lock hold span. The on-stack buffer is sized for the
+        // expected upper bound on devnet (un-pruned post-finalized
+        // states + cached anchor) plus headroom.
+        var buf: [128]u32 = undefined;
+        var n: usize = 0;
+        var overflow = false;
+
+        self.states_lock.lockShared();
+        var it = self.states.valueIterator();
+        while (it.next()) |rc_ptr| {
+            const rc: *RcBeamState = rc_ptr.*;
+            if (n < buf.len) {
+                buf[n] = rc.count();
+                n += 1;
+            } else {
+                // Map has more entries than the stack buffer can
+                // hold; emit the rest under the lock. This is a
+                // graceful degradation — the lock hold span grows
+                // with map size, but since we don't allocate or do
+                // IO it stays bounded by the map size.
+                overflow = true;
+                zeam_metrics.metrics.lean_chain_state_refcount_distribution.observe(
+                    @floatFromInt(rc.count()),
+                );
+            }
+        }
+        self.states_lock.unlockShared();
+
+        // Observe the buffered samples outside the critical section.
+        for (buf[0..n]) |c| {
+            zeam_metrics.metrics.lean_chain_state_refcount_distribution.observe(
+                @floatFromInt(c),
+            );
+        }
+        // Log the overflow case once per scrape so devnet operators
+        // notice maps growing past the buffer; not fatal.
+        if (overflow) {
+            self.logger.debug(
+                "recordChainStateRefcountDistribution: map size exceeded stack buffer ({d}), emitted overflow samples under lock",
+                .{buf.len},
+            );
+        }
+    }
+
+    /// Trampoline for the context-bearing scrape refresher. The opaque
+    /// `ctx` pointer is the `*BeamChain` registered in `init`.
+    fn chainStateRefcountScrapeRefresher(ctx: ?*anyopaque) void {
+        const self: *Self = @ptrCast(@alignCast(ctx orelse return));
+        self.recordChainStateRefcountDistribution();
+    }
+
+    /// Register this chain as the source for the
+    /// `lean_chain_state_refcount_distribution` scrape refresher.
+    /// Called from `init` after the chain is at its final heap address
+    /// so the refresher's ctx pointer is stable.
+    ///
+    /// Idempotent across init/deinit cycles within a single process:
+    /// `deinit` clears the refresher slot. Note that the metrics
+    /// module holds a single context-bearing refresher slot; if a
+    /// second BeamChain is initialized in the same process (e.g. test
+    /// harnesses spinning multiple chains) the second init silently
+    /// replaces the first registration. Today only one chain is alive
+    /// per process; revisit if that changes.
+    pub fn startChainStateRefcountObserver(self: *Self) void {
+        zeam_metrics.registerScrapeRefresherCtx(self, &chainStateRefcountScrapeRefresher);
+    }
+
+    /// Clear this chain's refcount-distribution scrape refresher. Idempotent.
+    /// Called from `deinit` so the metrics module does not call back into
+    /// freed chain memory after teardown.
+    pub fn stopChainStateRefcountObserver(_: *Self) void {
+        zeam_metrics.registerScrapeRefresherCtx(null, null);
     }
 
     pub fn registerValidatorIds(self: *Self, validator_ids: []usize) void {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -27,6 +27,7 @@ const BorrowedState = locking.BorrowedState;
 const LockTimer = locking.LockTimer;
 const rc_beam_state = @import("./rc_beam_state.zig");
 const RcBeamState = rc_beam_state.RcBeamState;
+const chain_worker = @import("./chain_worker.zig");
 
 const networkFactory = @import("./network.zig");
 const PeerInfo = networkFactory.PeerInfo;
@@ -212,6 +213,22 @@ pub const BeamChain = struct {
     root_to_slot_lock: zeam_utils.SyncMutex = .{},
     events_lock: zeam_utils.SyncMutex = .{},
 
+    /// Optional chain-worker thread (slice c-2b commit 3 of #803).
+    /// When non-null, `BeamChain` exposes the `submit*` family of
+    /// methods which enqueue work onto the worker's queues; the
+    /// worker thread serialises the actual chain mutations.
+    /// When null, callers fall through to the synchronous path
+    /// (current behavior). Surface flipped by
+    /// `ChainOpts.chain_worker_enabled`; CLI flag
+    /// `--chain-worker=on|off`.
+    ///
+    /// Lifecycle: allocated + started in `init` when
+    /// `chain_worker_enabled` is true; stopped + freed in `deinit`.
+    /// The worker borrows `*BeamChain` as its handler ctx, so the
+    /// chain MUST outlive the worker — hence the strict
+    /// stop/deinit/destroy ordering at the top of `BeamChain.deinit`.
+    chain_worker: ?*chain_worker.ChainWorker = null,
+
     pub const PruneCachedBlocksFn = *const fn (ptr: *anyopaque, finalized: types.Checkpoint) usize;
 
     const Self = @This();
@@ -278,11 +295,246 @@ pub const BeamChain = struct {
             .pubkey_cache_lock = .{},
             .root_to_slot_lock = .{},
             .events_lock = .{},
+            // chain_worker is started below (after the chain value is
+            // at its final heap location), so the worker's ctx pointer
+            // remains stable for its entire lifetime.
+            .chain_worker = null,
         };
         // Initialize cache with anchor block root and any post-finalized entries from state
         try chain.root_to_slot_cache.put(fork_choice.head.blockRoot, opts.anchorState.slot);
         try chain.anchor_state.initRootToSlotCache(&chain.root_to_slot_cache);
         return chain;
+    }
+
+    /// Allocate, initialise, and start a `chain_worker.ChainWorker`
+    /// against this chain. Called from `BeamNode.init` after the
+    /// chain is at its final heap address — the worker stores `self`
+    /// as its handler ctx, so the chain pointer must NOT move
+    /// afterwards.
+    ///
+    /// On error the partially-allocated worker is freed before
+    /// returning so the caller can treat init as all-or-nothing.
+    /// On success the worker thread is running and ready to drain;
+    /// calling code can now invoke `submit*` to route producer-side
+    /// work through the queue.
+    pub fn startChainWorker(self: *Self) !void {
+        std.debug.assert(self.chain_worker == null);
+        const w = try self.allocator.create(chain_worker.ChainWorker);
+        errdefer self.allocator.destroy(w);
+        w.* = try chain_worker.ChainWorker.init(self.allocator, .{
+            .logger = self.zeam_logger_config.logger(.chain),
+            .handlers = .{
+                .ctx = self,
+                .on_block = chainWorkerOnBlockThunk,
+                .on_gossip_attestation = chainWorkerOnGossipAttestationThunk,
+                .on_gossip_aggregated_attestation = chainWorkerOnGossipAggregatedAttestationThunk,
+                .process_pending_blocks = chainWorkerProcessPendingBlocksThunk,
+                .process_finalization_followup = chainWorkerProcessFinalizationFollowupThunk,
+            },
+        });
+        errdefer w.deinit();
+        try w.start();
+        self.chain_worker = w;
+        self.logger.info("chain-worker: started (block_q={d}, att_q={d})", .{
+            chain_worker.DEFAULT_BLOCK_QUEUE_CAPACITY,
+            chain_worker.DEFAULT_ATTESTATION_QUEUE_CAPACITY,
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // chain_worker handler thunks (slice c-2b commit 3)
+    // ------------------------------------------------------------------
+    //
+    // These thunks adapt the worker's type-erased vtable shape
+    // (`*anyopaque` ctx + value-typed payloads) to the real
+    // `BeamChain` methods. Each one:
+    //
+    //   1. Casts ctx back to `*BeamChain` (debug-build alignment
+    //      asserts via `@alignCast`).
+    //   2. Calls the synchronous chain method.
+    //   3. Catches and logs any error — the producer side already
+    //      fired-and-forgot, so there is no upstream error channel.
+    //   4. Frees any heap returned by the method (e.g. the
+    //      `missing_roots` slice from `onBlock` /
+    //      `processPendingBlocks`). In the chain-worker path, the
+    //      missing-attestation-roots feedback loop into the gossip
+    //      layer's RPC fetch is intentionally dropped — a follow-up
+    //      commit can plumb a back-channel if it proves necessary
+    //      on devnet, but for c-2b's narrow gossip-block-and-
+    //      attestation migration the loss is the same as a dropped
+    //      gossip message.
+    //
+    // The thunks live in `chain.zig` (not `chain_worker.zig`)
+    // because they need access to `BeamChain` and its private
+    // method `processFinalizationAdvancement`. Putting them here
+    // also keeps `chain_worker.zig` free of any `chain.zig`
+    // import — the layering this whole vtable design exists to
+    // preserve.
+
+    fn chainWorkerOnBlockThunk(
+        ctx: *anyopaque,
+        signed_block: types.SignedBlock,
+        prune_forkchoice: bool,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        const missing_roots = self.onBlock(signed_block, .{
+            .pruneForkchoice = prune_forkchoice,
+        }) catch |err| {
+            self.logger.err("chain-worker: onBlock failed slot={d}: {any}", .{
+                signed_block.block.slot,
+                err,
+            });
+            return;
+        };
+        defer self.allocator.free(missing_roots);
+        // Mirror the gossip path: followup runs after a successful
+        // import. We pass the (immutable) signed_block by reference
+        // for symmetry with chain.onGossip; current onBlockFollowup
+        // ignores the parameter (see the explicit `_ = signedBlock`
+        // at its top), so the value is functionally unused here.
+        self.onBlockFollowup(prune_forkchoice, &signed_block);
+    }
+
+    fn chainWorkerOnGossipAttestationThunk(
+        ctx: *anyopaque,
+        gossip: networks.AttestationGossip,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        self.onGossipAttestation(gossip) catch |err| {
+            self.logger.warn(
+                "chain-worker: onGossipAttestation failed slot={d} validator={d}: {any}",
+                .{ gossip.message.message.slot, gossip.message.validator_id, err },
+            );
+        };
+    }
+
+    fn chainWorkerOnGossipAggregatedAttestationThunk(
+        ctx: *anyopaque,
+        agg: types.SignedAggregatedAttestation,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        self.onGossipAggregatedAttestation(agg) catch |err| {
+            self.logger.warn(
+                "chain-worker: onGossipAggregatedAttestation failed slot={d}: {any}",
+                .{ agg.data.slot, err },
+            );
+        };
+    }
+
+    fn chainWorkerProcessPendingBlocksThunk(
+        ctx: *anyopaque,
+        current_slot: types.Slot,
+    ) void {
+        // current_slot is unused by the current `processPendingBlocks`
+        // implementation (it consults `forkChoice.fcStore.slot_clock`
+        // directly), but kept on the message so a future refactor
+        // that wants the producer's view of the slot doesn't need
+        // a Message-shape change.
+        _ = current_slot;
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        const missing_roots = self.processPendingBlocks();
+        self.allocator.free(missing_roots);
+    }
+
+    fn chainWorkerProcessFinalizationFollowupThunk(
+        ctx: *anyopaque,
+        previous_finalized: types.Checkpoint,
+        latest_finalized: types.Checkpoint,
+        prune_forkchoice: bool,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        self.processFinalizationAdvancement(
+            previous_finalized,
+            latest_finalized,
+            prune_forkchoice,
+        ) catch |err| {
+            self.logger.err(
+                "chain-worker: processFinalizationAdvancement failed prev={d} latest={d}: {any}",
+                .{ previous_finalized.slot, latest_finalized.slot, err },
+            );
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // submit* family (slice c-2b commit 3)
+    // ------------------------------------------------------------------
+    //
+    // These wrappers route producer-side work through the
+    // chain_worker queues. They are ALWAYS available (the chain
+    // exposes them regardless of whether the worker is running);
+    // when the worker is disabled they return
+    // `error.ChainWorkerDisabled` so the caller can fall back to
+    // the direct synchronous path. This keeps the off-mode
+    // semantics identical to slice (b) — the call site decides
+    // which path to take, the submit* wrappers never silently
+    // change behaviour.
+    //
+    // Ownership contract on success: the caller transfers ownership
+    // of any heap-bearing payload (currently `signed_block` and
+    // `signed_aggregation`) to the worker. The worker calls
+    // `Message.deinit` after dispatch. On `error.QueueFull`,
+    // `error.QueueClosed`, or `error.ChainWorkerDisabled` the
+    // caller retains ownership and is responsible for cleanup
+    // (including calling `.deinit()` on the payload).
+
+    pub const SubmitError = chain_worker.BlockQueue.TrySendError || error{ChainWorkerDisabled};
+
+    /// Route a block import through the chain-worker queue.
+    pub fn submitBlock(
+        self: *Self,
+        signed_block: types.SignedBlock,
+        prune_forkchoice: bool,
+    ) SubmitError!void {
+        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
+        try w.sendBlock(.{ .on_block = .{
+            .signed_block = signed_block,
+            .prune_forkchoice = prune_forkchoice,
+        } });
+    }
+
+    /// Route a gossip-attestation through the chain-worker queue.
+    pub fn submitGossipAttestation(
+        self: *Self,
+        gossip: networks.AttestationGossip,
+    ) SubmitError!void {
+        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
+        try w.sendAttestation(.{ .on_gossip_attestation = gossip });
+    }
+
+    /// Route a gossip aggregated-attestation through the worker queue.
+    pub fn submitGossipAggregatedAttestation(
+        self: *Self,
+        agg: types.SignedAggregatedAttestation,
+    ) SubmitError!void {
+        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
+        try w.sendAttestation(.{ .on_gossip_aggregated_attestation = agg });
+    }
+
+    /// Route a `processPendingBlocks` tick through the worker queue.
+    /// (Not migrated by any caller in commit 3 — included so the
+    /// vtable + queue plumbing is exercised end-to-end and the API
+    /// shape is stable for the follow-up commit that migrates the
+    /// libxev tick path.)
+    pub fn submitProcessPendingBlocks(self: *Self, current_slot: types.Slot) SubmitError!void {
+        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
+        try w.sendBlock(.{ .process_pending_blocks = .{ .current_slot = current_slot } });
+    }
+
+    /// Route a `processFinalizationFollowup` move-off through the worker queue.
+    /// (Not migrated by any caller in commit 3; see
+    /// `submitProcessPendingBlocks` for the rationale.)
+    pub fn submitProcessFinalizationFollowup(
+        self: *Self,
+        previous_finalized: types.Checkpoint,
+        latest_finalized: types.Checkpoint,
+        prune_forkchoice: bool,
+    ) SubmitError!void {
+        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
+        try w.sendBlock(.{ .process_finalization_followup = .{
+            .previous_finalized = previous_finalized,
+            .latest_finalized = latest_finalized,
+            .prune_forkchoice = prune_forkchoice,
+        } });
     }
 
     pub fn setPruneCachedBlocksCallback(self: *Self, ctx: *anyopaque, func: PruneCachedBlocksFn) void {
@@ -291,6 +543,18 @@ pub const BeamChain = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        // Stop and free the chain-worker FIRST (before any chain
+        // state the worker's handler thunks may touch is freed).
+        // `stop()` is idempotent and joins the worker thread; after
+        // it returns no handler can re-enter `self`. Only then is
+        // it safe to tear down `forkChoice`, `states`, etc.
+        if (self.chain_worker) |w| {
+            w.stop();
+            w.deinit();
+            self.allocator.destroy(w);
+            self.chain_worker = null;
+        }
+
         // Clean up forkchoice resources (attestation_signatures, aggregated_payloads)
         self.forkChoice.deinit();
 
@@ -1075,6 +1339,56 @@ pub const BeamChain = struct {
                         }
                     }
 
+                    // Slice c-2b commit 3 of #803: route through the
+                    // chain-worker queue when enabled. We clone
+                    // `signed_block` here — the gossip layer owns the
+                    // borrowed copy for the duration of this callback,
+                    // but the worker takes ownership and runs
+                    // asynchronously, so it needs an independent
+                    // allocation. On `submitBlock` success the worker
+                    // owns the clone (and will deinit it after
+                    // dispatch); on failure the errdefer frees it.
+                    //
+                    // Trade-offs of the worker path:
+                    //   * `missing_attestation_roots` feedback is
+                    //     dropped — the worker thunk swallows the
+                    //     return value because there is no upstream
+                    //     channel to surface it on. The same dataset
+                    //     is rediscovered on the next attestation
+                    //     gossip whose `head/source/target` is still
+                    //     unknown (gossip clients re-broadcast
+                    //     liberally), so this is observably equivalent
+                    //     to a dropped first attempt.
+                    //   * `processed_block_root` is returned
+                    //     immediately so `BeamNode.onGossip` can still
+                    //     fan out `processCachedDescendants(root)` and
+                    //     give cached children a retry chance.
+                    if (self.chain_worker != null) {
+                        var cloned: types.SignedBlock = undefined;
+                        try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
+                        var cloned_consumed = false;
+                        errdefer if (!cloned_consumed) cloned.deinit();
+                        self.submitBlock(cloned, true) catch |err| switch (err) {
+                            error.QueueFull => {
+                                self.logger.warn(
+                                    "chain-worker: block queue full, dropping slot={d} root=0x{x}",
+                                    .{ block.slot, &block_root },
+                                );
+                                return .{};
+                            },
+                            error.QueueClosed => {
+                                self.logger.warn(
+                                    "chain-worker: block queue closed, dropping slot={d} root=0x{x}",
+                                    .{ block.slot, &block_root },
+                                );
+                                return .{};
+                            },
+                            error.ChainWorkerDisabled => unreachable,
+                        };
+                        cloned_consumed = true;
+                        return .{ .processed_block_root = block_root };
+                    }
+
                     const missing_roots = self.onBlock(signed_block, .{
                         .blockRoot = block_root,
                     }) catch |err| {
@@ -1149,12 +1463,39 @@ pub const BeamChain = struct {
                 };
 
                 if (self.is_aggregator_enabled.load(.acquire)) {
-                    // Process validated attestation
-                    self.onGossipAttestation(signed_attestation) catch |err| {
-                        zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-                        self.logger.err("attestation processing error: {any}", .{err});
-                        return err;
-                    };
+                    // Slice c-2b commit 3 of #803: when the chain-worker
+                    // is enabled, route the validated attestation
+                    // through its queue. `AttestationGossip` is plain-
+                    // old-data (see `Message.deinit` in chain_worker.zig),
+                    // so no clone is required — the value is copied into
+                    // the `Message` enum at queue push time.
+                    if (self.chain_worker != null) {
+                        self.submitGossipAttestation(signed_attestation) catch |err| switch (err) {
+                            error.QueueFull => {
+                                zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                                self.logger.warn(
+                                    "chain-worker: attestation queue full, dropping slot={d} validator={d}",
+                                    .{ slot, validator_id },
+                                );
+                                return .{};
+                            },
+                            error.QueueClosed => {
+                                self.logger.warn(
+                                    "chain-worker: attestation queue closed, dropping slot={d} validator={d}",
+                                    .{ slot, validator_id },
+                                );
+                                return .{};
+                            },
+                            error.ChainWorkerDisabled => unreachable,
+                        };
+                    } else {
+                        // Process validated attestation synchronously.
+                        self.onGossipAttestation(signed_attestation) catch |err| {
+                            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                            self.logger.err("attestation processing error: {any}", .{err});
+                            return err;
+                        };
+                    }
                     self.logger.info("processed gossip attestation for slot={d} validator={d}{f}", .{
                         slot,
                         validator_id,
@@ -4528,4 +4869,216 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
     // failed to finalize — the no-torn-read + no-regression checks
     // would still trivially hold on a chain stuck at genesis.
     try std.testing.expect(ctx.max_observed_finalized_slot.load(.monotonic) > 0);
+}
+
+test "chain-worker: end-to-end submitBlock advances state via the worker thread" {
+    // Slice c-2b commit 3 of #803 integration test.
+    //
+    // Boots a BeamChain with the chain-worker started, submits a real
+    // block via `submitBlock` (the worker-routed producer wrapper),
+    // waits for the worker to drain its queue, and asserts the chain
+    // state advanced as if the synchronous path had been taken:
+    //
+    //   * `states` map gains an entry for the imported block root.
+    //   * `forkChoice.hasBlock(root)` is true.
+    //   * The post-state's slot matches the imported block.
+    //
+    // This exercises every layer the commit touches end-to-end:
+    //
+    //   producer thread (this test) ──submitBlock──▶ BlockQueue
+    //   ChainWorker.runLoop ──tryRecv──▶ dispatch ──vtable──▶
+    //   chainWorkerOnBlockThunk ──▶ BeamChain.onBlock + onBlockFollowup
+    //
+    // We deliberately do NOT use the BeamChain ctor's auto-start path
+    // (there is none), instead calling `startChainWorker()` after the
+    // chain is at its final stack address. This mirrors the production
+    // call site in `BeamNode.init` which does the same after the chain
+    // is at its heap address. (The chain in this test is on the test
+    // function's stack, but doesn't move once allocated, which is
+    // sufficient for the worker's lifetime here.)
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 3, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    // spec_name + fork_digest live as long as the chain (BeamChain.deinit
+    // frees them via self.allocator).
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+
+    var db = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir,
+    );
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    // Start the chain-worker. After this point any submit* call may
+    // race with the worker thread; deinit (via defer above) calls
+    // `chain_worker.stop()` first which is the only safe shutdown
+    // ordering.
+    try beam_chain.startChainWorker();
+    try std.testing.expect(beam_chain.chain_worker != null);
+
+    // Advance forkchoice clock past the imported block's slot so the
+    // worker's onBlock call doesn't reject with FutureSlot.
+    const signed_block = mock_chain.blocks[1];
+    const block_root = mock_chain.blockRoots[1];
+    try beam_chain.forkChoice.onInterval(
+        signed_block.block.slot * constants.INTERVALS_PER_SLOT,
+        false,
+    );
+
+    // The worker takes ownership of the SignedBlock on a successful
+    // send, so we must clone the mock-chain block (which is owned by
+    // the arena and will be freed when the arena deinits, NOT by the
+    // worker after dispatch).
+    var cloned: types.SignedBlock = undefined;
+    try types.sszClone(std.testing.allocator, types.SignedBlock, signed_block, &cloned);
+    var cloned_consumed = false;
+    errdefer if (!cloned_consumed) cloned.deinit();
+
+    try beam_chain.submitBlock(cloned, false);
+    cloned_consumed = true;
+
+    // Wait for the worker to drain the queue. We poll on the
+    // states map (the post-condition we actually care about); the
+    // forkchoice insert happens synchronously inside onBlock and
+    // states is populated by `statesCommitKeepExisting` shortly
+    // after, so observing the entry is the strongest single signal
+    // that the message was processed end-to-end.
+    //
+    // 5s timeout is generous: a single STF on this 9-validator
+    // mock chain is well under 100 ms in Debug.
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns: i128 = start_ns + 5 * std.time.ns_per_s;
+    var observed = false;
+    while (zeam_utils.monotonicTimestampNs() < deadline_ns) {
+        beam_chain.states_lock.lockShared();
+        const present = beam_chain.states.get(block_root) != null;
+        beam_chain.states_lock.unlockShared();
+        if (present) {
+            observed = true;
+            break;
+        }
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expect(observed);
+
+    // Forkchoice must have observed the import.
+    try std.testing.expect(beam_chain.forkChoice.hasBlock(block_root));
+
+    // Post-state slot must match the imported block.
+    var borrow = beam_chain.statesGet(block_root) orelse {
+        try std.testing.expect(false);
+        unreachable;
+    };
+    defer borrow.deinit();
+    try std.testing.expectEqual(signed_block.block.slot, borrow.state.slot);
+
+    // Disabled-mode contract: with no worker, the submit* family
+    // returns ChainWorkerDisabled rather than silently doing the
+    // synchronous path. We can't test that on this chain (the
+    // worker is started), so spot-check it on a fresh chain.
+    var beam_state_2: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state_2);
+    defer beam_state_2.deinit();
+
+    const spec_name_2 = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest_2 = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config_2 = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name_2,
+            .fork_digest = fork_digest_2,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var tmp_dir_2 = std.testing.tmpDir(.{});
+    defer tmp_dir_2.cleanup();
+    var path_buf_2: [128]u8 = undefined;
+    const data_dir_2 = try std.fmt.bufPrint(&path_buf_2, ".zig-cache/tmp/{s}", .{tmp_dir_2.sub_path});
+    var db2 = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir_2,
+    );
+    defer db2.deinit();
+
+    const connected_peers_2 = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers_2);
+    connected_peers_2.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers_2.deinit();
+
+    const registry_2 = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(registry_2);
+    registry_2.* = NodeNameRegistry.init(std.testing.allocator);
+    defer registry_2.deinit();
+
+    var beam_chain_off = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config_2,
+        .anchorState = &beam_state_2,
+        .nodeId = 1,
+        .logger_config = &zeam_logger_config,
+        .db = db2,
+        .node_registry = registry_2,
+    }, connected_peers_2);
+    defer beam_chain_off.deinit();
+
+    try std.testing.expect(beam_chain_off.chain_worker == null);
+    // Caller still owns this clone (errdefer below frees it after the
+    // expected ChainWorkerDisabled comes back).
+    var off_cloned: types.SignedBlock = undefined;
+    try types.sszClone(std.testing.allocator, types.SignedBlock, signed_block, &off_cloned);
+    defer off_cloned.deinit();
+    try std.testing.expectError(
+        error.ChainWorkerDisabled,
+        beam_chain_off.submitBlock(off_cloned, false),
+    );
 }

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -349,6 +349,41 @@ pub fn BoundedQueue(comptime T: type) type {
 pub const BlockQueue = BoundedQueue(Message);
 pub const AttestationQueue = BoundedQueue(Message);
 
+/// Per-variant dispatch vtable.
+///
+/// The chain-worker is intentionally decoupled from `chain.zig` to
+/// avoid a circular dependency (`chain.zig` already imports this
+/// module for the queue types). Instead of `@import`-ing the chain,
+/// the worker dispatches via this vtable, which the chain wires up
+/// in `BeamChain.init` using `&self` as `ctx`.
+///
+/// All function pointers return `void`: producers fire-and-forget
+/// onto the queue (see `sendBlock` / `sendAttestation`), so there
+/// is no error channel back to them. Each handler is responsible
+/// for catching and logging its own errors. Returning anything
+/// other than `void` would force the worker to invent a
+/// reply-channel for results that nobody on the producer side
+/// is positioned to consume — gossipsub validation has already
+/// happened upstream by the time these messages are enqueued.
+///
+/// `ctx` is type-erased to `*anyopaque` so that this header has no
+/// dependency on `BeamChain`. The handler thunks in `chain.zig`
+/// `@ptrCast` the ctx back to `*BeamChain` and invoke the real
+/// chain method.
+pub const Handlers = struct {
+    ctx: *anyopaque,
+    on_block: *const fn (ctx: *anyopaque, signed_block: types.SignedBlock, prune_forkchoice: bool) void,
+    on_gossip_attestation: *const fn (ctx: *anyopaque, gossip: networks.AttestationGossip) void,
+    on_gossip_aggregated_attestation: *const fn (ctx: *anyopaque, agg: types.SignedAggregatedAttestation) void,
+    process_pending_blocks: *const fn (ctx: *anyopaque, current_slot: types.Slot) void,
+    process_finalization_followup: *const fn (
+        ctx: *anyopaque,
+        previous_finalized: types.Checkpoint,
+        latest_finalized: types.Checkpoint,
+        prune_forkchoice: bool,
+    ) void,
+};
+
 /// Default capacities. Generous enough that a 30s gossip burst on
 /// devnet4 (~3 attestations/slot × 32 validators × 8 slots ≈ 800) does
 /// not saturate. Tuned by the slice c-2 stress harness.
@@ -438,10 +473,20 @@ pub const ChainWorker = struct {
 
     logger: zeam_utils.ModuleLogger,
 
+    /// Optional dispatch vtable. `null` (the default) preserves the
+    /// c-1 stub behavior: every popped message is logged-and-freed.
+    /// Tests that only exercise the queue / wake / shutdown contracts
+    /// leave this null. Production callers in `BeamChain.init` build
+    /// a `Handlers` value using the chain as `ctx` and pass it via
+    /// `InitOpts.handlers`.
+    handlers: ?Handlers = null,
+
     pub const InitOpts = struct {
         block_queue_capacity: usize = DEFAULT_BLOCK_QUEUE_CAPACITY,
         attestation_queue_capacity: usize = DEFAULT_ATTESTATION_QUEUE_CAPACITY,
         logger: zeam_utils.ModuleLogger,
+        /// Optional dispatch vtable; see `ChainWorker.handlers`.
+        handlers: ?Handlers = null,
     };
 
     pub fn init(allocator: Allocator, opts: InitOpts) !Self {
@@ -470,6 +515,7 @@ pub const ChainWorker = struct {
             .block_queue = BlockQueue.init(block_buf, io),
             .attestation_queue = AttestationQueue.init(att_buf, io),
             .logger = opts.logger,
+            .handlers = opts.handlers,
         };
     }
 
@@ -671,30 +717,44 @@ pub const ChainWorker = struct {
         }
     }
 
-    /// c-1 stub: log the popped variant and free its heap. c-2 will
-    /// replace this with a per-variant dispatch into the chain
-    /// methods. Even after c-2 lands, the `Message.deinit` call must
-    /// remain at the bottom of every dispatch path — the worker is
-    /// the sole owner from `tryRecv` to handler return.
+    /// Per-variant dispatch into the chain (c-2b commit 3). When
+    /// `handlers` is null we fall back to the c-1 stub semantics —
+    /// log the variant and free it. This keeps the unit tests in
+    /// this module (which only stress the queue / wake / shutdown
+    /// contracts) working unchanged: they leave `handlers = null`,
+    /// so popping any message simply logs and frees.
+    ///
+    /// When `handlers` is set, we route by tag into the supplied
+    /// function pointers. Handlers are responsible for their own
+    /// error logging (the producer side fired-and-forgot the
+    /// message at queue-push time and is no longer in a position
+    /// to react). After the handler returns, `defer m.deinit()`
+    /// frees any heap-owned payload — the worker remains the sole
+    /// owner from `tryRecv` through handler return, regardless of
+    /// whether the handler succeeded or threw internally.
     fn dispatch(self: *Self, msg: Message) void {
         var m = msg;
         defer m.deinit();
+        const h = self.handlers orelse {
+            // No vtable wired (c-1 stub / queue-only tests). Log and
+            // drop: the message will be deinit'd by the defer above.
+            self.logger.warn(
+                "chain-worker: dropping message (no handlers wired): {s}",
+                .{@tagName(m)},
+            );
+            return;
+        };
         switch (m) {
-            .on_block,
-            .on_gossip_attestation,
-            .on_gossip_aggregated_attestation,
-            .process_pending_blocks,
-            .process_finalization_followup,
-            => {
-                // c-2 wires these. Until then, the worker should never
-                // receive them in production (no producer is wired).
-                // In tests we may exercise the shape; do not panic, just
-                // log so test failures are debuggable.
-                self.logger.warn(
-                    "chain-worker: unhandled message variant in c-1 scaffold: {s}",
-                    .{@tagName(m)},
-                );
-            },
+            .on_block => |payload| h.on_block(h.ctx, payload.signed_block, payload.prune_forkchoice),
+            .on_gossip_attestation => |gossip| h.on_gossip_attestation(h.ctx, gossip),
+            .on_gossip_aggregated_attestation => |agg| h.on_gossip_aggregated_attestation(h.ctx, agg),
+            .process_pending_blocks => |payload| h.process_pending_blocks(h.ctx, payload.current_slot),
+            .process_finalization_followup => |payload| h.process_finalization_followup(
+                h.ctx,
+                payload.previous_finalized,
+                payload.latest_finalized,
+                payload.prune_forkchoice,
+            ),
         }
     }
 };

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -1601,6 +1601,108 @@ test "BorrowedState: cloneAndRelease against Backing.none + acquired_rc releases
     rc.release();
 }
 
+test "lean_chain_state_refcount_distribution: writer + N readers shape (slice c-2b commit 5)" {
+    // Slice c-2b commit 5 of #803: the
+    // `lean_chain_state_refcount_distribution` histogram is updated by
+    // a scrape-time observer that samples `rc.count()` for every
+    // map-resident BeamState. This audit-pattern test verifies the
+    // distribution shape end-to-end without spinning a full BeamChain:
+    //   1. Create N RcBeamStates (writer-only — each refcount=1).
+    //   2. Observe each into the histogram — simulates the
+    //      scrape-time observer's per-entry observe call.
+    //   3. Have N readers acquireConst on each rc (refcount=2) and
+    //      observe again — simulates a scrape during reader
+    //      concurrency.
+    //   4. Drop all reader acquires (refcount=1) and observe again.
+    //   5. Release writer copies (refcount=0 — frees).
+    //   6. Scrape /metrics: the histogram series MUST be present, the
+    //      `_count` line MUST equal 3*N (three observation rounds of N
+    //      samples each).
+    //
+    // Test uses page_allocator for the same reason
+    // `LockTimer: ... metrics output` does — the histogram bucket
+    // backing storage outlives this test.
+    try zeam_metrics.init(std.heap.page_allocator);
+
+    const N: usize = 4;
+    var rcs: [N]*rc_beam_state.RcBeamState = undefined;
+    var i: usize = 0;
+    while (i < N) : (i += 1) {
+        const state = try makeTestStateForBorrowed();
+        rcs[i] = try rc_beam_state.RcBeamState.create(testing.allocator, state);
+    }
+    defer {
+        for (rcs) |rc| rc.release();
+    }
+
+    // Snapshot the histogram count BEFORE we observe anything so we
+    // can assert the delta. The histogram series may already have
+    // observations from earlier tests in this binary.
+    var alloc_writer1 = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer1.deinit();
+    try zeam_metrics.writeMetrics(&alloc_writer1.writer);
+    const body_pre = alloc_writer1.writer.buffered();
+    const count_before = parseHistogramCount(body_pre, "lean_chain_state_refcount_distribution");
+
+    // Round 1: writer-only (refcount=1 for every entry).
+    for (rcs) |rc| {
+        try testing.expectEqual(@as(u32, 1), rc.count());
+        zeam_metrics.metrics.lean_chain_state_refcount_distribution.observe(
+            @floatFromInt(rc.count()),
+        );
+    }
+
+    // Round 2: each rc has one reader acquire (refcount=2).
+    var reader_views: [N]*const rc_beam_state.RcBeamState = undefined;
+    for (rcs, 0..) |rc, k| reader_views[k] = rc.acquireConst();
+    for (rcs) |rc| {
+        try testing.expectEqual(@as(u32, 2), rc.count());
+        zeam_metrics.metrics.lean_chain_state_refcount_distribution.observe(
+            @floatFromInt(rc.count()),
+        );
+    }
+    // Drop the reader acquires.
+    for (reader_views) |v| v.release();
+
+    // Round 3: back to writer-only (refcount=1).
+    for (rcs) |rc| {
+        try testing.expectEqual(@as(u32, 1), rc.count());
+        zeam_metrics.metrics.lean_chain_state_refcount_distribution.observe(
+            @floatFromInt(rc.count()),
+        );
+    }
+
+    // Scrape and verify the histogram count grew by exactly 3*N.
+    var alloc_writer2 = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer2.deinit();
+    try zeam_metrics.writeMetrics(&alloc_writer2.writer);
+    const body_post = alloc_writer2.writer.buffered();
+
+    // Series MUST be advertised.
+    try testing.expect(std.mem.indexOf(u8, body_post, "lean_chain_state_refcount_distribution") != null);
+    // `_count` line MUST be present.
+    try testing.expect(std.mem.indexOf(u8, body_post, "lean_chain_state_refcount_distribution_count") != null);
+
+    const count_after = parseHistogramCount(body_post, "lean_chain_state_refcount_distribution");
+    try testing.expectEqual(count_before + 3 * @as(u64, @intCast(N)), count_after);
+}
+
+/// Tiny Prometheus-text parser: locate the `_count` line for a series
+/// name and return its u64 value, or 0 if not found. Tolerates labeled
+/// and unlabeled forms (the histogram in question is unlabeled).
+fn parseHistogramCount(body: []const u8, comptime series: []const u8) u64 {
+    const needle = series ++ "_count";
+    const idx = std.mem.indexOf(u8, body, needle) orelse return 0;
+    // Find the end of the line.
+    const end = std.mem.indexOfScalarPos(u8, body, idx, '\n') orelse body.len;
+    const line = body[idx..end];
+    // The count is the last whitespace-separated token on the line.
+    var it = std.mem.tokenizeAny(u8, line, " \t");
+    var last: []const u8 = "";
+    while (it.next()) |tok| last = tok;
+    return std.fmt.parseInt(u64, last, 10) catch 0;
+}
+
 test "BorrowedState: cloneAndRelease against Backing.none + acquired_rc returns owned state and releases rc" {
     // Success path: cloneAndRelease must return an owned BeamState
     // copy AND release the acquired_rc as part of self.deinit() on

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -42,6 +42,7 @@ const Allocator = std.mem.Allocator;
 const types = @import("@zeam/types");
 const zeam_metrics = @import("@zeam/metrics");
 const zeam_utils = @import("@zeam/utils");
+const rc_beam_state = @import("./rc_beam_state.zig");
 
 /// Thread-local depth counter for tier-5 sibling locks (5a/5b/5c). The design
 /// doc forbids co-holding any two of them; this counter is the runtime check
@@ -1034,15 +1035,43 @@ pub const BorrowedState = struct {
     /// long-lived borrows (especially the new states_exclusive borrow)
     /// had their hold span systematically under-reported.
     timer: ?LockTimer = null,
+    /// Optional RcBeamState refcount that gates the borrow's lifetime.
+    /// Set by the lock-free read path (slice c-2b commit 4 of #803):
+    /// when chain-worker is the sole writer to `BeamChain.states`,
+    /// `statesGet` / `getFinalizedState` cache-hit may take an
+    /// `rc.tryAcquire()` and drop the backing lock immediately,
+    /// returning a `Backing.none` borrow whose `state` pointer is
+    /// kept alive purely by this acquired refcount. `deinit` calls
+    /// `release()` on the rc AFTER any backing lock unlock so the
+    /// (potentially expensive) freeing path runs OUTSIDE the critical
+    /// section.
+    ///
+    /// Held as `*const` because the reader does not need to mutate
+    /// `state.<field>` through this borrow; the chain-worker path
+    /// takes a separate `acquireWriter` view when it needs to mutate.
+    acquired_rc: ?*const rc_beam_state.RcBeamState = null,
 
     pub const Backing = union(enum) {
         states_shared_rwlock: *zeam_utils.SyncRwLock,
         states_exclusive_rwlock: *zeam_utils.SyncRwLock,
         events_mutex: *zeam_utils.SyncMutex,
+        /// Lock-free borrow: lifetime is gated entirely by
+        /// `acquired_rc` (which MUST be non-null). Used by the
+        /// chain-worker-enabled paths in `statesGet` and
+        /// `getFinalizedState` cache-hit. `deinit` performs no lock
+        /// release on this variant — only the rc release runs.
+        none,
     };
 
-    /// Idempotent. Releases the backing lock. After a successful release
-    /// the `state` pointer must not be touched.
+    /// Idempotent. Releases the backing lock (when present) and the
+    /// acquired rc (when present). After a successful release the
+    /// `state` pointer must not be touched.
+    ///
+    /// Order: backing-lock unlock → tier-5 leave → LockTimer close →
+    /// rc release. The rc release runs LAST and OUTSIDE any backing
+    /// critical section so a refcount→0 free (which calls
+    /// `state.deinit()` + `allocator.destroy(rc)`) does not extend the
+    /// lock hold span.
     pub fn deinit(self: *BorrowedState) void {
         if (self.released) return;
         self.released = true;
@@ -1050,6 +1079,7 @@ pub const BorrowedState = struct {
             .states_shared_rwlock => |rw| rw.unlockShared(),
             .states_exclusive_rwlock => |rw| rw.unlock(),
             .events_mutex => |m| m.unlock(),
+            .none => {},
         }
         // Decrement tier-5 depth AFTER unlocking so the sibling-rule
         // assertion at the next acquire site sees the correct depth.
@@ -1065,6 +1095,13 @@ pub const BorrowedState = struct {
         // actually released. Idempotent inside LockTimer.released().
         if (self.timer) |*t| {
             t.released();
+        }
+        // Release the rc AFTER everything else so the freeing path
+        // (state.deinit + allocator.destroy when refcount→0) runs
+        // outside the critical section.
+        if (self.acquired_rc) |rc| {
+            self.acquired_rc = null;
+            rc.release();
         }
     }
 
@@ -1462,6 +1499,134 @@ test "BorrowedState: assertReleased fires only when not released" {
     borrow.deinit();
     // Should not panic — borrow is released.
     borrow.assertReleased();
+}
+
+/// Build a minimal genesis BeamState for tests in this file. Uses the
+/// canonical `BeamState.genGenesisState` constructor with a tiny
+/// validator set so the test allocator's leak detector can verify
+/// clean teardown via `BeamState.deinit`. Mirrors the helper inside
+/// `rc_beam_state.zig` (kept private to that file to avoid leaking
+/// test-only API surface).
+fn makeTestStateForBorrowed() !types.BeamState {
+    const validator_count: usize = 1;
+    const attestation_pubkeys = try testing.allocator.alloc(types.Bytes52, validator_count);
+    defer testing.allocator.free(attestation_pubkeys);
+    const proposal_pubkeys = try testing.allocator.alloc(types.Bytes52, validator_count);
+    defer testing.allocator.free(proposal_pubkeys);
+    for (attestation_pubkeys, proposal_pubkeys, 0..) |*apk, *ppk, i| {
+        @memset(apk, @intCast(i + 1));
+        @memset(ppk, @intCast(i + 1));
+    }
+    var state: types.BeamState = undefined;
+    try state.genGenesisState(testing.allocator, .{
+        .genesis_time = 0,
+        .validator_attestation_pubkeys = attestation_pubkeys,
+        .validator_proposal_pubkeys = proposal_pubkeys,
+    });
+    return state;
+}
+
+test "BorrowedState: Backing.none + acquired_rc deinit releases the rc" {
+    // Slice c-2b commit 4 of #803: the lock-free read path returns a
+    // Backing.none borrow whose lifetime is gated entirely by an
+    // RcBeamState refcount. deinit must release the rc; testing.allocator
+    // catches a leak if it does not.
+    const state = try makeTestStateForBorrowed();
+    const rc = try rc_beam_state.RcBeamState.create(testing.allocator, state);
+    // Initial refcount is 1 (matches the create contract). Bump to 2 so
+    // we can simulate the "reader holds an acquire" view; the borrow's
+    // deinit will drop one reference, and we explicitly release the
+    // remaining one ourselves to free.
+    _ = rc.acquireWriter();
+    try testing.expectEqual(@as(u32, 2), rc.count());
+
+    var borrow = BorrowedState{
+        .state = &rc.state,
+        .backing = .none,
+        .acquired_rc = rc,
+    };
+    borrow.deinit();
+    try testing.expect(borrow.released);
+    // Borrow released ONE acquire — our outer acquireWriter still holds
+    // refcount=1.
+    try testing.expectEqual(@as(u32, 1), rc.count());
+    // Idempotent: second deinit must NOT re-release.
+    borrow.deinit();
+    try testing.expectEqual(@as(u32, 1), rc.count());
+
+    // Drop the last reference — frees state + rc wrapper.
+    rc.release();
+}
+
+test "BorrowedState: Backing.none + acquired_rc deinit drives final free" {
+    // Variant: the borrow's deinit IS the final release (refcount→0).
+    // testing.allocator catches a leak if state.deinit + destroy are
+    // not run.
+    const state = try makeTestStateForBorrowed();
+    const rc = try rc_beam_state.RcBeamState.create(testing.allocator, state);
+    try testing.expectEqual(@as(u32, 1), rc.count());
+
+    var borrow = BorrowedState{
+        .state = &rc.state,
+        .backing = .none,
+        .acquired_rc = rc,
+    };
+    borrow.deinit();
+    // After this point `rc` and its wrapped state are FREED — do not
+    // touch them. (Reading `rc.count()` here would be UAF.)
+    try testing.expect(borrow.released);
+}
+
+test "BorrowedState: cloneAndRelease against Backing.none + acquired_rc releases rc on OOM" {
+    // The cloneAndRelease errdefer must run self.deinit(), which for a
+    // Backing.none borrow MUST release the acquired_rc. testing.allocator
+    // catches the leak if the errdefer doesn't fire correctly.
+    const state = try makeTestStateForBorrowed();
+    const rc = try rc_beam_state.RcBeamState.create(testing.allocator, state);
+    _ = rc.acquireWriter();
+    try testing.expectEqual(@as(u32, 2), rc.count());
+
+    var borrow = BorrowedState{
+        .state = &rc.state,
+        .backing = .none,
+        .acquired_rc = rc,
+    };
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    const failing_allocator = failing.allocator();
+    try testing.expectError(error.OutOfMemory, borrow.cloneAndRelease(failing_allocator));
+    try testing.expect(borrow.released);
+    // One reference released by deinit-via-errdefer; outer acquire still holds refcount=1.
+    try testing.expectEqual(@as(u32, 1), rc.count());
+
+    rc.release();
+}
+
+test "BorrowedState: cloneAndRelease against Backing.none + acquired_rc returns owned state and releases rc" {
+    // Success path: cloneAndRelease must return an owned BeamState
+    // copy AND release the acquired_rc as part of self.deinit() on
+    // the success branch (the second `self.deinit()` after the last
+    // `try`). testing.allocator catches a leak in either the cloned
+    // BeamState or the rc release.
+    const state = try makeTestStateForBorrowed();
+    const rc = try rc_beam_state.RcBeamState.create(testing.allocator, state);
+    _ = rc.acquireWriter();
+    try testing.expectEqual(@as(u32, 2), rc.count());
+
+    var borrow = BorrowedState{
+        .state = &rc.state,
+        .backing = .none,
+        .acquired_rc = rc,
+    };
+    const owned = try borrow.cloneAndRelease(testing.allocator);
+    try testing.expect(borrow.released);
+    // Borrow released ONE acquire; outer acquire still alive.
+    try testing.expectEqual(@as(u32, 1), rc.count());
+    // Owned clone's slot must match.
+    try testing.expectEqual(rc.state.slot, owned.slot);
+
+    owned.deinit();
+    testing.allocator.destroy(owned);
+    rc.release();
 }
 
 test "BorrowedState: cloneAndRelease releases lock on OOM-mid-clone" {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -46,6 +46,13 @@ const NodeOpts = struct {
     /// Optional worker pool for parallelizing CPU-bound chain work (signature verification).
     /// When non-null it is shared across all nodes in the same process.
     thread_pool: ?*ThreadPool = null,
+    /// Slice c-2b commit 3 of #803: when true, the chain spawns a
+    /// dedicated worker thread and producer-side handlers for
+    /// gossip blocks / attestations route through its bounded
+    /// queues instead of running synchronously on the libp2p
+    /// thread. Default `false` preserves slice-(b) behavior.
+    /// Surfaced to the CLI as `--chain-worker=on|off` (bool).
+    chain_worker_enabled: bool = false,
 };
 
 pub const BeamNode = struct {
@@ -110,6 +117,17 @@ pub const BeamNode = struct {
         errdefer {
             chain.deinit();
             allocator.destroy(chain);
+        }
+
+        // Slice c-2b commit 3 of #803: start the chain-worker AFTER
+        // the chain is at its final heap address (allocator.create +
+        // assignment-via-deref above), because the worker stores
+        // `chain` as its handler ctx and that pointer must remain
+        // stable for the worker's entire lifetime. `chain.deinit()`
+        // (above errdefer + the deinit method) tears the worker
+        // down before any chain state it might touch.
+        if (opts.chain_worker_enabled) {
+            try chain.startChainWorker();
         }
         // Now that the chain is at its final heap location, point the logger config
         // at the forkchoice slot clock so every log line carries slot/interval context.

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -129,6 +129,17 @@ pub const BeamNode = struct {
         if (opts.chain_worker_enabled) {
             try chain.startChainWorker();
         }
+
+        // Slice c-2b commit 5 of #803: register the
+        // `lean_chain_state_refcount_distribution` scrape refresher
+        // with the chain at its final heap address. The refresher
+        // iterates `chain.states` under the shared lock and samples
+        // `rc.count()` for each entry; surfaces leaked acquires (any
+        // entry stuck >16) on the /metrics endpoint. Cleared in
+        // `chain.deinit` so the metrics module never calls back into
+        // freed chain memory.
+        chain.startChainStateRefcountObserver();
+
         // Now that the chain is at its final heap location, point the logger config
         // at the forkchoice slot clock so every log line carries slot/interval context.
         opts.logger_config.slot_clock = &chain.forkChoice.fcStore.slot_clock;

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -283,6 +283,79 @@ pub const RcBeamState = struct {
         }
     }
 
+    /// Try to bump refcount, returning the same pointer on success
+    /// or `null` if the rc is already being freed (refcount has
+    /// reached 0). This is the upgrade-from-weak primitive that
+    /// makes "read pointer from a shared map without holding the
+    /// map lock" safe: a concurrent release-to-zero is detected
+    /// and the caller backs off instead of dereferencing freed
+    /// memory.
+    ///
+    /// CAS pattern (matches Rust `Arc::upgrade` / C++
+    /// `weak_ptr::lock`):
+    ///
+    ///   loop:
+    ///     load current
+    ///     if current == 0: return null  // freeing thread won
+    ///     cmpxchg(current, current+1)
+    ///     if swapped: retry             // someone else won the race
+    ///     else:        return self      // we won
+    ///
+    /// The freeing thread's claim is the `.acq_rel` `fetchSub` in
+    /// `release()` that takes refcount from 1 to 0; once that
+    /// publishes, every subsequent `tryAcquire` observes 0 and
+    /// returns null. There is no race against the free itself
+    /// because:
+    ///
+    ///   * `tryAcquire`'s cmpxchg from 0 to 1 is always rejected
+    ///     (the load returns 0 first; the if-guard short-circuits
+    ///     before cmpxchg).
+    ///   * `tryAcquire`'s cmpxchg from N>0 to N+1 only succeeds
+    ///     while the freeing thread has not yet committed its
+    ///     `fetchSub(1)` from 1 to 0 — i.e. while the rc is still
+    ///     alive.
+    ///
+    /// SAFETY PRECONDITION: the caller must guarantee that `self`
+    /// is a valid `*Self` (not a dangling pointer to freed memory).
+    /// The typical pattern is to read the pointer from a shared
+    /// data structure (e.g. `BeamChain.states.get(root)`) under
+    /// some membership invariant: as long as the pointer is in the
+    /// map, the underlying allocation is alive, and `tryAcquire`
+    /// then resolves the in-flight free race. Holding the map lock
+    /// across the read AND the `tryAcquire` makes this trivially
+    /// safe; dropping the lock in c-2b is what motivates this
+    /// primitive in the first place. The c-2b removal-protocol
+    /// requires "remove-from-map then release" so the pointer is
+    /// guaranteed alive at any time it is reachable through the
+    /// map.
+    ///
+    /// Memory ordering: `.monotonic` on both load and the cmpxchg
+    /// success/failure orderings. The increment side does not need
+    /// to synchronise (caller of a successful `tryAcquire` then
+    /// holds a valid acquire and any subsequent reads of `state`
+    /// are ordered by the producer's prior `.release` decrement
+    /// when the producer eventually releases its own ref). For the
+    /// freeing thread's visibility guarantee, see the `release`
+    /// docstring.
+    pub fn tryAcquire(self: *Self) ?*Self {
+        var current = self.refcount.load(.monotonic);
+        while (true) {
+            if (current == 0) return null;
+            if (self.refcount.cmpxchgWeak(
+                current,
+                current + 1,
+                .monotonic,
+                .monotonic,
+            )) |actual| {
+                current = actual;
+            } else {
+                // CAS succeeded; we won the race.
+                std.debug.assert(current < std.math.maxInt(u32));
+                return self;
+            }
+        }
+    }
+
     /// Snapshot the current refcount. For tests + metrics only; do
     /// NOT branch on this value to decide whether to release. Reads
     /// are `.monotonic` because the only correct uses are
@@ -699,6 +772,153 @@ test "RcBeamState.acquireConst: concurrent readers free cleanly when creator dro
 
         i = 0;
         while (i < NUM_READERS) : (i += 1) {
+            threads[i].join();
+        }
+    }
+}
+
+test "RcBeamState.tryAcquire: succeeds when rc is alive (basic case)" {
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    defer rc.release();
+    // refcount = 1
+    const got = rc.tryAcquire();
+    try testing.expect(got != null);
+    try testing.expectEqual(rc, got.?);
+    try testing.expectEqual(@as(u32, 2), rc.count());
+    got.?.release();
+    try testing.expectEqual(@as(u32, 1), rc.count());
+}
+
+test "RcBeamState.tryAcquire: increments refcount under producer race" {
+    // Same shape as the existing pair-accounting test but using
+    // tryAcquire instead of acquireWriter. Each thread does a
+    // tryAcquire (which must succeed because the creator holds
+    // a valid reference), reads, releases. Creator's refcount=1
+    // is held throughout; tryAcquire never observes 0.
+    const NUM_THREADS: usize = 32;
+    const ITERS_PER_THREAD: usize = 1_000;
+
+    const Worker = struct {
+        fn run(rc: *RcBeamState, iters: usize) void {
+            var i: usize = 0;
+            while (i < iters) : (i += 1) {
+                const got = rc.tryAcquire() orelse {
+                    // Should never happen: creator holds a ref so
+                    // refcount is always >= 1.
+                    @panic("tryAcquire returned null while creator held ref");
+                };
+                std.mem.doNotOptimizeAway(got.state.slot);
+                got.release();
+            }
+        }
+    };
+
+    const state = try makeState();
+    const rc = try RcBeamState.create(testing.allocator, state);
+    defer rc.release();
+
+    var threads: [NUM_THREADS]std.Thread = undefined;
+    var i: usize = 0;
+    while (i < NUM_THREADS) : (i += 1) {
+        threads[i] = try std.Thread.spawn(.{}, Worker.run, .{ rc, ITERS_PER_THREAD });
+    }
+    i = 0;
+    while (i < NUM_THREADS) : (i += 1) {
+        threads[i].join();
+    }
+    try testing.expectEqual(@as(u32, 1), rc.count());
+}
+
+test "RcBeamState.tryAcquire: returns null after refcount reaches 0" {
+    // White-box test: drop the refcount to 0 manually (simulating
+    // the freeing thread's commit) BEFORE calling tryAcquire, then
+    // verify tryAcquire short-circuits to null without bumping.
+    //
+    // We can't actually let release() free the wrapper here —
+    // we'd be calling tryAcquire on freed memory, which is UAF
+    // even with our short-circuit. So we use a hand-rolled fixture
+    // that bypasses the destroy() so the wrapper memory stays alive
+    // for the test's read. testing.allocator's leak detector ignores
+    // this fixture because we destroy it manually at the end.
+    const state = try makeState();
+    const wrapper = try testing.allocator.create(RcBeamState);
+    wrapper.* = .{
+        .allocator = testing.allocator,
+        .refcount = std.atomic.Value(u32).init(0), // simulate post-free state
+        .state = state,
+    };
+    defer {
+        // Manual cleanup: the wrapper's state was never released
+        // through the normal path because we forced refcount to 0.
+        wrapper.state.deinit();
+        testing.allocator.destroy(wrapper);
+    }
+
+    const got = wrapper.tryAcquire();
+    try testing.expect(got == null);
+    try testing.expectEqual(@as(u32, 0), wrapper.count()); // no increment
+}
+
+test "RcBeamState.tryAcquire: race against release-to-zero — producer + freer" {
+    // Stress test: one freeing thread, N tryAcquire'rs. The
+    // freeing thread starts holding the only reference (refcount=1)
+    // and releases. The N tryAcquire'rs each loop trying to bump.
+    // The acceptable outcomes for each tryAcquire call are:
+    //   (a) succeed (refcount was >0 when CAS won) — in which
+    //       case the caller MUST release exactly once.
+    //   (b) fail (refcount hit 0 first) — caller does nothing.
+    // testing.allocator's leak detector verifies that every
+    // successful tryAcquire is matched by a release, and that the
+    // wrapper is freed exactly once.
+    //
+    // Because the wrapper may be freed at any moment after the
+    // freer's release, callers can't safely call tryAcquire on a
+    // dangling pointer. To make this a valid test we have each
+    // tryAcquire'r take its own pre-bump on the spawn thread (so
+    // it enters the worker holding a valid reference), then the
+    // worker's body itself calls tryAcquire on a SECOND reference
+    // it could legally observe. This still exercises the freer's
+    // observed-from-outside CAS pattern: the freer is dropping
+    // its own ref while concurrent tryAcquires run.
+    const NUM_TRIERS: usize = 16;
+    const OUTER_ITERS: usize = 50;
+
+    const Trier = struct {
+        fn run(handed: *RcBeamState) void {
+            // We hold one valid reference (handed). While we hold
+            // it, refcount is >= 1, so any tryAcquire on this rc
+            // MUST succeed. This is the safety-precondition path.
+            const got = handed.tryAcquire() orelse {
+                @panic("tryAcquire failed while we held a ref");
+            };
+            std.mem.doNotOptimizeAway(got.state.slot);
+            got.release();    // drop the tryAcquire bump
+            handed.release(); // drop the pre-bump
+        }
+    };
+
+    var outer: usize = 0;
+    while (outer < OUTER_ITERS) : (outer += 1) {
+        const state = try makeState();
+        const rc = try RcBeamState.create(testing.allocator, state);
+        // refcount = 1 (creator)
+
+        var threads: [NUM_TRIERS]std.Thread = undefined;
+        var i: usize = 0;
+        while (i < NUM_TRIERS) : (i += 1) {
+            const handed = rc.acquireWriter();
+            threads[i] = std.Thread.spawn(.{}, Trier.run, .{handed}) catch |err| {
+                handed.release();
+                return err;
+            };
+        }
+        // Drop creator's ref while triers are still running. The
+        // last release — from any thread — frees.
+        rc.release();
+
+        i = 0;
+        while (i < NUM_TRIERS) : (i += 1) {
             threads[i].join();
         }
     }

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -893,7 +893,7 @@ test "RcBeamState.tryAcquire: race against release-to-zero — producer + freer"
                 @panic("tryAcquire failed while we held a ref");
             };
             std.mem.doNotOptimizeAway(got.state.slot);
-            got.release();    // drop the tryAcquire bump
+            got.release(); // drop the tryAcquire bump
             handed.release(); // drop the pre-bump
         }
     };

--- a/pkgs/node/src/rc_beam_state.zig
+++ b/pkgs/node/src/rc_beam_state.zig
@@ -860,27 +860,45 @@ test "RcBeamState.tryAcquire: returns null after refcount reaches 0" {
     try testing.expectEqual(@as(u32, 0), wrapper.count()); // no increment
 }
 
-test "RcBeamState.tryAcquire: race against release-to-zero — producer + freer" {
-    // Stress test: one freeing thread, N tryAcquire'rs. The
-    // freeing thread starts holding the only reference (refcount=1)
-    // and releases. The N tryAcquire'rs each loop trying to bump.
-    // The acceptable outcomes for each tryAcquire call are:
-    //   (a) succeed (refcount was >0 when CAS won) — in which
-    //       case the caller MUST release exactly once.
-    //   (b) fail (refcount hit 0 first) — caller does nothing.
-    // testing.allocator's leak detector verifies that every
-    // successful tryAcquire is matched by a release, and that the
-    // wrapper is freed exactly once.
+test "RcBeamState.tryAcquire: succeeds while caller holds a pre-bump (no UAF under release-to-zero of separate ref)" {
+    // Renamed from "race against release-to-zero — producer + freer"
+    // because that title oversold what the test actually exercises
+    // (PR #828 review by @ch4r10t33r):
     //
-    // Because the wrapper may be freed at any moment after the
-    // freer's release, callers can't safely call tryAcquire on a
-    // dangling pointer. To make this a valid test we have each
-    // tryAcquire'r take its own pre-bump on the spawn thread (so
-    // it enters the worker holding a valid reference), then the
-    // worker's body itself calls tryAcquire on a SECOND reference
-    // it could legally observe. This still exercises the freer's
-    // observed-from-outside CAS pattern: the freer is dropping
-    // its own ref while concurrent tryAcquires run.
+    // Each Trier thread is HANDED its own pre-bumped reference by
+    // the spawning thread (`rc.acquireWriter()` before spawn). So
+    // for the entire body of `Trier.run`, refcount is >= 1 — the
+    // Trier itself is one of the holders. `tryAcquire` on that rc
+    // MUST therefore succeed (the panic-on-null in the body proves
+    // the test ASSUMES success). The freeing thread (the spawning
+    // thread, after dropping the creator ref) is racing the Triers'
+    // releases, but it never races a tryAcquire-vs-zero observation
+    // because every tryAcquire-caller is itself a refcount holder.
+    //
+    // What the test DOES prove (which is still useful):
+    //   * No UAF: the wrapper is freed exactly once, by whichever
+    //     thread observes the last release — testing.allocator's
+    //     leak detector + double-free detector are the witnesses.
+    //   * Refcount accounting under contention: every successful
+    //     tryAcquire is matched by exactly one release, regardless
+    //     of interleaving.
+    //   * The CAS loop in tryAcquire is safe under concurrent
+    //     release pressure on a SEPARATE reference (the creator's
+    //     ref being dropped while Triers are running).
+    //
+    // What the test CANNOT prove (and why no test can):
+    //   tryAcquire returning null in a multi-threaded race against
+    //   release-to-zero is unreachable by safe code, because
+    //   tryAcquire's SAFETY PRECONDITION (lines 318–330) requires
+    //   the caller to hold a reference (or otherwise know the rc
+    //   wrapper is alive) at the moment of the call. Calling
+    //   tryAcquire on a freed wrapper IS a UAF. The null-return
+    //   path is exercised by the white-box test above
+    //   (`returns null after refcount reaches 0`) which manually
+    //   sets refcount=0 on a wrapper whose destroy() it skips.
+    //   That is the only safe shape, and it's the right one
+    //   because the docstring's safety preconditions ARE the
+    //   contract surface tryAcquire offers.
     const NUM_TRIERS: usize = 16;
     const OUTER_ITERS: usize = 50;
 

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -753,6 +753,466 @@ fn runStress(allocator: Allocator, cfg: StressConfig) !StressSummary {
     };
 }
 
+// =====================================================================
+// Saturation mode — slice (c-2c) commit 6 of #803.
+//
+// The default mode above (`runStress`) drives `chain.onBlock` /
+// `chain.onGossipAttestation` directly on producer threads, exercising
+// the per-resource locks under contention. The saturation mode here
+// drives the chain-worker QUEUES instead, by calling `submitBlock` /
+// `submitGossipAttestation` from N producer threads while a single
+// chain-worker thread drains. The queues are bounded; producers are
+// expected to observe `error.QueueFull` whenever they outpace the
+// drainer. The mode verifies:
+//
+//   * Backpressure is correctly observed (QueueFull seen on both
+//     queues).
+//   * No lost producer-side accounting (every send_attempt accounted
+//     for as ok|queue_full|other_err).
+//   * The drainer makes progress (some sends succeed on both queues,
+//     so the worker is not deadlocked behind something else).
+//   * No panic / UAF (DebugAllocator + testing.allocator-grade
+//     bookkeeping in the chain).
+//
+// This is the c-2c part-1 deliverable. Part-2 is the devnet4 burn-in,
+// which is NOT gated on this PR.
+//
+// Producers that observe `error.QueueFull` retain ownership of their
+// payload (per the c-2b commit-3 contract on `submitBlock` /
+// `submitGossipAttestation`) and must `deinit()` the payload. The
+// success path transfers ownership to the worker (which calls
+// `Message.deinit` after dispatch) so the producer must NOT also free
+// it. Both code paths below honor that contract — review them when
+// touching the cleanup logic.
+
+const SaturationConfig = struct {
+    duration_secs: u64,
+    num_blocks: usize,
+    block_producer_threads: usize,
+    attestation_producer_threads: usize,
+    watchdog_stall_secs: u64,
+
+    fn fromEnv(allocator: Allocator) !SaturationConfig {
+        _ = allocator;
+        return SaturationConfig{
+            .duration_secs = StressConfig.readEnvU64("ZEAM_STRESS_DURATION_SECS", 30),
+            .num_blocks = StressConfig.readEnvUsize("ZEAM_STRESS_NUM_BLOCKS", 6),
+            // 4 producers per queue is enough to outpace the single
+            // worker on every devnet-class machine we've measured. The
+            // env knobs let CI dial down on slower runners.
+            .block_producer_threads = StressConfig.readEnvUsize("ZEAM_STRESS_SAT_BLOCK_PRODUCERS", 4),
+            .attestation_producer_threads = StressConfig.readEnvUsize("ZEAM_STRESS_SAT_ATTN_PRODUCERS", 4),
+            .watchdog_stall_secs = StressConfig.readEnvU64("ZEAM_STRESS_WATCHDOG_SECS", 60),
+        };
+    }
+
+    fn dump(self: SaturationConfig) void {
+        std.debug.print(
+            "saturation config: duration={d}s num_blocks={d} block_producers={d} attn_producers={d} watchdog={d}s\n",
+            .{
+                self.duration_secs,
+                self.num_blocks,
+                self.block_producer_threads,
+                self.attestation_producer_threads,
+                self.watchdog_stall_secs,
+            },
+        );
+    }
+};
+
+const SaturationCtx = struct {
+    chain: *BeamChain,
+    blocks: []types.SignedBlock,
+    block_roots: []types.Root,
+    key_manager: *keymanager.KeyManager,
+    deadline_ns: i128,
+    watchdog_stall_ns: i128,
+    watchdog_stall_secs: u64,
+    stop: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+    // Per-queue counters. Every producer attempt lands in exactly one
+    // of {send_ok, queue_full, other_err}. The summary asserts
+    // attempts == ok + queue_full + other_err so a regression that
+    // "loses" a producer-side count is visible.
+    block_attempts: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    block_send_ok: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    block_queue_full: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    block_other_err: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    attn_attempts: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    attn_send_ok: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    attn_queue_full: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+    attn_other_err: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    fatal: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    fatal_msg: [256]u8 = undefined,
+    fatal_msg_len: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+
+    fn shouldStop(self: *SaturationCtx) bool {
+        if (self.stop.load(.acquire)) return true;
+        const now = zeam_utils.monotonicTimestampNs();
+        if (now >= self.deadline_ns) {
+            self.stop.store(true, .release);
+            return true;
+        }
+        return false;
+    }
+
+    fn totalSendOk(self: *SaturationCtx) u64 {
+        return self.block_send_ok.load(.monotonic) + self.attn_send_ok.load(.monotonic);
+    }
+    fn totalQueueFull(self: *SaturationCtx) u64 {
+        return self.block_queue_full.load(.monotonic) + self.attn_queue_full.load(.monotonic);
+    }
+
+    fn recordFatal(self: *SaturationCtx, comptime fmt: []const u8, args: anytype) void {
+        if (self.fatal.swap(true, .acq_rel)) return;
+        const msg = std.fmt.bufPrint(&self.fatal_msg, fmt, args) catch &self.fatal_msg;
+        self.fatal_msg_len.store(msg.len, .release);
+        self.stop.store(true, .release);
+    }
+};
+
+fn saturationBlockProducerWorker(ctx: *SaturationCtx, thread_id: usize) void {
+    const allocator = ctx.chain.allocator;
+    var i: usize = 0;
+    while (!ctx.shouldStop()) : (i += 1) {
+        // Cycle through pre-imported blocks (skip genesis at index 0).
+        const block_idx = (i % (ctx.blocks.len - 1)) + 1;
+        const template = ctx.blocks[block_idx];
+
+        // Clone: submitBlock takes ownership of the SignedBlock on a
+        // successful send (the worker calls Message.deinit after
+        // dispatch). On QueueFull / QueueClosed / ChainWorkerDisabled,
+        // the producer retains ownership and MUST deinit the clone.
+        var cloned: types.SignedBlock = undefined;
+        types.sszClone(allocator, types.SignedBlock, template, &cloned) catch {
+            _ = ctx.block_attempts.fetchAdd(1, .monotonic);
+            _ = ctx.block_other_err.fetchAdd(1, .monotonic);
+            continue;
+        };
+
+        _ = ctx.block_attempts.fetchAdd(1, .monotonic);
+        ctx.chain.submitBlock(cloned, false) catch |err| {
+            // We retain ownership on every error path — free the clone.
+            cloned.deinit();
+            switch (err) {
+                error.QueueFull => _ = ctx.block_queue_full.fetchAdd(1, .monotonic),
+                error.QueueClosed => _ = ctx.block_other_err.fetchAdd(1, .monotonic),
+                error.ChainWorkerDisabled => {
+                    ctx.recordFatal(
+                        "sat-block-producer (thread {d}): submitBlock returned ChainWorkerDisabled — chain-worker MUST be running for the saturation mode",
+                        .{thread_id},
+                    );
+                    _ = ctx.block_other_err.fetchAdd(1, .monotonic);
+                    return;
+                },
+            }
+            continue;
+        };
+        _ = ctx.block_send_ok.fetchAdd(1, .monotonic);
+    }
+}
+
+fn saturationAttestationProducerWorker(ctx: *SaturationCtx, thread_id: usize) void {
+    const allocator = ctx.chain.allocator;
+    var prng = std.Random.DefaultPrng.init(0xA77E57 ^ @as(u64, @intCast(thread_id)));
+    const rand = prng.random();
+    while (!ctx.shouldStop()) {
+        // Pick a random valid (block_idx, validator_id) pair like the
+        // default attestationSpammerWorker does. We only need
+        // submit-side throughput here; the worker thread does the
+        // real verification work.
+        const slot_idx = rand.uintAtMost(usize, ctx.block_roots.len - 1);
+        const target_root = ctx.block_roots[slot_idx];
+        const target_slot: types.Slot = ctx.blocks[slot_idx].block.slot;
+        const source_idx = if (slot_idx > 1) slot_idx - 1 else 0;
+        const validator_id = rand.uintLessThan(usize, 4);
+
+        const message = types.Attestation{
+            .validator_id = @intCast(validator_id),
+            .data = .{
+                .slot = target_slot,
+                .head = .{ .root = target_root, .slot = target_slot },
+                .source = .{
+                    .root = ctx.block_roots[source_idx],
+                    .slot = ctx.blocks[source_idx].block.slot,
+                },
+                .target = .{ .root = target_root, .slot = target_slot },
+            },
+        };
+
+        const signature = ctx.key_manager.signAttestation(&message, allocator) catch {
+            _ = ctx.attn_attempts.fetchAdd(1, .monotonic);
+            _ = ctx.attn_other_err.fetchAdd(1, .monotonic);
+            continue;
+        };
+
+        const valid_attestation = types.SignedAttestation{
+            .validator_id = message.validator_id,
+            .message = message.data,
+            .signature = signature,
+        };
+        const subnet_id = types.computeSubnetId(
+            @intCast(valid_attestation.validator_id),
+            ctx.chain.config.spec.attestation_committee_count,
+        ) catch {
+            _ = ctx.attn_attempts.fetchAdd(1, .monotonic);
+            _ = ctx.attn_other_err.fetchAdd(1, .monotonic);
+            continue;
+        };
+        const gossip_attestation = networks.AttestationGossip{
+            .subnet_id = @intCast(subnet_id),
+            .message = valid_attestation,
+        };
+
+        _ = ctx.attn_attempts.fetchAdd(1, .monotonic);
+        // submitGossipAttestation takes the AttestationGossip by
+        // value; on QueueFull it returns and the producer retains the
+        // value. AttestationGossip currently has no owned heap fields
+        // (the SignedAttestation payload is a value type with a fixed
+        // signature buffer), so there is nothing to free on the error
+        // path — the value goes out of scope. If a future change
+        // adds heap-bearing fields, this branch needs a corresponding
+        // deinit().
+        ctx.chain.submitGossipAttestation(gossip_attestation) catch |err| {
+            switch (err) {
+                error.QueueFull => _ = ctx.attn_queue_full.fetchAdd(1, .monotonic),
+                error.QueueClosed => _ = ctx.attn_other_err.fetchAdd(1, .monotonic),
+                error.ChainWorkerDisabled => {
+                    ctx.recordFatal(
+                        "sat-attn-producer (thread {d}): submitGossipAttestation returned ChainWorkerDisabled — chain-worker MUST be running for the saturation mode",
+                        .{thread_id},
+                    );
+                    _ = ctx.attn_other_err.fetchAdd(1, .monotonic);
+                    return;
+                },
+            }
+            continue;
+        };
+        _ = ctx.attn_send_ok.fetchAdd(1, .monotonic);
+    }
+}
+
+fn saturationWatchdogWorker(ctx: *SaturationCtx) void {
+    // Saturation-specific watchdog: progress = sends OR queue-fulls.
+    // "No queue-fulls AND no sends" for >stall_secs means producers
+    // are deadlocked. Either signal alone is fine — sends-only means
+    // the worker is keeping up, queue-fulls-only means the producers
+    // are running but the worker is stalled (which is also caught by
+    // the post-run assertion that some sends succeeded).
+    var last_progress = ctx.totalSendOk() + ctx.totalQueueFull();
+    var last_progress_ns: i128 = zeam_utils.monotonicTimestampNs();
+
+    while (!ctx.shouldStop()) {
+        sleepSecs(2);
+        const now = zeam_utils.monotonicTimestampNs();
+        const cur = ctx.totalSendOk() + ctx.totalQueueFull();
+        if (cur != last_progress) {
+            last_progress = cur;
+            last_progress_ns = now;
+            continue;
+        }
+        if (now - last_progress_ns > ctx.watchdog_stall_ns) {
+            ctx.recordFatal(
+                "saturation watchdog: no producer progress for {d}s — likely deadlock (send_ok + queue_full counters not advancing)",
+                .{ctx.watchdog_stall_secs},
+            );
+            return;
+        }
+    }
+}
+
+const SaturationSummary = struct {
+    duration_secs: f64,
+    block_attempts: u64,
+    block_send_ok: u64,
+    block_queue_full: u64,
+    block_other_err: u64,
+    attn_attempts: u64,
+    attn_send_ok: u64,
+    attn_queue_full: u64,
+    attn_other_err: u64,
+    fatal: bool,
+    fatal_msg: []const u8,
+    final_states_len: usize,
+};
+
+fn runStressSaturation(allocator: Allocator, cfg: SaturationConfig) !SaturationSummary {
+    cfg.dump();
+
+    // 1. Build mock chain.
+    std.debug.print("building mock chain ({d} blocks)...\n", .{cfg.num_blocks});
+    var arena_allocator = std.heap.ArenaAllocator.init(allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, cfg.num_blocks, null);
+
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    var data_dir_buf: [256]u8 = undefined;
+    const ts: u64 = @as(u64, @intCast(@max(zeam_utils.monotonicTimestampNs(), 0)));
+    const pid: u64 = @intCast(std.c.getpid());
+    const data_dir = try std.fmt.bufPrint(&data_dir_buf, ".zig-cache/tmp/zeam-stress-sat-{d}-{d}", .{ pid, ts });
+    const io = std.Io.Threaded.global_single_threaded.io();
+    try std.Io.Dir.cwd().createDirPath(io, data_dir);
+    defer std.Io.Dir.cwd().deleteTree(io, data_dir) catch {};
+
+    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database), data_dir);
+    defer db.deinit();
+
+    const connected_peers = try allocator.create(ConnectedPeers);
+    defer allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try allocator.create(NodeNameRegistry);
+    defer allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 99,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    // 2. Pre-import all blocks (synchronously, before starting the
+    // worker). This populates `states`, forkChoice, db with valid
+    // entries so the worker's onBlock calls hit the kept_existing
+    // path of statesCommitKeepExisting.
+    std.debug.print("pre-importing blocks...\n", .{});
+    for (1..mock_chain.blocks.len) |i| {
+        const block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing = try beam_chain.onBlock(block, .{ .pruneForkchoice = false });
+        allocator.free(missing);
+    }
+    const last_slot = mock_chain.blocks[mock_chain.blocks.len - 1].block.slot;
+    try beam_chain.forkChoice.onInterval((last_slot + 4) * constants.INTERVALS_PER_SLOT, false);
+
+    // 3. Start the chain-worker. Saturation mode REQUIRES the worker
+    // to be running — producers route through `submitBlock` /
+    // `submitGossipAttestation` which return `ChainWorkerDisabled`
+    // when no worker is set. The deinit ordering above is correct:
+    // BeamChain.deinit calls chain_worker.stop() first.
+    try beam_chain.startChainWorker();
+    std.debug.print("chain-worker started; entering saturation mode\n", .{});
+
+    // 4. KeyManager for attestation signing.
+    var attn_keymanager = try keymanager.getTestKeyManager(allocator, 4, cfg.num_blocks);
+    defer attn_keymanager.deinit();
+
+    // 5. Spin up workers.
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns = start_ns + @as(i128, @intCast(cfg.duration_secs)) * std.time.ns_per_s;
+
+    var ctx = SaturationCtx{
+        .chain = &beam_chain,
+        .blocks = mock_chain.blocks,
+        .block_roots = mock_chain.blockRoots,
+        .key_manager = &attn_keymanager,
+        .deadline_ns = deadline_ns,
+        .watchdog_stall_ns = @as(i128, @intCast(cfg.watchdog_stall_secs)) *
+            std.time.ns_per_s,
+        .watchdog_stall_secs = cfg.watchdog_stall_secs,
+    };
+
+    const total_threads = cfg.block_producer_threads + cfg.attestation_producer_threads + 1;
+    const threads = try allocator.alloc(std.Thread, total_threads);
+    defer allocator.free(threads);
+
+    var ti: usize = 0;
+    for (0..cfg.block_producer_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, saturationBlockProducerWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    for (0..cfg.attestation_producer_threads) |k| {
+        threads[ti] = try std.Thread.spawn(.{}, saturationAttestationProducerWorker, .{ &ctx, k });
+        ti += 1;
+    }
+    threads[ti] = try std.Thread.spawn(.{}, saturationWatchdogWorker, .{&ctx});
+    ti += 1;
+
+    // 6. Periodic progress prints (every 10s for the typically-short
+    // saturation runs). Final summary line MUST include
+    // `errs g=N a=M b=K queue_full_b=X queue_full_a=Y` so a CI grep
+    // can spot regressions easily.
+    const progress_interval_ns: i128 = 10 * std.time.ns_per_s;
+    var next_progress_ns = start_ns + progress_interval_ns;
+    while (!ctx.shouldStop()) {
+        sleepSecs(1);
+        const now = zeam_utils.monotonicTimestampNs();
+        if (now >= next_progress_ns) {
+            const elapsed_s: f64 = @as(f64, @floatFromInt(now - start_ns)) / @as(f64, std.time.ns_per_s);
+            std.debug.print(
+                "[+{d:.0}s] block(ok={d} qfull={d} err={d}) attn(ok={d} qfull={d} err={d})\n",
+                .{
+                    elapsed_s,
+                    ctx.block_send_ok.load(.monotonic),
+                    ctx.block_queue_full.load(.monotonic),
+                    ctx.block_other_err.load(.monotonic),
+                    ctx.attn_send_ok.load(.monotonic),
+                    ctx.attn_queue_full.load(.monotonic),
+                    ctx.attn_other_err.load(.monotonic),
+                },
+            );
+            next_progress_ns += progress_interval_ns;
+        }
+    }
+
+    // 7. Join.
+    for (threads) |t| t.join();
+
+    const end_ns = zeam_utils.monotonicTimestampNs();
+    const duration_secs: f64 = @as(f64, @floatFromInt(end_ns - start_ns)) / @as(f64, std.time.ns_per_s);
+
+    beam_chain.states_lock.lockShared();
+    const final_states_len = beam_chain.states.count();
+    beam_chain.states_lock.unlockShared();
+
+    const fatal_len = ctx.fatal_msg_len.load(.acquire);
+    const fatal_msg_slice: []const u8 = if (fatal_len > 0) ctx.fatal_msg[0..fatal_len] else "";
+
+    return SaturationSummary{
+        .duration_secs = duration_secs,
+        .block_attempts = ctx.block_attempts.load(.monotonic),
+        .block_send_ok = ctx.block_send_ok.load(.monotonic),
+        .block_queue_full = ctx.block_queue_full.load(.monotonic),
+        .block_other_err = ctx.block_other_err.load(.monotonic),
+        .attn_attempts = ctx.attn_attempts.load(.monotonic),
+        .attn_send_ok = ctx.attn_send_ok.load(.monotonic),
+        .attn_queue_full = ctx.attn_queue_full.load(.monotonic),
+        .attn_other_err = ctx.attn_other_err.load(.monotonic),
+        .fatal = ctx.fatal.load(.acquire),
+        .fatal_msg = fatal_msg_slice,
+        .final_states_len = final_states_len,
+    };
+}
+
 pub fn main() !void {
     var gpa = std.heap.DebugAllocator(.{
         .safety = true,
@@ -762,8 +1222,26 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     std.debug.print("=== zeam single-node ingestion stress harness ===\n", .{});
-    std.debug.print("issue #803 slice (b) merge gate. design doc:\n", .{});
+    std.debug.print("issue #803 slice (b)/(c-2c) merge gates. design doc:\n", .{});
     std.debug.print("  docs/threading_refactor_slice_a.md §Stress test plan\n", .{});
+
+    // Mode dispatch: ZEAM_STRESS_MODE=default (the slice-(b) merge
+    // gate, default) or ZEAM_STRESS_MODE=saturation (slice (c-2c)
+    // commit 6 — chain-worker queue saturation).
+    const mode_ptr = std.c.getenv("ZEAM_STRESS_MODE");
+    const mode: []const u8 = if (mode_ptr) |p| std.mem.sliceTo(p, 0) else "default";
+
+    if (std.mem.eql(u8, mode, "saturation")) {
+        try runSaturationMain(allocator);
+        return;
+    }
+    if (!std.mem.eql(u8, mode, "default")) {
+        std.debug.print(
+            "FATAL: unknown ZEAM_STRESS_MODE={s} (expected: default|saturation)\n",
+            .{mode},
+        );
+        std.process.exit(2);
+    }
 
     const cfg = try StressConfig.fromEnv(allocator);
 
@@ -811,4 +1289,161 @@ pub fn main() !void {
         std.process.exit(1);
     }
     std.debug.print("\nclean exit — no panics, no UAFs, no deadlocks observed\n", .{});
+}
+
+/// Saturation-mode entry point. Mirrors `main()`'s default-mode flow
+/// but runs the saturation harness, prints a saturation-shaped
+/// summary, and applies the saturation-mode assertions.
+fn runSaturationMain(allocator: Allocator) !void {
+    std.debug.print("mode: saturation (slice c-2c commit 6 of #803)\n", .{});
+
+    const cfg = try SaturationConfig.fromEnv(allocator);
+
+    const summary = runStressSaturation(allocator, cfg) catch |err| {
+        std.debug.print("FATAL: saturation harness errored: {s}\n", .{@errorName(err)});
+        return err;
+    };
+
+    const total_attempts = summary.block_attempts + summary.attn_attempts;
+    const total_ok = summary.block_send_ok + summary.attn_send_ok;
+    const total_qfull = summary.block_queue_full + summary.attn_queue_full;
+    const total_err = summary.block_other_err + summary.attn_other_err;
+    const ops_per_sec: f64 = if (summary.duration_secs > 0)
+        @as(f64, @floatFromInt(total_attempts)) / summary.duration_secs
+    else
+        0;
+
+    std.debug.print("\n=== saturation run summary ===\n", .{});
+    std.debug.print("duration: {d:.1}s\n", .{summary.duration_secs});
+    std.debug.print("total attempts: {d} ({d:.0} attempts/sec)\n", .{ total_attempts, ops_per_sec });
+    std.debug.print("  block: attempts={d} ok={d} queue_full={d} other_err={d}\n", .{
+        summary.block_attempts,
+        summary.block_send_ok,
+        summary.block_queue_full,
+        summary.block_other_err,
+    });
+    std.debug.print("  attn : attempts={d} ok={d} queue_full={d} other_err={d}\n", .{
+        summary.attn_attempts,
+        summary.attn_send_ok,
+        summary.attn_queue_full,
+        summary.attn_other_err,
+    });
+    std.debug.print("final state: states_len={d}\n", .{summary.final_states_len});
+    // Compact CI-friendly summary line. Match the shape used by the
+    // default-mode summary so a single grep pattern catches both
+    // mode regressions:
+    //   `errs g=N a=M b=K queue_full_b=X queue_full_a=Y`
+    // (g/a/b are inherited names from the slice-(b) summary; we map
+    //  block_other_err→g, attn_other_err→a, total—b stays 0 here
+    //  since saturation has no borrow worker).
+    std.debug.print(
+        "errs g={d} a={d} b=0 queue_full_b={d} queue_full_a={d}\n",
+        .{
+            summary.block_other_err,
+            summary.attn_other_err,
+            summary.block_queue_full,
+            summary.attn_queue_full,
+        },
+    );
+
+    if (summary.fatal) {
+        std.debug.print("\nFATAL: {s}\n", .{summary.fatal_msg});
+        std.process.exit(1);
+    }
+
+    // Saturation-mode invariants. Each one is a regression on a
+    // separate property of the chain-worker queue plumbing; group
+    // failures so a CI failure is self-explaining.
+    var failed = false;
+
+    // (1) Producer-side accounting balances: attempts == ok + qfull + other_err.
+    if (summary.block_attempts != summary.block_send_ok + summary.block_queue_full + summary.block_other_err) {
+        std.debug.print(
+            "\nFATAL: block accounting mismatch — attempts={d} but ok+qfull+err={d}+{d}+{d}={d}\n",
+            .{
+                summary.block_attempts,
+                summary.block_send_ok,
+                summary.block_queue_full,
+                summary.block_other_err,
+                summary.block_send_ok + summary.block_queue_full + summary.block_other_err,
+            },
+        );
+        failed = true;
+    }
+    if (summary.attn_attempts != summary.attn_send_ok + summary.attn_queue_full + summary.attn_other_err) {
+        std.debug.print(
+            "\nFATAL: attn accounting mismatch — attempts={d} but ok+qfull+err={d}+{d}+{d}={d}\n",
+            .{
+                summary.attn_attempts,
+                summary.attn_send_ok,
+                summary.attn_queue_full,
+                summary.attn_other_err,
+                summary.attn_send_ok + summary.attn_queue_full + summary.attn_other_err,
+            },
+        );
+        failed = true;
+    }
+
+    // (2) Backpressure was actually exercised: at least one
+    // QueueFull on each queue. If neither queue ever filled, the
+    // run did not actually saturate — either the producers were
+    // too slow or the worker is starting from a closed/disabled
+    // state. Fail loudly so the test can be tuned (more producers,
+    // shorter duration, smaller queue capacity).
+    if (summary.block_queue_full == 0) {
+        std.debug.print(
+            "\nFATAL: block queue never saturated (queue_full=0) — increase ZEAM_STRESS_SAT_BLOCK_PRODUCERS or extend duration\n",
+            .{},
+        );
+        failed = true;
+    }
+    if (summary.attn_queue_full == 0) {
+        std.debug.print(
+            "\nFATAL: attn queue never saturated (queue_full=0) — increase ZEAM_STRESS_SAT_ATTN_PRODUCERS or extend duration\n",
+            .{},
+        );
+        failed = true;
+    }
+
+    // (3) The worker drained at least some messages on each queue.
+    // "queue_full only, no successful sends" means the worker is
+    // dead/deadlocked behind something other than the queue itself.
+    if (summary.block_send_ok == 0) {
+        std.debug.print(
+            "\nFATAL: chain-worker drained zero block messages — likely deadlock or worker startup failure\n",
+            .{},
+        );
+        failed = true;
+    }
+    if (summary.attn_send_ok == 0) {
+        std.debug.print(
+            "\nFATAL: chain-worker drained zero attestation messages — likely deadlock or worker startup failure\n",
+            .{},
+        );
+        failed = true;
+    }
+
+    // (4) Soft-error counters non-zero is a regression — any
+    // unexpected `submitBlock` / `submitGossipAttestation` error
+    // tag (today only `QueueClosed` and `ChainWorkerDisabled`
+    // would land in `other_err`). The first is observable only
+    // mid-shutdown; the second is the recordFatal path above.
+    if (summary.block_other_err > 0 or summary.attn_other_err > 0) {
+        std.debug.print(
+            "\nFATAL: producer-side other_err counters non-zero (block={d} attn={d}) — see per-queue counts above\n",
+            .{ summary.block_other_err, summary.attn_other_err },
+        );
+        failed = true;
+    }
+
+    _ = total_ok;
+    _ = total_qfull;
+    _ = total_err;
+
+    if (failed) std.process.exit(1);
+
+    std.debug.print(
+        "\nclean exit — chain-worker queues saturated and drained as expected, no UAF/deadlock observed\n",
+        .{},
+    );
 }


### PR DESCRIPTION
**Slice c-2b + c-2c of #803** — clubbed per @ch4r10t33r's call.

Branch off `main` @ `f76e762` (= c-2a's merge commit `node: introduce RcBeamState refcounted state pointer (slice c-2a of #803) (#827)`).

## Plan

Detailed plan: https://github.com/blockblaz/zeam/issues/803#issuecomment-4382830836

6 commits, each independently reviewable. **All six landed.**

| # | Status | SHA | Commit |
|---|---|---|---|
| 1 | ✅ landed | `5bf12dd` | `tryAcquire` upgrade-from-weak primitive on `RcBeamState` |
| 2 | ✅ landed | `9b3b036` | `BeamChain.states` map value type: `*BeamState` → `*RcBeamState` |
| 3 | ✅ landed | `4709e7b` | Producer-side handlers route through chain_worker queues; `--chain-worker=on\|off` CLI flag |
| 4 | ✅ landed | `cf12167` | Drop `BorrowedState` rwlock when chain-worker is sole writer |
| 5 | ✅ landed | `72d0244` | `lean_chain_state_refcount_distribution` histogram metric |
| 6 | ✅ landed | `df81046` | Queue-saturation stress mode (c-2c part 1) |

Plus three review-fix commits picked up during review rounds:

| SHA | What |
|---|---|
| `1835008` | `zig fmt` (trailing spaces in `rc_beam_state.zig` comment block) |
| `fa7cce1` | Fix `post_state_rc` leak on `statesCommitKeepExisting` OOM (errdefer + `rc_owned` flag, mirrors `statesPutExclusive`) + `FailingAllocator` regression test |
| `c19e5f2` | `wrapOwnedStateIntoRc` helper unifying `produceBlock`/`onBlock` post_state→rc dance + rename misleadingly-titled `tryAcquire: race against release-to-zero` test (reflects what the test actually proves; null-path-under-contention is unreachable by safe code per the doc'd safety preconditions) |

**Burn-in (c-2c part 2)** is NOT gated on this PR — devnet4 burn-in runs from `main` post-merge, then a separate one-line PR flips the `--chain-worker` default from `off` to `on`.

## Commits

### Commit 1 (`5bf12dd`) — `tryAcquire` primitive

Pure-additive. Standard CAS pattern (Rust `Arc::upgrade` / C++ `weak_ptr::lock`):

```zig
pub fn tryAcquire(self: *Self) ?*Self {
    var current = self.refcount.load(.monotonic);
    while (true) {
        if (current == 0) return null;
        if (self.refcount.cmpxchgWeak(current, current + 1, .monotonic, .monotonic)) |actual| {
            current = actual;
        } else {
            return self;
        }
    }
}
```

The freeing thread's claim is the existing `.acq_rel` `fetchSub` in `release()`; once it commits 1 → 0, every subsequent `tryAcquire` observes 0 and returns null. `.monotonic` on both load + cmpxchg is correct because the increment side has nothing to synchronize against.

4 new tests: basic, producer race (32 threads), null-after-zero (white-box fixture), and the pre-bumped concurrency test (renamed in `c19e5f2` to accurately reflect what it proves vs the unreachable null-under-contention path).

### Commit 2 (`9b3b036`) — `BeamChain.states` migration

Mechanical map type swap. Functionally a no-op:
- Refcount stays at 1 throughout (no other holder takes acquires yet)
- `states_lock` rwlock continues to gate concurrent map access exactly as before
- `BorrowedState` public shape unchanged: still exposes `state: *const BeamState`. Internally points at `&rc.state`.

Updated:
- `init`: stack-build via sszClone + `RcBeamState.create` (replaces create-then-clone-into-heap)
- `deinit`: `.release()` per entry instead of `.deinit() + .destroy()`
- `statesGet`: `BorrowedState{ .state = &rc.state }`
- `statesPutExclusive` / `statesCommitKeepExisting` / `statesFetchRemoveExclusivePtr`: signatures take/return `*RcBeamState`
- `produceBlock.commit` / `onBlock.commit`: wrap heap-allocated `post_state` into rc before commit (with care to flip `post_state_settled` BEFORE `create()` so the upstream errdefer doesn't deref freed memory on OOM)
- `pruneStates`: `release()` per pruned root
- 3 test sites updated

### Commit 3 (`4709e7b`) — chain-worker routing + `--chain-worker` CLI flag

`processBlockJob` / gossip-attestation handlers can now route through the c-1 chain_worker queue under a new `--chain-worker=on|off` CLI flag (default `off`). When on, the chain worker thread is the sole consumer for gossip blocks and gossip attestations; producer-side wrappers `submitBlock` / `submitGossipAttestation` enqueue on the worker queues. When off, handlers run synchronously on caller threads exactly as today.

Ownership contract on success: the caller transfers ownership of any heap-bearing payload (`SignedBlock`, `SignedAggregatedAttestation`) to the worker; the worker calls `Message.deinit` after dispatch. On `error.QueueFull` / `error.QueueClosed` / `error.ChainWorkerDisabled` the caller retains ownership and is responsible for cleanup.

End-to-end test wires the producer thread → BlockQueue → ChainWorker.runLoop → vtable thunk → `BeamChain.onBlock` + `onBlockFollowup`, polls until the post-state appears in the states map.

### Commit 4 (`cf12167`) — drop `BorrowedState` rwlock under `--chain-worker=on`

When chain-worker is the sole writer, cross-thread readers no longer need the shared rwlock to gate borrow lifetime — the `RcBeamState` refcount IS the lifetime mechanism.

`BorrowedState` extended:
- New variant `Backing.none` (lock-free borrow, lifetime gated by `acquired_rc` only).
- New optional field `acquired_rc: ?*const RcBeamState`. `deinit` releases it AFTER dropping any backing lock so `release()` (which may run the freeing path inline if refcount → 0) is OUTSIDE the critical section.

`statesGet` and `getFinalizedState` (cache-hit and DB-load paths) switch to `tryAcquire`-then-drop-lock when `chain_worker != null`, returning a `Backing.none` borrow whose deinit releases the rc. Under `--chain-worker=off` the lock-based path is unchanged (kill-switch backward-compat).

`statesCommitKeepExisting` INTENTIONALLY keeps holding the exclusive lock across its borrow even under `chain_worker_enabled` — the PR #820/#803 cross-call write-barrier rationale (DB write + `forkChoice.confirmBlock` must observe the in-map pointer atomically) still applies. Documented inline.

`cached_finalized_state` migrated from raw `*BeamState` to `*RcBeamState` (Option B from the PR review thread) for uniformity with the in-memory states map.

New tests cover: `Backing.none` + `acquired_rc` deinit (rc released, no leak), `cloneAndRelease` against a `Backing.none` borrow (rc released as part of the success-path deinit), `statesGet` returning `Backing.none` borrow under `chain_worker_enabled`, concurrent `statesGet` while a writer takes the exclusive lock (would deadlock under the old shared-held-for-borrow shape).

### Commit 5 (`72d0244`) — `lean_chain_state_refcount_distribution` histogram

Scrape-time observer iterates `BeamChain.states` under shared lock and samples `rc.count()` for each entry. Buckets `[1, 2, 4, 8, 16, 32, +Inf]`. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires.

Wired via a new context-bearing scrape refresher slot `registerScrapeRefresherCtx(ctx, fn(?*anyopaque) void)` parallel to the existing `void → void` slot. Trampoline casts back to `*BeamChain` so the observer can iterate the chain's in-memory map without forcing the chain into a global.

Lock-hold minimization: stack-buffered snapshot (size 128) for the iteration; observe outside the lock. On overflow falls back to observing under the lock (graceful degradation — observe is just a bucket increment).

Lifecycle: registered in `BeamNode.init` after `startChainWorker` (chain at final heap address); cleared in `BeamChain.deinit` BEFORE any chain state is torn down so the metrics endpoint cannot call back into freed memory mid-deinit.

Audit-pattern test: 3 rounds of N observations (writer-only → +N readers → back to writer-only) → scrape `/metrics` → assert the `_count` line grew by exactly `3*N`. Includes a tiny Prometheus-text parser for the count assertion.

### Commit 6 (`df81046`) — queue-saturation stress mode (c-2c part 1)

New mode in `pkgs/node/src/stress.zig` driven by `ZEAM_STRESS_MODE=saturation`. 4 block-producer threads + 4 attestation-producer threads slam `submitBlock` / `submitGossipAttestation` against a single chain-worker drainer.

Producers correctly handle `error.QueueFull` (block path retains ownership and deinits the clone per the c-2b commit-3 contract; attestation path is value-typed today so QueueFull just drops the value).

Assertions at run end:
1. `attempts == ok + queue_full + other_err` per queue (no lost producer-side accounting).
2. `queue_full > 0` on both queues (otherwise we never saturated — the test would pass trivially).
3. `send_ok > 0` on both queues (otherwise the worker is deadlocked behind something other than the queue).
4. `other_err == 0` (no unexpected `submitBlock` / `submitGossipAttestation` error tag).

Plus a saturation-specific watchdog that catches producer-side deadlock (no progress in either send_ok OR queue_full counters).

New build steps:
- `zig build stress-saturation` — operator-driven full run (~30s default).
- `zig build stress-quick-saturation` — 10s, **wired into `zig build test`** alongside the existing `stress-quick`.

Verified locally with a 10s `zig build stress-quick-saturation`:

```
=== saturation run summary ===
duration: 10.0s
total attempts: 7746 (773 attempts/sec)
  block: attempts=3016 ok=455 queue_full=2561 other_err=0
  attn : attempts=4730 ok=1037 queue_full=3693 other_err=0
errs g=0 a=0 b=0 queue_full_b=2561 queue_full_a=3693
clean exit — chain-worker queues saturated and drained as expected, no UAF/deadlock observed
```

## Verification

```
$ zig build test
...
All 132 tests passed.
clean exit — no panics, no UAFs, no deadlocks observed
```

Test count: 119 (slice c-2a base) → 132 in this PR (+13 across all 6 commits). `stress-quick` (30s) and `stress-quick-saturation` (10s) both wired into `zig build test` and green. CI green on `df81046`.

## Out of scope (deferred follow-ups)

- **Burn-in (c-2c part 2):** devnet4 ≥24h with `--chain-worker=on` from `main` post-merge. NOT gated on this PR.
- **Default flip:** separate one-line PR after burn-in flips `--chain-worker` default from `off` to `on`.
- **`TODO(slice-c-2c)` lock-hold option (b):** marker in `statesCommitKeepExisting` for moving the kept-existing `rc.release()` outside the exclusive lock if devnet shows a `zeam_lock_hold_seconds{site="onBlock.commit"}` p99 regression vs slice (b) baseline. Currently option (a) — accept the inline release, observe via the existing metric — per the PR review thread.
- Double-release `prev > 0` assert remains best-effort (doc-only; flagged in c-2a).
- `RcBeamStateWriter` / `RcBeamStateReader` two-distinct-types refactor stays as escalation path.

Closes/relates to #803 (slice c-2b + c-2c part 1).
