### PR TITLE
node: --chain-worker on|off enum + flip default to on (#803 follow-up)

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -76,9 +76,16 @@ pub const NodeCommand = struct {
     @"aggregate-subnet-ids": ?[]const u8 = null,
     @"db-backend": database.Backend = .rocksdb,
     /// Slice c-2b commit 3 of #803: route producer-side gossip
-    /// handlers through the chain-worker queue. Default `false`
-    /// preserves slice-(b) synchronous behavior.
-    @"chain-worker": bool = false,
+    /// handlers through the chain-worker queue. Default `.on`
+    /// post-c-2b/c-2c merge (PR #828 follow-up): the chain-worker
+    /// is the prod path; `.off` is the kill-switch.
+    ///
+    /// Value-taking flag: `--chain-worker on|off`. NOT a
+    /// presence-only bool, NOT `--chain-worker=on` syntax — the
+    /// simargs parser uses enum tag names verbatim, identical to
+    /// the `--db-backend rocksdb|lmdb` shape. See
+    /// `node_lib.ChainWorkerMode`.
+    @"chain-worker": node_lib.ChainWorkerMode = .on,
 
     pub const __shorts__ = .{
         .help = .h,
@@ -102,7 +109,7 @@ pub const NodeCommand = struct {
         .@"attestation-committee-count" = "Number of attestation committees (subnets); overrides config.yaml ATTESTATION_COMMITTEE_COUNT",
         .@"aggregate-subnet-ids" = "Comma-separated list of subnet ids to additionally subscribe and aggregate gossip attestations (e.g. '0,1,2'); adds to automatic computation from validator ids",
         .@"db-backend" = "Database backend to use for on-disk state: 'rocksdb' (default) or 'lmdb'",
-        .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread. Off by default; the synchronous path stays in place when disabled.",
+        .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread (slice c-2b/c-2c, zeam #803). Values: 'on' (default, prod path) or 'off' (kill-switch / legacy synchronous path).",
         .help = "Show help information for the node command",
     };
 };

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -95,10 +95,11 @@ pub const NodeOptions = struct {
     max_attestations_data: ?u8 = null,
     db_backend: database.Backend = .rocksdb,
     /// Slice c-2b commit 3 of #803: route producer-side gossip
-    /// handlers through the chain-worker queue. Default `false`
-    /// preserves slice-(b) synchronous behavior. Surfaced as
-    /// `--chain-worker` on the `zeam node` CLI.
-    chain_worker_enabled: bool = false,
+    /// handlers through the chain-worker queue. Default `.on` per
+    /// PR #828 follow-up (post-c-2b/c-2c merge): the chain-worker
+    /// is the prod path; `.off` is the kill-switch. Surfaced as
+    /// `--chain-worker on|off` on the `zeam node` CLI.
+    chain_worker: node_lib.ChainWorkerMode = .on,
 
     pub fn deinit(self: *NodeOptions, allocator: std.mem.Allocator) void {
         for (self.bootnodes) |b| allocator.free(b);
@@ -364,7 +365,7 @@ pub const Node = struct {
             .is_aggregator = options.is_aggregator,
             .aggregation_subnet_ids = options.aggregation_subnet_ids,
             .thread_pool = self.thread_pool,
-            .chain_worker_enabled = options.chain_worker_enabled,
+            .chain_worker = options.chain_worker,
         });
         errdefer self.beam_node.deinit();
 
@@ -766,7 +767,7 @@ pub fn buildStartOptions(
     opts.hash_sig_key_dir = hash_sig_key_dir;
     opts.checkpoint_sync_url = node_cmd.@"checkpoint-sync-url";
     opts.is_aggregator = node_cmd.@"is-aggregator";
-    opts.chain_worker_enabled = node_cmd.@"chain-worker";
+    opts.chain_worker = node_cmd.@"chain-worker";
 
     // Parse --aggregate-subnet-ids (comma-separated list of subnet ids, e.g. "0,1,2")
     // Require --is-aggregator to be set when --aggregate-subnet-ids is provided.

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -226,11 +226,12 @@ pub const BeamChain = struct {
     /// worker thread serialises the actual chain mutations.
     /// When null, callers fall through to the synchronous path
     /// (current behavior). Surface flipped by
-    /// `ChainOpts.chain_worker_enabled`; CLI flag
-    /// `--chain-worker=on|off`.
+    /// `BeamNodeOpts.chain_worker` (mode `.on` / `.off`); CLI flag
+    /// `--chain-worker on|off`.
     ///
-    /// Lifecycle: allocated + started in `init` when
-    /// `chain_worker_enabled` is true; stopped + freed in `deinit`.
+    /// Lifecycle: allocated + started in `BeamNode.init` when
+    /// `BeamNodeOpts.chain_worker.isEnabled()` is true; stopped
+    /// + freed in `deinit`.
     /// The worker borrows `*BeamChain` as its handler ctx, so the
     /// chain MUST outlive the worker — hence the strict
     /// stop/deinit/destroy ordering at the top of `BeamChain.deinit`.
@@ -586,7 +587,7 @@ pub const BeamChain = struct {
         // Clean up cached finalized state if present.
         // Slice c-2b commit 4: cached_finalized_state is an
         // RcBeamState now — release drives state.deinit + destroy when
-        // refcount reaches 0. Under chain_worker_enabled the cache may
+        // refcount reaches 0. Under chain_worker mode `.on` the cache may
         // have outstanding reader acquires; the rc keeps the underlying
         // allocation alive until the last reader releases. (At deinit
         // time we are single-threaded by contract, so refcount=1 in
@@ -662,7 +663,7 @@ pub const BeamChain = struct {
     ///     entire point of the c-2b migration.
     ///
     ///   * `chain_worker == null` (kill-switch / backward-compat under
-    ///     `--chain-worker=off`): keep the legacy lock-based borrow.
+    ///     `--chain-worker off`): keep the legacy lock-based borrow.
     ///     The shared lock is held for the borrow lifetime; map mutation
     ///     by the gossip/req-resp paths is gated by the exclusive side
     ///     as before. Slice (b) semantics are preserved exactly.

--- a/pkgs/node/src/lib.zig
+++ b/pkgs/node/src/lib.zig
@@ -3,6 +3,7 @@ pub const Clock = clockFactory.Clock;
 
 const nodeFactory = @import("./node.zig");
 pub const BeamNode = nodeFactory.BeamNode;
+pub const ChainWorkerMode = nodeFactory.ChainWorkerMode;
 
 const chainFactory = @import("./chain.zig");
 pub const BeamChain = chainFactory.BeamChain;

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -46,13 +46,40 @@ const NodeOpts = struct {
     /// Optional worker pool for parallelizing CPU-bound chain work (signature verification).
     /// When non-null it is shared across all nodes in the same process.
     thread_pool: ?*ThreadPool = null,
-    /// Slice c-2b commit 3 of #803: when true, the chain spawns a
+    /// Slice c-2b commit 3 of #803: when `.on`, the chain spawns a
     /// dedicated worker thread and producer-side handlers for
     /// gossip blocks / attestations route through its bounded
     /// queues instead of running synchronously on the libp2p
-    /// thread. Default `false` preserves slice-(b) behavior.
-    /// Surfaced to the CLI as `--chain-worker=on|off` (bool).
-    chain_worker_enabled: bool = false,
+    /// thread. When `.off`, the legacy slice-(b) synchronous path
+    /// is in effect (kill-switch).
+    ///
+    /// Default flipped from `.off` to `.on` post-merge of PR #828
+    /// (the c-2b/c-2c migration) per @ch4r10t33r's call: shipping
+    /// the chain-worker default-off would mean the burn-in is
+    /// exactly testing the path nobody actually runs in prod. The
+    /// kill-switch survives via `--chain-worker off`.
+    ///
+    /// Surfaced to the CLI as `--chain-worker on|off`. Note this
+    /// is a value-taking flag; the parser accepts the enum tag
+    /// names verbatim, so the CLI shape is `--chain-worker on`
+    /// (NOT `--chain-worker=on` and NOT bare `--chain-worker`).
+    chain_worker: ChainWorkerMode = .on,
+};
+
+/// Chain-worker thread routing mode. Surfaced to the CLI as the
+/// `--chain-worker on|off` flag and threaded through `BeamNodeOpts`.
+/// Slice c-2b commit 3 of #803.
+pub const ChainWorkerMode = enum {
+    on,
+    off,
+
+    /// True when the chain-worker thread should be started and
+    /// gossip-block / gossip-attestation handlers should route
+    /// through its bounded queues. False when the legacy synchronous
+    /// path (slice-(b) behavior) is in effect.
+    pub inline fn isEnabled(self: ChainWorkerMode) bool {
+        return self == .on;
+    }
 };
 
 pub const BeamNode = struct {
@@ -126,7 +153,7 @@ pub const BeamNode = struct {
         // stable for the worker's entire lifetime. `chain.deinit()`
         // (above errdefer + the deinit method) tears the worker
         // down before any chain state it might touch.
-        if (opts.chain_worker_enabled) {
+        if (opts.chain_worker.isEnabled()) {
             try chain.startChainWorker();
         }
 


### PR DESCRIPTION
Two-part follow-up to [#828](https://github.com/blockblaz/zeam/pull/828) (slice c-2b + c-2c part 1 of [#803](https://github.com/blockblaz/zeam/issues/803)).

## What

1. **`--chain-worker` becomes a value-taking enum `{on, off}`** instead of a presence-only `bool`. Mirrors the existing `--db-backend rocksdb|lmdb` precedent in `pkgs/cli/src/main.zig` (which uses simargs's enum support).

2. **Compiled-in default flips from `.off` → `.on`.** Per @ch4r10t33r — shipping the chain-worker default-off would mean the burn-in tests the path nobody actually runs in prod. The kill-switch survives via an explicit `--chain-worker off`.

## Why

When I shipped #828 with `@"chain-worker": bool = false`, I documented the lean-quickstart side as `--chain-worker on` / `--chain-worker off`. **But simargs treats `bool` as presence-only** — bare `--chain-worker` flips it to `true`, and `on` / `off` would be parsed as a stray positional, breaking startup. lean-quickstart [#170](https://github.com/blockblaz/lean-quickstart/pull/170) (merged) and [#171](https://github.com/blockblaz/lean-quickstart/pull/171) were already wired for the value-taking shape, so the simpler fix is to make the zeam CLI match what's already deployed in lean-quickstart.

This PR is a strict superset of what would have been a separate "default-flip" PR after burn-in. Combining them: zeam v0.4.14 (the pre-deployment build) is broken on the chain-worker flag anyway — fix the CLI shape and flip the default in the same release.

## Diff

```
 pkgs/cli/src/main.zig   | 15 +++++++++++----
 pkgs/cli/src/node.zig   | 13 +++++++------
 pkgs/node/src/chain.zig | 13 +++++++------
 pkgs/node/src/lib.zig   |  1 +
 pkgs/node/src/node.zig  | 37 ++++++++++++++++++++++++++++++++-----
 5 files changed, 58 insertions(+), 21 deletions(-)
```

New public type: `node_lib.ChainWorkerMode = enum { on, off }` with `pub inline fn isEnabled(self) bool` helper. Replaces the `chain_worker_enabled: bool` field on `BeamNodeOpts` and `NodeOptions`. Doc comments in `chain.zig` + `cli/main.zig` + `cli/node.zig` updated to reflect the new shape.

## Verification

```
$ zig build install
Finished `release` profile [optimized] target(s) in 11.02s
EXIT:0

$ ./zig-out/bin/zeam node --help | grep chain-worker
      --chain-worker STRING        Route gossip block + attestation handlers through the dedicated chain-worker thread (slice c-2b/c-2c, zeam #803). Values: 'on' (default, prod path) or 'off' (kill-switch / legacy synchronous path). (valid: on|off)(default: on)

$ ./zig-out/bin/zeam node --chain-worker hello --custom_genesis /tmp 2>&1 | head -3
# (parser rejects InvalidEnumValue and prints help)

$ ./zig-out/bin/zeam node --chain-worker on --custom_genesis /nonexistent
# (parses cleanly, errors later on missing --node-id as expected)

$ ./zig-out/bin/zeam node --chain-worker off --custom_genesis /nonexistent
# (same — flag accepted)

$ zig build test
All 132 tests passed.
clean exit — no panics, no UAFs, no deadlocks observed
```

## Plan

Once this lands on `main`, cut **v0.4.15** with this fix + the c-2b default-on. That's the build the devnet4 burn-in restarts on (with `ZEAM_CHAIN_WORKER` _unset_ or `=on` — both yield the prod path).

If burn-in regresses, kill-switch is `export ZEAM_CHAIN_WORKER=off` on the spin-node host (already wired through the ansible role on lean-quickstart `main`).