### PR TITLE
node: buffer future-slot gossip blocks during clock lag (fixes #788)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -150,8 +150,11 @@ const Metrics = struct {
     //     legitimate near-future gossip blocks).
     //   * `lean_pending_blocks_evicted_total{reason}` — cumulative count of
     //     blocks dropped from the queue, by reason: `cap` (capacity hit),
-    //     `pre_finalized` (slot < finalized), `duplicate` (same root
-    //     already queued), `append_oom` (allocator failure).
+    //     `pre_finalized` (slot < finalized), `too_far_future` (slot >
+    //     current_slot + MAX_FUTURE_SLOT_QUEUE_TOLERANCE; drain-side
+    //     eviction added in PR #841 review #8), `duplicate` (same root
+    //     already queued), `append_oom` (allocator failure on capacity
+    //     reservation; the new block is dropped, the queue is unchanged).
     //   * `lean_pending_blocks_replayed_total{result}` — cumulative count
     //     of replays attempted from `processPendingBlocks`, by
     //     terminal result: `accepted` / `rejected` / `error`.

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -142,6 +142,26 @@ const Metrics = struct {
     // measurement floor before deciding whether to bound the queue or add
     // a cursor optimisation.
     lean_pending_blocks_drain_iters: PendingBlocksDrainItersHistogram,
+    // Issue #788: visibility into the future-block queueing path.
+    //   * `lean_pending_blocks_depth` — instantaneous queue depth, set on
+    //     every successful enqueue and every `processPendingBlocks` drain.
+    //     Combined with `_evicted_total{reason="cap"}` it tells operators
+    //     when the queue cap is being hit (which would silently drop
+    //     legitimate near-future gossip blocks).
+    //   * `lean_pending_blocks_evicted_total{reason}` — cumulative count of
+    //     blocks dropped from the queue, by reason: `cap` (capacity hit),
+    //     `pre_finalized` (slot < finalized), `duplicate` (same root
+    //     already queued), `append_oom` (allocator failure).
+    //   * `lean_pending_blocks_replayed_total{result}` — cumulative count
+    //     of replays attempted from `processPendingBlocks`, by
+    //     terminal result: `accepted` / `rejected` / `error`.
+    //   * `lean_blocks_future_slot_dropped_total` — cumulative count of
+    //     gossip blocks hard-rejected as `FutureSlot` (beyond the
+    //     queueable window), the symptom #788 was tracking.
+    lean_pending_blocks_depth: LeanPendingBlocksDepthGauge,
+    lean_pending_blocks_evicted_total: LeanPendingBlocksEvictedCounter,
+    lean_pending_blocks_replayed_total: LeanPendingBlocksReplayedCounter,
+    lean_blocks_future_slot_dropped_total: LeanBlocksFutureSlotDroppedCounter,
     // Chain-worker queue + loop metrics (slice c-1 of #803).
     //   * `_dropped_total{queue="block"|"attestation"}` — producer
     //     `trySend` rejections when the queue was full.
@@ -254,6 +274,11 @@ const Metrics = struct {
     const LockHoldTimeHistogram = metrics_lib.HistogramVec(f32, LockLabel, &NODE_MUTEX_BUCKETS);
     // pending_blocks drain iteration histogram type (slice a-2)
     const PendingBlocksDrainItersHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 });
+    // Issue #788: future-block queue visibility.
+    const LeanPendingBlocksDepthGauge = metrics_lib.Gauge(u64);
+    const LeanPendingBlocksEvictedCounter = metrics_lib.CounterVec(u64, struct { reason: []const u8 });
+    const LeanPendingBlocksReplayedCounter = metrics_lib.CounterVec(u64, struct { result: []const u8 });
+    const LeanBlocksFutureSlotDroppedCounter = metrics_lib.Counter(u64);
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -628,6 +653,10 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_lock_wait_seconds = try Metrics.LockWaitTimeHistogram.init(allocator, io, "zeam_lock_wait_seconds", .{ .help = "Time spent waiting to acquire a per-resource lock, labeled by lock and callsite." }, .{}),
         .zeam_lock_hold_seconds = try Metrics.LockHoldTimeHistogram.init(allocator, io, "zeam_lock_hold_seconds", .{ .help = "Time a per-resource lock was held, labeled by lock and callsite." }, .{}),
         .lean_pending_blocks_drain_iters = Metrics.PendingBlocksDrainItersHistogram.init("lean_pending_blocks_drain_iters", .{ .help = "Number of iterations chain.processPendingBlocks ran through before draining the queue or finding nothing ready." }, .{}),
+        .lean_pending_blocks_depth = Metrics.LeanPendingBlocksDepthGauge.init("lean_pending_blocks_depth", .{ .help = "Instantaneous depth of the future-block pending queue (issue #788)." }, .{}),
+        .lean_pending_blocks_evicted_total = try Metrics.LeanPendingBlocksEvictedCounter.init(allocator, io, "lean_pending_blocks_evicted_total", .{ .help = "Total number of blocks evicted from the pending-blocks queue, by reason (issue #788)." }, .{}),
+        .lean_pending_blocks_replayed_total = try Metrics.LeanPendingBlocksReplayedCounter.init(allocator, io, "lean_pending_blocks_replayed_total", .{ .help = "Total number of replays from pending_blocks, by terminal result (issue #788)." }, .{}),
+        .lean_blocks_future_slot_dropped_total = Metrics.LeanBlocksFutureSlotDroppedCounter.init("lean_blocks_future_slot_dropped_total", .{ .help = "Total number of gossip blocks hard-rejected as FutureSlot beyond the queueable window (issue #788)." }, .{}),
         // Chain-worker queue + loop metrics (slice c-1 of #803).
         .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Instantaneous depth of the chain-worker queues, labeled by queue (block|attestation)." }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -1082,6 +1082,113 @@ pub const BeamChain = struct {
         zeam_metrics.metrics.lean_validators_count.set(self.registered_validator_ids.len);
     }
 
+    /// Append a block to `pending_blocks` for later replay.
+    ///
+    /// Issue #788: under mutex contention the forkchoice clock can lag
+    /// wall-time by tens of slots; gossip blocks for those slots arrive at
+    /// the wall-clock time and would otherwise be rejected as `FutureSlot`,
+    /// causing the forkchoice head to fall back to `latest_finalized` (no
+    /// descendants exist in protoArray). Buffering them here lets
+    /// `processPendingBlocks` replay them once the clock catches up.
+    ///
+    /// Bounded by `MAX_PENDING_BLOCKS`. When the cap is hit we evict the
+    /// oldest entry by *receive order* (front of queue) rather than the
+    /// lowest slot, because:
+    ///   * a peer flooding with high-slot fake-future blocks should not
+    ///     starve a legitimate near-future block out of the queue;
+    ///   * receive-order eviction is FIFO-fair and trivial to reason about.
+    /// In practice the queue is drained on every `onInterval` tick so the
+    /// cap is only hit during a sustained large clock lag, and the lost
+    /// block can always be re-fetched via `blocks_by_range` once the node
+    /// catches up.
+    ///
+    /// Dedup: if a block with the same root is already queued (a peer can
+    /// gossip the same block multiple times during the lag window), the
+    /// duplicate is discarded so we do not pay the cost of re-running it.
+    ///
+    /// Pre-finalized eviction: drop any queued block with
+    /// `slot < latest_finalized.slot` opportunistically while we're under
+    /// the lock — these can never become canonical and would be rejected
+    /// by `validateBlock` on replay anyway.
+    ///
+    /// Returns `true` if the block was queued, `false` if it was dropped
+    /// (cap-hit-after-eviction-failed, or duplicate).
+    fn enqueuePendingBlock(
+        self: *Self,
+        cloned: types.SignedBlock,
+        block_root: types.Root,
+    ) bool {
+        const finalized_slot = self.forkChoice.getLatestFinalized().slot;
+
+        var t = LockTimer.start("pending_blocks", "enqueuePendingBlock");
+        self.pending_blocks_lock.lock();
+        t.acquired();
+        defer t.released();
+        defer self.pending_blocks_lock.unlock();
+
+        // Pre-finalized opportunistic eviction. Cheap (single linear scan,
+        // queue is bounded at MAX_PENDING_BLOCKS = 1024) and amortises the
+        // cost of pruning across the gossip path so `processPendingBlocks`
+        // doesn't need to re-walk a queue full of dead entries.
+        var i: usize = 0;
+        while (i < self.pending_blocks.items.len) {
+            if (self.pending_blocks.items[i].block.slot < finalized_slot) {
+                var dropped = self.pending_blocks.orderedRemove(i);
+                dropped.deinit();
+                zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "pre_finalized" }) catch {};
+                continue;
+            }
+            i += 1;
+        }
+
+        // Dedup by root. Linear scan is fine at this size; if the queue
+        // ever grows we can switch to an auxiliary HashMap.
+        for (self.pending_blocks.items) |existing| {
+            var existing_root: [32]u8 = undefined;
+            // Re-hashing on every dedup check is wasteful but the queue is
+            // bounded and the gossip path is not the hot loop. Avoiding a
+            // second per-entry root field keeps the SignedBlock storage
+            // slim. If profiling ever shows this dominating, add a
+            // `roots: ArrayList([32]u8)` parallel array.
+            zeam_utils.hashTreeRoot(types.BeamBlock, existing.block, &existing_root, self.allocator) catch continue;
+            if (std.mem.eql(u8, &existing_root, &block_root)) {
+                self.logger.debug(
+                    "pending_blocks: duplicate slot={d} root=0x{x} dropped",
+                    .{ cloned.block.slot, &block_root },
+                );
+                var dup = cloned;
+                dup.deinit();
+                zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "duplicate" }) catch {};
+                return false;
+            }
+        }
+
+        // Cap eviction: drop the oldest by receive order if at capacity.
+        if (self.pending_blocks.items.len >= constants.MAX_PENDING_BLOCKS) {
+            var oldest = self.pending_blocks.orderedRemove(0);
+            self.logger.warn(
+                "pending_blocks: cap={d} hit; evicting oldest slot={d} to make room for slot={d}",
+                .{ constants.MAX_PENDING_BLOCKS, oldest.block.slot, cloned.block.slot },
+            );
+            oldest.deinit();
+            zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "cap" }) catch {};
+        }
+
+        self.pending_blocks.append(self.allocator, cloned) catch |err| {
+            self.logger.err(
+                "pending_blocks: append failed for slot={d} root=0x{x}: {any}",
+                .{ cloned.block.slot, &block_root, err },
+            );
+            var failed = cloned;
+            failed.deinit();
+            zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "append_oom" }) catch {};
+            return false;
+        };
+
+        zeam_metrics.metrics.lean_pending_blocks_depth.set(self.pending_blocks.items.len);
+        return true;
+    }
+
     /// Replay blocks that were queued because the forkchoice clock hadn't yet
     /// reached their slot.  Called from onInterval after advancing the clock.
     /// Returns a slice of all missing attestation roots encountered while
@@ -1101,13 +1208,29 @@ pub const BeamChain = struct {
         defer {
             const iter_f: f32 = @floatFromInt(iter_count);
             zeam_metrics.lean_pending_blocks_drain_iters.record(iter_f);
+            // Refresh the depth gauge so a busy drain leaves the gauge
+            // accurate for the next scrape (avoids "queue stayed at depth
+            // N forever" reads when the drain actually emptied it).
+            self.pending_blocks_lock.lock();
+            const depth = self.pending_blocks.items.len;
+            self.pending_blocks_lock.unlock();
+            zeam_metrics.metrics.lean_pending_blocks_depth.set(depth);
         }
 
         while (true) {
             const fc_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
+            const finalized_slot = self.forkChoice.getLatestFinalized().slot;
 
             // Pop the first ready block under the lock; release before any
             // heavy work so gossip-thread appends can proceed.
+            //
+            // While scanning we opportunistically evict pre-finalized
+            // blocks that have aged out (their slot is now below the
+            // latest_finalized). This keeps the queue self-cleaning even
+            // for a long-running clock-lag burst whose tail entries
+            // would otherwise never be "ready" by the
+            // `slot * INTERVALS_PER_SLOT <= fc_time` rule but also never
+            // become canonical.
             var ready: ?types.SignedBlock = null;
             {
                 var t = LockTimer.start("pending_blocks", "processPendingBlocks.scan");
@@ -1116,11 +1239,22 @@ pub const BeamChain = struct {
                 defer t.released();
                 defer self.pending_blocks_lock.unlock();
 
-                for (self.pending_blocks.items, 0..) |b, i| {
+                var i: usize = 0;
+                while (i < self.pending_blocks.items.len) {
+                    const b = self.pending_blocks.items[i];
+                    if (b.block.slot < finalized_slot) {
+                        var dropped = self.pending_blocks.orderedRemove(i);
+                        dropped.deinit();
+                        zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "pre_finalized" }) catch {};
+                        // do NOT increment i — we just shifted the next
+                        // entry down into slot i.
+                        continue;
+                    }
                     if (b.block.slot * constants.INTERVALS_PER_SLOT <= fc_time) {
                         ready = self.pending_blocks.orderedRemove(i);
                         break;
                     }
+                    i += 1;
                 }
             }
 
@@ -1133,6 +1267,7 @@ pub const BeamChain = struct {
                 var block_root: types.Root = undefined;
                 zeam_utils.hashTreeRoot(types.BeamBlock, queued_block.block, &block_root, self.allocator) catch |err| {
                     self.logger.err("queued block slot={d}: failed to compute block root: {any}", .{ queued_slot, err });
+                    zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "error" }) catch {};
                     continue;
                 };
 
@@ -1145,10 +1280,12 @@ pub const BeamChain = struct {
                     .blockRoot = block_root,
                 }) catch |err| {
                     self.logger.err("queued block slot={d} root=0x{x}: processing failed: {any}", .{ queued_slot, &block_root, err });
+                    zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "rejected" }) catch {};
                     continue;
                 };
                 defer self.allocator.free(missing_roots);
 
+                zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "accepted" }) catch {};
                 self.onBlockFollowup(true, &queued_block);
 
                 // Accumulate missing roots so the caller can fetch them.
@@ -1598,8 +1735,40 @@ pub const BeamChain = struct {
                 });
 
                 if (!hasBlock) {
-                    // Validation errors propagate to node.zig for context-aware logging
-                    try self.validateBlock(block, true);
+                    // Validate the block. `validateBlock` distinguishes
+                    // three future-slot cases (issue #788):
+                    //   * within `MAX_FUTURE_SLOT_TOLERANCE` — fall through
+                    //     to the existing per-interval pending-queue check
+                    //     and either queue or process now.
+                    //   * within `MAX_FUTURE_SLOT_QUEUE_TOLERANCE` (but not
+                    //     the small immediate tolerance) — surfaced as
+                    //     `FutureSlotQueueable`; we clone + queue and exit.
+                    //   * beyond `MAX_FUTURE_SLOT_QUEUE_TOLERANCE` —
+                    //     surfaced as `FutureSlot`; hard-rejected with a
+                    //     metric bump for visibility.
+                    self.validateBlock(block, true) catch |err| switch (err) {
+                        error.FutureSlotQueueable => {
+                            var cloned: types.SignedBlock = undefined;
+                            try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
+                            const queued = self.enqueuePendingBlock(cloned, block_root);
+                            if (queued) {
+                                self.logger.info(
+                                    "queued future-slot gossip block slot={d} blockroot=0x{x}: current_slot={d}",
+                                    .{
+                                        block.slot,
+                                        &block_root,
+                                        self.forkChoice.fcStore.slot_clock.timeSlots.load(.monotonic),
+                                    },
+                                );
+                            }
+                            return .{};
+                        },
+                        error.FutureSlot => {
+                            zeam_metrics.metrics.lean_blocks_future_slot_dropped_total.incr();
+                            return err;
+                        },
+                        else => return err,
+                    };
 
                     // If the forkchoice clock hasn't yet ticked to this block's slot,
                     // onBlock would reject it with FutureSlot.  Queue the block and
@@ -1612,24 +1781,18 @@ pub const BeamChain = struct {
                         var cloned: types.SignedBlock = undefined;
                         try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
 
-                        // TODO: in beam sim, it seems to have queued after the oninterval fires even if block arrives pre on interval
-                        // because of race conditions between competing threads as the above sszClone aparently takes too much time
-                        // currently managing this by checking condition again but ideally fix it by identifying chain entrypoints and
-                        // holding mutex between then for chain modification sections
+                        // Re-check after the clone in case `onInterval`
+                        // ticked the clock past this block's slot while
+                        // we were cloning. If it did, fall through and
+                        // process the block directly; otherwise enqueue.
                         if (block.slot * constants.INTERVALS_PER_SLOT > self.forkChoice.fcStore.slot_clock.time.load(.monotonic)) {
-                            {
-                                var t = LockTimer.start("pending_blocks", "onGossip.append");
-                                self.pending_blocks_lock.lock();
-                                t.acquired();
-                                defer t.released();
-                                defer self.pending_blocks_lock.unlock();
-                                try self.pending_blocks.append(self.allocator, cloned);
+                            const queued = self.enqueuePendingBlock(cloned, block_root);
+                            if (queued) {
+                                self.logger.info(
+                                    "queued gossip block slot={d} blockroot=0x{x}: forkchoice time={d} < slot_start={d}",
+                                    .{ block.slot, &block_root, self.forkChoice.fcStore.slot_clock.time.load(.monotonic), block.slot * constants.INTERVALS_PER_SLOT },
+                                );
                             }
-
-                            self.logger.info(
-                                "queued gossip block slot={d} blockroot=0x{x}: forkchoice time={d} < slot_start={d}",
-                                .{ block.slot, &block_root, self.forkChoice.fcStore.slot_clock.time.load(.monotonic), block.slot * constants.INTERVALS_PER_SLOT },
-                            );
                             return .{};
                         } else {
                             self.logger.debug(
@@ -2554,14 +2717,52 @@ pub const BeamChain = struct {
         // accessor to avoid a torn (slot, root) pair. PR #820 / #803.
         const finalized_slot = self.forkChoice.getLatestFinalized().slot;
 
-        // 1. Future slot check - reject blocks too far in the future
-        // Allow a small tolerance for clock skew, but reject clearly invalid future slots
-        // this can also happen because of race conditions between oninterval and block arrival
+        // 1. Future slot check.
+        //
+        // Issue #788: under heavy mutex contention (#786) the forkchoice's
+        // local clock (`timeSlots`) can lag wall-time by tens of slots.
+        // Gossip blocks for those slots arrive at wall-time and would
+        // otherwise be rejected as `FutureSlot`, causing the head to fall
+        // back to the latest finalized checkpoint (no descendants in
+        // protoArray). We split the future-slot range into two windows:
+        //
+        //   * `block.slot <= current_slot + MAX_FUTURE_SLOT_TOLERANCE` is
+        //     immediately processable; the existing per-interval
+        //     `pending_blocks` boundary handler will queue it if the
+        //     interval-level clock isn't quite caught up.
+        //   * `block.slot <= current_slot + MAX_FUTURE_SLOT_QUEUE_TOLERANCE`
+        //     is queueable in `pending_blocks` for replay once the
+        //     forkchoice clock catches up. The caller (`onGossip` block
+        //     branch) is responsible for the actual queuing; we surface
+        //     this case as `FutureSlotQueueable` so the caller can
+        //     distinguish it from a hard `FutureSlot` reject.
+        //   * Anything beyond `MAX_FUTURE_SLOT_QUEUE_TOLERANCE` is almost
+        //     certainly malicious/buggy and is hard-rejected with
+        //     `FutureSlot`.
+        //
+        // Note: the queueable window deliberately includes blocks already
+        // covered by the small `MAX_FUTURE_SLOT_TOLERANCE`; the call site
+        // queues only when `onBlock` would actually reject (i.e. when the
+        // forkchoice's interval-level clock disagrees), so this is just an
+        // upper bound, not a routing decision.
         const max_future_tolerance: types.Slot = constants.MAX_FUTURE_SLOT_TOLERANCE;
+        const max_future_queue: types.Slot = constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE;
         if (block.slot > current_slot + max_future_tolerance) {
+            if (block.slot <= current_slot + max_future_queue) {
+                self.logger.debug(
+                    "block queueable as future-slot: slot={d} current_slot={d} queue_tolerance={d} time(intervals)={d}",
+                    .{
+                        block.slot,
+                        current_slot,
+                        max_future_queue,
+                        self.forkChoice.fcStore.slot_clock.time.load(.monotonic),
+                    },
+                );
+                return BlockValidationError.FutureSlotQueueable;
+            }
             self.logger.debug("block validation failed: future slot {d} > max allowed {d} time(intervals)={d}", .{
                 block.slot,
-                current_slot + max_future_tolerance,
+                current_slot + max_future_queue,
                 self.forkChoice.fcStore.slot_clock.time.load(.monotonic),
             });
             return BlockValidationError.FutureSlot;
@@ -3151,8 +3352,15 @@ const AttestationValidationError = error{
 };
 pub const BlockValidationError = error{
     UnknownParentBlock,
-    /// Block slot is too far in the future
+    /// Block slot is too far in the future and cannot be reasonably queued
+    /// (beyond `MAX_FUTURE_SLOT_QUEUE_TOLERANCE`). Hard reject.
     FutureSlot,
+    /// Block slot is in the future but within the `pending_blocks`
+    /// queueing window. The caller should clone + queue the block for
+    /// later replay rather than treating it as an error. See #788 for
+    /// the rationale (forkchoice clock can lag wall-time under mutex
+    /// contention; we should not drop otherwise-valid gossip).
+    FutureSlotQueueable,
     /// Block slot is before the finalized slot
     PreFinalizedSlot,
     /// Block proposer_index exceeds validator count
@@ -3806,6 +4014,287 @@ test "attestation validation - gossip vs block future slot handling" {
     try std.testing.expectError(error.AttestationTooFarInFuture, beam_chain.validateAttestationData(too_far_attestation.message, false));
     try std.testing.expectError(error.AttestationTooFarInFuture, beam_chain.validateAttestationData(too_far_attestation.message, true));
 }
+
+// ----------------------------------------------------------------------
+// Issue #788 — future-slot block queueing tests
+//
+// Cover the FutureSlot/FutureSlotQueueable distinction added by
+// `validateBlock` and the `enqueuePendingBlock` helper that backs the
+// gossip path. The actual `onGossip` integration is exercised by the
+// chain-worker / node tests; here we focus on the boundary conditions
+// of the new logic so a regression that re-introduces the
+// drop-on-future-slot pathway (#788) lights up immediately.
+// ----------------------------------------------------------------------
+
+const FutureSlotTestFixture = struct {
+    arena: std.heap.ArenaAllocator,
+    allocator: std.mem.Allocator,
+    mock_chain: stf.MockChainData,
+    chain_config: configs.ChainConfig,
+    beam_state: types.BeamState,
+    zeam_logger_config: zeam_utils.ZeamLoggerConfig,
+    tmp_dir: std.testing.TmpDir,
+    db: database.Db,
+    connected_peers: *ConnectedPeers,
+    test_registry: *NodeNameRegistry,
+    beam_chain: *BeamChain,
+
+    fn init(parent_allocator: std.mem.Allocator) !*FutureSlotTestFixture {
+        const fx = try parent_allocator.create(FutureSlotTestFixture);
+        fx.arena = std.heap.ArenaAllocator.init(parent_allocator);
+        fx.allocator = fx.arena.allocator();
+
+        fx.mock_chain = try stf.genMockChain(fx.allocator, 4, null);
+        const spec_name = try fx.allocator.dupe(u8, "beamdev");
+        const fork_digest = try fx.allocator.dupe(u8, "12345678");
+        fx.chain_config = configs.ChainConfig{
+            .id = configs.Chain.custom,
+            .genesis = fx.mock_chain.genesis_config,
+            .spec = .{
+                .preset = params.Preset.mainnet,
+                .name = spec_name,
+                .fork_digest = fork_digest,
+                .attestation_committee_count = 1,
+                .max_attestations_data = 16,
+            },
+        };
+        fx.beam_state = fx.mock_chain.genesis_state;
+        fx.zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+        fx.tmp_dir = std.testing.tmpDir(.{});
+        const data_dir = try std.fmt.allocPrint(fx.allocator, ".zig-cache/tmp/{s}", .{fx.tmp_dir.sub_path});
+        fx.db = try database.Db.open(fx.allocator, fx.zeam_logger_config.logger(.database_test), data_dir);
+
+        fx.connected_peers = try fx.allocator.create(ConnectedPeers);
+        fx.connected_peers.* = ConnectedPeers.init(fx.allocator);
+
+        fx.test_registry = try fx.allocator.create(NodeNameRegistry);
+        fx.test_registry.* = NodeNameRegistry.init(fx.allocator);
+
+        fx.beam_chain = try fx.allocator.create(BeamChain);
+        fx.beam_chain.* = try BeamChain.init(fx.allocator, ChainOpts{
+            .config = fx.chain_config,
+            .anchorState = &fx.beam_state,
+            .nodeId = 0,
+            .logger_config = &fx.zeam_logger_config,
+            .db = fx.db,
+            .node_registry = fx.test_registry,
+        }, fx.connected_peers);
+        return fx;
+    }
+
+    fn deinit(fx: *FutureSlotTestFixture, parent_allocator: std.mem.Allocator) void {
+        fx.beam_chain.deinit();
+        fx.test_registry.deinit();
+        fx.db.deinit();
+        fx.tmp_dir.cleanup();
+        fx.arena.deinit();
+        parent_allocator.destroy(fx);
+    }
+};
+
+test "validateBlock #788: FutureSlotQueueable for block within queue tolerance" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    // Forkchoice clock starts at slot 0. A block at slot
+    // MAX_FUTURE_SLOT_TOLERANCE + 1 (=2) is queueable but not immediately
+    // processable; validateBlock should surface FutureSlotQueueable.
+    var block = fx.mock_chain.blocks[1].block;
+    block.slot = constants.MAX_FUTURE_SLOT_TOLERANCE + 1;
+
+    try std.testing.expectError(
+        error.FutureSlotQueueable,
+        fx.beam_chain.validateBlock(block, true),
+    );
+}
+
+test "validateBlock #788: FutureSlot hard-reject for block beyond queue tolerance" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    // Anything beyond MAX_FUTURE_SLOT_QUEUE_TOLERANCE is rejected as
+    // FutureSlot — the hard reject that pre-#788 behaviour applied to
+    // every future-slot block, now narrowed to the truly-bogus range.
+    var block = fx.mock_chain.blocks[1].block;
+    block.slot = constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE + 10;
+
+    try std.testing.expectError(
+        error.FutureSlot,
+        fx.beam_chain.validateBlock(block, true),
+    );
+}
+
+test "validateBlock #788: queue-tolerance boundary is inclusive" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    // current_slot=0 + MAX_FUTURE_SLOT_QUEUE_TOLERANCE is the highest
+    // slot that should still be FutureSlotQueueable, not FutureSlot.
+    // One slot beyond that flips to FutureSlot. Lock both sides of the
+    // boundary so a future contributor cannot accidentally drop it by
+    // one and silently re-introduce the #788 reset symptom.
+    var block_at_boundary = fx.mock_chain.blocks[1].block;
+    block_at_boundary.slot = constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE;
+    try std.testing.expectError(
+        error.FutureSlotQueueable,
+        fx.beam_chain.validateBlock(block_at_boundary, true),
+    );
+
+    var block_just_past = fx.mock_chain.blocks[1].block;
+    block_just_past.slot = constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE + 1;
+    try std.testing.expectError(
+        error.FutureSlot,
+        fx.beam_chain.validateBlock(block_just_past, true),
+    );
+}
+
+test "enqueuePendingBlock #788: deduplicates by root" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    const allocator = std.testing.allocator;
+
+    // Clone the same block twice and enqueue both. Second enqueue
+    // should be deduped — a peer can re-gossip the same block several
+    // times during a clock-lag window and we must not pay the cost
+    // (or memory) of re-running it.
+    const signed = fx.mock_chain.blocks[1];
+    var root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, signed.block, &root, allocator);
+
+    var clone1: types.SignedBlock = undefined;
+    try types.sszClone(allocator, types.SignedBlock, signed, &clone1);
+    var clone2: types.SignedBlock = undefined;
+    try types.sszClone(allocator, types.SignedBlock, signed, &clone2);
+
+    // Stash the chain's allocator so we hand the clones to it (matches
+    // how `onGossip` does it via `self.allocator`). Use that here too.
+    const chain_allocator = fx.beam_chain.allocator;
+    var clone1_in_chain: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, signed, &clone1_in_chain);
+    var clone2_in_chain: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, signed, &clone2_in_chain);
+    clone1.deinit();
+    clone2.deinit();
+
+    const first = fx.beam_chain.enqueuePendingBlock(clone1_in_chain, root);
+    try std.testing.expect(first);
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+
+    const second = fx.beam_chain.enqueuePendingBlock(clone2_in_chain, root);
+    try std.testing.expect(!second);
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+}
+
+test "enqueuePendingBlock #788: cap eviction drops oldest by receive order" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    const chain_allocator = fx.beam_chain.allocator;
+
+    // Fill the queue to capacity with synthetic distinct blocks (we
+    // re-use the same block but bump `slot` to give each a distinct
+    // root, since dedup is by root). Then push one more and verify
+    // the queue stays at MAX_PENDING_BLOCKS and the new block is at
+    // the tail.
+    const base = fx.mock_chain.blocks[1];
+    var i: usize = 0;
+    while (i < constants.MAX_PENDING_BLOCKS) : (i += 1) {
+        var clone: types.SignedBlock = undefined;
+        try types.sszClone(chain_allocator, types.SignedBlock, base, &clone);
+        // Distinct slot → distinct root after re-hash.
+        clone.block.slot = @intCast(i + 100);
+        var root: types.Root = undefined;
+        try zeam_utils.hashTreeRoot(types.BeamBlock, clone.block, &root, chain_allocator);
+        const ok = fx.beam_chain.enqueuePendingBlock(clone, root);
+        try std.testing.expect(ok);
+    }
+    try std.testing.expectEqual(constants.MAX_PENDING_BLOCKS, fx.beam_chain.pending_blocks.items.len);
+
+    // The first slot in the queue is currently 100 (the oldest by
+    // receive order). Enqueue one more; the cap-evictor must drop
+    // slot=100 and leave a length-MAX queue with slot=200..MAX+99.
+    var newest: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, base, &newest);
+    newest.block.slot = constants.MAX_PENDING_BLOCKS + 200;
+    var newest_root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, newest.block, &newest_root, chain_allocator);
+
+    const ok = fx.beam_chain.enqueuePendingBlock(newest, newest_root);
+    try std.testing.expect(ok);
+    try std.testing.expectEqual(constants.MAX_PENDING_BLOCKS, fx.beam_chain.pending_blocks.items.len);
+    // Front is no longer slot=100 (it was evicted).
+    try std.testing.expect(fx.beam_chain.pending_blocks.items[0].block.slot != 100);
+    // Tail is the newly-inserted block.
+    const last = fx.beam_chain.pending_blocks.items[constants.MAX_PENDING_BLOCKS - 1];
+    try std.testing.expectEqual(@as(types.Slot, constants.MAX_PENDING_BLOCKS + 200), last.block.slot);
+}
+
+test "enqueuePendingBlock #788: drops blocks before latest_finalized" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    const chain_allocator = fx.beam_chain.allocator;
+
+    // Seed the queue with one fresh-slot entry, then artificially
+    // raise `latest_finalized.slot` to a higher value to simulate the
+    // case where queued entries fall behind finalization between
+    // arrival and the next drain. enqueueing a new block triggers the
+    // pre-finalized eviction sweep.
+    var stale: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, fx.mock_chain.blocks[1], &stale);
+    stale.block.slot = 5;
+    var stale_root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, stale.block, &stale_root, chain_allocator);
+    try std.testing.expect(fx.beam_chain.enqueuePendingBlock(stale, stale_root));
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+
+    // Move finalization forward past the queued entry (test-only
+    // mutation; under the forkchoice's RwLock for the same reasons
+    // the production path uses it).
+    fx.beam_chain.forkChoice.mutex.lock();
+    fx.beam_chain.forkChoice.fcStore.latest_finalized.slot = 100;
+    fx.beam_chain.forkChoice.mutex.unlock();
+
+    // Enqueue a fresh future block; the helper's pre-finalized sweep
+    // should drop the stale entry and accept the fresh one, leaving
+    // a length-1 queue with the newer block.
+    var fresh: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, fx.mock_chain.blocks[1], &fresh);
+    fresh.block.slot = 200;
+    var fresh_root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, fresh.block, &fresh_root, chain_allocator);
+    try std.testing.expect(fx.beam_chain.enqueuePendingBlock(fresh, fresh_root));
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+    try std.testing.expectEqual(@as(types.Slot, 200), fx.beam_chain.pending_blocks.items[0].block.slot);
+}
+
+test "processPendingBlocks #788: evicts pre-finalized entries during scan" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    const chain_allocator = fx.beam_chain.allocator;
+
+    // Queue an entry, then move finalization past it without going
+    // through enqueue (so the gossip-path sweep doesn't get a chance).
+    // processPendingBlocks must still drop it during its own scan.
+    var stale: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, fx.mock_chain.blocks[1], &stale);
+    stale.block.slot = 5;
+    var stale_root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, stale.block, &stale_root, chain_allocator);
+    try std.testing.expect(fx.beam_chain.enqueuePendingBlock(stale, stale_root));
+
+    fx.beam_chain.forkChoice.mutex.lock();
+    fx.beam_chain.forkChoice.fcStore.latest_finalized.slot = 100;
+    fx.beam_chain.forkChoice.mutex.unlock();
+
+    const missing = fx.beam_chain.processPendingBlocks();
+    defer chain_allocator.free(missing);
+    try std.testing.expectEqual(@as(usize, 0), fx.beam_chain.pending_blocks.items.len);
+}
+
 // TODO: Enable and update this test once the keymanager file-reading PR is added
 // JSON parsing for chain config needs to support validator_attestation_pubkeys instead of num_validators
 test "attestation processing - valid block attestation" {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -97,6 +97,27 @@ pub const ProducedBlock = struct {
     }
 };
 
+/// Future-block queue entry (issue #788).
+///
+/// Stores the producer's already-computed hash-tree root alongside the
+/// block so the gossip-path dedup loop and the drain don't have to
+/// re-hash. PR #841 review: `hashTreeRoot(BeamBlock, ...)` is a full
+/// SSZ tree walk — doing it 1024 times per duplicate-check is
+/// observable under a sustained clock-lag flood, which is the exact
+/// scenario the future-block queue exists to handle. Storing the
+/// 32-byte root here drops dedup from O(N·hash) to O(N·memcmp).
+///
+/// Mirrors leanSpec's `PendingBlock` shape
+/// (subspecs/sync/block_cache.py:55) for the load-bearing `root`
+/// field. Other PendingBlock fields (`received_from`, `received_at`,
+/// `backfill_depth`) are deliberately omitted in this PR — they hook
+/// into peer scoring + staleness detection that don't have consumers
+/// in zeam yet. Tracked as follow-up cleanup in #788's PR thread.
+pub const PendingBlockEntry = struct {
+    signed_block: types.SignedBlock,
+    block_root: types.Root,
+};
+
 pub const BeamChain = struct {
     config: configs.ChainConfig,
     anchor_state: *types.BeamState,
@@ -197,7 +218,14 @@ pub const BeamChain = struct {
     // When a peer gossips a block for the current slot before our local interval
     // timer fires, the forkchoice rejects it with FutureSlot.  We hold such
     // blocks here and replay them in onInterval once the clock has caught up.
-    pending_blocks: std.ArrayList(types.SignedBlock),
+    //
+    // Each entry carries the producer's already-computed hash-tree root
+    // alongside the block so dedup checks compare 32 bytes instead of
+    // re-hashing the full block body. See `PendingBlockEntry` doc above for
+    // the per-field rationale. Re-finalized eviction (when finalization
+    // advances past a queued slot) happens both on enqueue (gossip path) and
+    // during `processPendingBlocks` (drain path) so the queue self-cleans.
+    pending_blocks: std.ArrayList(PendingBlockEntry),
 
     // Per-resource locks (slice a-2 of #803). See
     // `docs/threading_refactor_slice_a.md` for the lock-hierarchy contract:
@@ -601,8 +629,8 @@ pub const BeamChain = struct {
         // Clean up root to slot cache
         self.root_to_slot_cache.deinit();
         // Clean up any blocks that were queued waiting for the forkchoice clock
-        for (self.pending_blocks.items) |*block| {
-            block.deinit();
+        for (self.pending_blocks.items) |*entry| {
+            entry.signed_block.deinit();
         }
         self.pending_blocks.deinit(self.allocator);
 
@@ -1091,6 +1119,26 @@ pub const BeamChain = struct {
     /// descendants exist in protoArray). Buffering them here lets
     /// `processPendingBlocks` replay them once the clock catches up.
     ///
+    /// **Complexity** (PR #841 review #5/#6): all sub-passes are O(N) in
+    /// the queue length, no O(N²) anywhere.
+    ///   * Pre-finalized eviction is a single in-place compaction pass
+    ///     using a write-pointer (preserves receive order; no per-removal
+    ///     `orderedRemove` shift).
+    ///   * Dedup is `memcmp` against the cached root in each
+    ///     `PendingBlockEntry`, not a re-hash of the full block body. The
+    ///     review explicitly called out the prior O(N·hash) loop as a
+    ///     blocking issue under sustained gossip floods.
+    ///   * Cap-eviction uses `orderedRemove(0)` for the FIFO drop and is
+    ///     O(N) for the single shift.
+    ///
+    /// **Append OOM safety** (PR #841 review #7): we reserve space *before*
+    /// the cap-eviction. If the reservation itself OOMs we return early
+    /// without evicting anything — the prior shape would free the oldest
+    /// entry, then OOM on the append, losing two blocks per OOM event.
+    /// `ensureUnusedCapacity(1)` is a no-op in steady state because the
+    /// ArrayList's underlying buffer was already sized to the cap on a
+    /// previous append.
+    ///
     /// Bounded by `MAX_PENDING_BLOCKS`. When the cap is hit we evict the
     /// oldest entry by *receive order* (front of queue) rather than the
     /// lowest slot, because:
@@ -1105,6 +1153,8 @@ pub const BeamChain = struct {
     /// Dedup: if a block with the same root is already queued (a peer can
     /// gossip the same block multiple times during the lag window), the
     /// duplicate is discarded so we do not pay the cost of re-running it.
+    /// Each entry caches its root in `PendingBlockEntry.block_root`, so
+    /// dedup is a 32-byte `memcmp` per entry.
     ///
     /// Pre-finalized eviction: drop any queued block with
     /// `slot < latest_finalized.slot` opportunistically while we're under
@@ -1112,7 +1162,8 @@ pub const BeamChain = struct {
     /// by `validateBlock` on replay anyway.
     ///
     /// Returns `true` if the block was queued, `false` if it was dropped
-    /// (cap-hit-after-eviction-failed, or duplicate).
+    /// (cap reservation failed, or duplicate). `cloned` is `deinit`'d in
+    /// the failure path; on success the queue takes ownership.
     fn enqueuePendingBlock(
         self: *Self,
         cloned: types.SignedBlock,
@@ -1126,32 +1177,34 @@ pub const BeamChain = struct {
         defer t.released();
         defer self.pending_blocks_lock.unlock();
 
-        // Pre-finalized opportunistic eviction. Cheap (single linear scan,
-        // queue is bounded at MAX_PENDING_BLOCKS = 1024) and amortises the
-        // cost of pruning across the gossip path so `processPendingBlocks`
-        // doesn't need to re-walk a queue full of dead entries.
-        var i: usize = 0;
-        while (i < self.pending_blocks.items.len) {
-            if (self.pending_blocks.items[i].block.slot < finalized_slot) {
-                var dropped = self.pending_blocks.orderedRemove(i);
-                dropped.deinit();
-                zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "pre_finalized" }) catch {};
-                continue;
+        // Pre-finalized in-place compaction (PR #841 review #6 — prior
+        // `orderedRemove(i)` per dropped entry was O(N²) under flood).
+        // Walk forward, copy keepers down to a write pointer, deinit
+        // dropped entries as we pass over them. Receive order is preserved
+        // because the relative order of survivors is unchanged.
+        {
+            const items = self.pending_blocks.items;
+            var write: usize = 0;
+            var read: usize = 0;
+            while (read < items.len) : (read += 1) {
+                if (items[read].signed_block.block.slot < finalized_slot) {
+                    var dropped = items[read];
+                    dropped.signed_block.deinit();
+                    zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "pre_finalized" }) catch {};
+                    continue;
+                }
+                if (write != read) {
+                    items[write] = items[read];
+                }
+                write += 1;
             }
-            i += 1;
+            self.pending_blocks.shrinkRetainingCapacity(write);
         }
 
-        // Dedup by root. Linear scan is fine at this size; if the queue
-        // ever grows we can switch to an auxiliary HashMap.
+        // Dedup by cached root — PR #841 review #5: was an O(N) re-hash
+        // per check, now an O(N) memcmp.
         for (self.pending_blocks.items) |existing| {
-            var existing_root: [32]u8 = undefined;
-            // Re-hashing on every dedup check is wasteful but the queue is
-            // bounded and the gossip path is not the hot loop. Avoiding a
-            // second per-entry root field keeps the SignedBlock storage
-            // slim. If profiling ever shows this dominating, add a
-            // `roots: ArrayList([32]u8)` parallel array.
-            zeam_utils.hashTreeRoot(types.BeamBlock, existing.block, &existing_root, self.allocator) catch continue;
-            if (std.mem.eql(u8, &existing_root, &block_root)) {
+            if (std.mem.eql(u8, &existing.block_root, &block_root)) {
                 self.logger.debug(
                     "pending_blocks: duplicate slot={d} root=0x{x} dropped",
                     .{ cloned.block.slot, &block_root },
@@ -1163,20 +1216,15 @@ pub const BeamChain = struct {
             }
         }
 
-        // Cap eviction: drop the oldest by receive order if at capacity.
-        if (self.pending_blocks.items.len >= constants.MAX_PENDING_BLOCKS) {
-            var oldest = self.pending_blocks.orderedRemove(0);
-            self.logger.warn(
-                "pending_blocks: cap={d} hit; evicting oldest slot={d} to make room for slot={d}",
-                .{ constants.MAX_PENDING_BLOCKS, oldest.block.slot, cloned.block.slot },
-            );
-            oldest.deinit();
-            zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "cap" }) catch {};
-        }
-
-        self.pending_blocks.append(self.allocator, cloned) catch |err| {
+        // PR #841 review #7: reserve append capacity BEFORE evicting so an
+        // allocator failure in the reservation step does not lose the
+        // oldest entry too. In steady state this is a no-op (the ArrayList
+        // was already grown to MAX_PENDING_BLOCKS on a prior append). If
+        // the reservation fails we return without touching the queue —
+        // the caller's `cloned` is freed below.
+        self.pending_blocks.ensureUnusedCapacity(self.allocator, 1) catch |err| {
             self.logger.err(
-                "pending_blocks: append failed for slot={d} root=0x{x}: {any}",
+                "pending_blocks: capacity reservation failed for slot={d} root=0x{x}: {any}",
                 .{ cloned.block.slot, &block_root, err },
             );
             var failed = cloned;
@@ -1184,6 +1232,25 @@ pub const BeamChain = struct {
             zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "append_oom" }) catch {};
             return false;
         };
+
+        // Cap eviction: drop the oldest by receive order if at capacity.
+        if (self.pending_blocks.items.len >= constants.MAX_PENDING_BLOCKS) {
+            var oldest = self.pending_blocks.orderedRemove(0);
+            self.logger.warn(
+                "pending_blocks: cap={d} hit; evicting oldest slot={d} to make room for slot={d}",
+                .{ constants.MAX_PENDING_BLOCKS, oldest.signed_block.block.slot, cloned.block.slot },
+            );
+            oldest.signed_block.deinit();
+            zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "cap" }) catch {};
+        }
+
+        // Reservation above guarantees this `appendAssumeCapacity` cannot
+        // fail — even after an `orderedRemove` (which only shrinks `len`,
+        // not `capacity`).
+        self.pending_blocks.appendAssumeCapacity(.{
+            .signed_block = cloned,
+            .block_root = block_root,
+        });
 
         zeam_metrics.metrics.lean_pending_blocks_depth.set(self.pending_blocks.items.len);
         return true;
@@ -1220,18 +1287,28 @@ pub const BeamChain = struct {
         while (true) {
             const fc_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
             const finalized_slot = self.forkChoice.getLatestFinalized().slot;
+            const current_slot = self.forkChoice.fcStore.slot_clock.timeSlots.load(.monotonic);
+            // PR #841 review #8: drain-side eviction of "too-far-future"
+            // entries whose slot the forkchoice clock has not yet caught
+            // up to and is unlikely to ever (an adversary can flood with
+            // blocks at `current_slot + 250` that are within the
+            // queueable window at enqueue time but stay un-replayable
+            // until the clock advances by 250 slots). Saturating add
+            // avoids u64 wrap-around on adversarial input — see PR #841
+            // review #8.
+            const too_far_future_slot: types.Slot = current_slot +| constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE;
 
             // Pop the first ready block under the lock; release before any
             // heavy work so gossip-thread appends can proceed.
             //
-            // While scanning we opportunistically evict pre-finalized
-            // blocks that have aged out (their slot is now below the
-            // latest_finalized). This keeps the queue self-cleaning even
-            // for a long-running clock-lag burst whose tail entries
-            // would otherwise never be "ready" by the
-            // `slot * INTERVALS_PER_SLOT <= fc_time` rule but also never
-            // become canonical.
-            var ready: ?types.SignedBlock = null;
+            // The scan is an in-place compaction (review #6: prior
+            // `orderedRemove(i)` per dropped entry was O(N²) under flood).
+            // Walk forward, copy keepers down to a write pointer; when we
+            // see the first "ready" block (slot * intervals <= fc_time)
+            // we pop it into `ready` and continue compacting the tail.
+            // Pre-finalized and too-far-future entries are dropped
+            // in-line; receive order is preserved for survivors.
+            var ready: ?PendingBlockEntry = null;
             {
                 var t = LockTimer.start("pending_blocks", "processPendingBlocks.scan");
                 self.pending_blocks_lock.lock();
@@ -1239,44 +1316,51 @@ pub const BeamChain = struct {
                 defer t.released();
                 defer self.pending_blocks_lock.unlock();
 
-                var i: usize = 0;
-                while (i < self.pending_blocks.items.len) {
-                    const b = self.pending_blocks.items[i];
-                    if (b.block.slot < finalized_slot) {
-                        var dropped = self.pending_blocks.orderedRemove(i);
-                        dropped.deinit();
+                const items = self.pending_blocks.items;
+                var write: usize = 0;
+                var read: usize = 0;
+                while (read < items.len) : (read += 1) {
+                    const entry_slot = items[read].signed_block.block.slot;
+                    if (entry_slot < finalized_slot) {
+                        var dropped = items[read];
+                        dropped.signed_block.deinit();
                         zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "pre_finalized" }) catch {};
-                        // do NOT increment i — we just shifted the next
-                        // entry down into slot i.
                         continue;
                     }
-                    if (b.block.slot * constants.INTERVALS_PER_SLOT <= fc_time) {
-                        ready = self.pending_blocks.orderedRemove(i);
-                        break;
+                    if (entry_slot > too_far_future_slot) {
+                        var dropped = items[read];
+                        dropped.signed_block.deinit();
+                        zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "too_far_future" }) catch {};
+                        continue;
                     }
-                    i += 1;
+                    if (ready == null and entry_slot * constants.INTERVALS_PER_SLOT <= fc_time) {
+                        ready = items[read];
+                        continue;
+                    }
+                    if (write != read) {
+                        items[write] = items[read];
+                    }
+                    write += 1;
                 }
+                self.pending_blocks.shrinkRetainingCapacity(write);
             }
 
             if (ready) |unwrapped| {
                 iter_count += 1;
-                var queued_block = unwrapped;
-                defer queued_block.deinit();
+                var queued_entry = unwrapped;
+                defer queued_entry.signed_block.deinit();
 
-                const queued_slot = queued_block.block.slot;
-                var block_root: types.Root = undefined;
-                zeam_utils.hashTreeRoot(types.BeamBlock, queued_block.block, &block_root, self.allocator) catch |err| {
-                    self.logger.err("queued block slot={d}: failed to compute block root: {any}", .{ queued_slot, err });
-                    zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "error" }) catch {};
-                    continue;
-                };
+                const queued_slot = queued_entry.signed_block.block.slot;
+                // PR #841 review #5: use the cached root from the queue
+                // entry instead of re-hashing the block.
+                const block_root = queued_entry.block_root;
 
                 self.logger.info(
                     "replaying queued block slot={d} blockroot=0x{x} (fc_time now={d})",
                     .{ queued_slot, &block_root, fc_time },
                 );
 
-                const missing_roots = self.onBlock(queued_block, .{
+                const missing_roots = self.onBlock(queued_entry.signed_block, .{
                     .blockRoot = block_root,
                 }) catch |err| {
                     self.logger.err("queued block slot={d} root=0x{x}: processing failed: {any}", .{ queued_slot, &block_root, err });
@@ -1286,7 +1370,7 @@ pub const BeamChain = struct {
                 defer self.allocator.free(missing_roots);
 
                 zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "accepted" }) catch {};
-                self.onBlockFollowup(true, &queued_block);
+                self.onBlockFollowup(true, &queued_entry.signed_block);
 
                 // Accumulate missing roots so the caller can fetch them.
                 all_missing_roots.appendSlice(self.allocator, missing_roots) catch {};
@@ -2747,8 +2831,17 @@ pub const BeamChain = struct {
         // upper bound, not a routing decision.
         const max_future_tolerance: types.Slot = constants.MAX_FUTURE_SLOT_TOLERANCE;
         const max_future_queue: types.Slot = constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE;
-        if (block.slot > current_slot + max_future_tolerance) {
-            if (block.slot <= current_slot + max_future_queue) {
+        // PR #841 review #8: `current_slot + max_future_*` can overflow
+        // `types.Slot` (u64) on adversarial input. Practically safe — slots
+        // stay well below 2^32 for centuries — but Zig 0.16 release-mode
+        // arithmetic doesn't trap, so a wrap-around could silently flip the
+        // comparison and either reject valid blocks or accept impossible
+        // ones. Use saturating add (`+|`) so the upper bound is always at
+        // least as large as any real slot.
+        const tolerance_threshold: types.Slot = current_slot +| max_future_tolerance;
+        const queue_threshold: types.Slot = current_slot +| max_future_queue;
+        if (block.slot > tolerance_threshold) {
+            if (block.slot <= queue_threshold) {
                 self.logger.debug(
                     "block queueable as future-slot: slot={d} current_slot={d} queue_tolerance={d} time(intervals)={d}",
                     .{
@@ -2762,7 +2855,7 @@ pub const BeamChain = struct {
             }
             self.logger.debug("block validation failed: future slot {d} > max allowed {d} time(intervals)={d}", .{
                 block.slot,
-                current_slot + max_future_queue,
+                queue_threshold,
                 self.forkChoice.fcStore.slot_clock.time.load(.monotonic),
             });
             return BlockValidationError.FutureSlot;
@@ -4225,10 +4318,10 @@ test "enqueuePendingBlock #788: cap eviction drops oldest by receive order" {
     try std.testing.expect(ok);
     try std.testing.expectEqual(constants.MAX_PENDING_BLOCKS, fx.beam_chain.pending_blocks.items.len);
     // Front is no longer slot=100 (it was evicted).
-    try std.testing.expect(fx.beam_chain.pending_blocks.items[0].block.slot != 100);
+    try std.testing.expect(fx.beam_chain.pending_blocks.items[0].signed_block.block.slot != 100);
     // Tail is the newly-inserted block.
     const last = fx.beam_chain.pending_blocks.items[constants.MAX_PENDING_BLOCKS - 1];
-    try std.testing.expectEqual(@as(types.Slot, constants.MAX_PENDING_BLOCKS + 200), last.block.slot);
+    try std.testing.expectEqual(@as(types.Slot, constants.MAX_PENDING_BLOCKS + 200), last.signed_block.block.slot);
 }
 
 test "enqueuePendingBlock #788: drops blocks before latest_finalized" {
@@ -4267,7 +4360,7 @@ test "enqueuePendingBlock #788: drops blocks before latest_finalized" {
     try zeam_utils.hashTreeRoot(types.BeamBlock, fresh.block, &fresh_root, chain_allocator);
     try std.testing.expect(fx.beam_chain.enqueuePendingBlock(fresh, fresh_root));
     try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
-    try std.testing.expectEqual(@as(types.Slot, 200), fx.beam_chain.pending_blocks.items[0].block.slot);
+    try std.testing.expectEqual(@as(types.Slot, 200), fx.beam_chain.pending_blocks.items[0].signed_block.block.slot);
 }
 
 test "processPendingBlocks #788: evicts pre-finalized entries during scan" {
@@ -4293,6 +4386,221 @@ test "processPendingBlocks #788: evicts pre-finalized entries during scan" {
     const missing = fx.beam_chain.processPendingBlocks();
     defer chain_allocator.free(missing);
     try std.testing.expectEqual(@as(usize, 0), fx.beam_chain.pending_blocks.items.len);
+}
+
+// PR #841 review #10: drain-side eviction of "too-far-future" entries.
+// An adversary that floods with blocks at `current_slot + 200` (within
+// MAX_FUTURE_SLOT_QUEUE_TOLERANCE = 256 so accepted into queue) leaves
+// them sitting in the queue forever — they never become processable
+// until the forkchoice clock advances by 200 slots. The drain now
+// evicts them in the same compaction pass that handles pre-finalized.
+test "processPendingBlocks #788: evicts too-far-future entries during scan" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    const chain_allocator = fx.beam_chain.allocator;
+
+    // Queue an entry near the queue's upper bound while the forkchoice
+    // clock is still at slot 0. The bound is
+    //   `current_slot + MAX_FUTURE_SLOT_QUEUE_TOLERANCE`
+    // so anything strictly greater is "too far" by the drain's
+    // contract. We pick `+ TOLERANCE + 1` to live exactly one slot
+    // beyond the cutoff. enqueuePendingBlock itself does NOT enforce
+    // this rule (validateBlock does at gossip ingress), so we can
+    // legitimately have such an entry in the queue if e.g. a previous
+    // build tolerated a wider window or finalization advancement
+    // shifted the boundary.
+    var entry: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, fx.mock_chain.blocks[1], &entry);
+    entry.block.slot = constants.MAX_FUTURE_SLOT_QUEUE_TOLERANCE + 1;
+    var entry_root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, entry.block, &entry_root, chain_allocator);
+    try std.testing.expect(fx.beam_chain.enqueuePendingBlock(entry, entry_root));
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+
+    // current_slot stays at 0 (forkchoice clock has not advanced),
+    // so the entry's slot strictly exceeds
+    //   current_slot +| MAX_FUTURE_SLOT_QUEUE_TOLERANCE = 0 + 256 = 256.
+    // The drain must evict it.
+    const missing = fx.beam_chain.processPendingBlocks();
+    defer chain_allocator.free(missing);
+    try std.testing.expectEqual(@as(usize, 0), fx.beam_chain.pending_blocks.items.len);
+}
+
+// PR #841 review #9: append_oom path coverage. The capacity
+// reservation in `enqueuePendingBlock` MUST fail before the
+// cap-eviction so an allocator failure does not lose two blocks per
+// OOM event (one evicted, one rejected). Use a FailingAllocator
+// pinned to the chain's pending-blocks ArrayList so we can drive it
+// to OOM on the reservation step deterministically.
+test "enqueuePendingBlock #788: append_oom path returns false without evicting" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    // Construct a SignedBlock owned by a FailingAllocator. The clone
+    // we pass into `enqueuePendingBlock` lives off `failing_alloc`;
+    // failing_alloc.fail_index = 0 means "every alloc fails". The
+    // ArrayList's `ensureUnusedCapacity(allocator, 1)` is the first
+    // allocation it makes after the queue’s steady-state buffer is
+    // already at MAX_PENDING_BLOCKS, so a fresh, empty queue with no
+    // backing capacity will hit the failing-allocator on the
+    // reservation step.
+    //
+    // We replace the chain's pending_blocks with a fresh ArrayList
+    // backed by the FailingAllocator (its allocator is what the
+    // helper passes through), then issue an enqueue and assert: (a)
+    // returns false, (b) bumps `append_oom`, (c) does NOT bump `cap`
+    // (no eviction took place), (d) the queue stays empty.
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    const failing_alloc = failing.allocator();
+
+    // Swap in a fresh ArrayList allocated under the failing allocator.
+    // The chain's lock isn't yet contended (single-threaded test) so
+    // direct field assignment is safe; we restore the original at end.
+    const orig = fx.beam_chain.pending_blocks;
+    fx.beam_chain.pending_blocks = .empty;
+    defer {
+        // Drain whatever the failing-allocator queue ended up holding
+        // (it should be empty post-test) and free its tiny backing
+        // buffer through the same allocator. Then restore.
+        for (fx.beam_chain.pending_blocks.items) |*e| e.signed_block.deinit();
+        fx.beam_chain.pending_blocks.deinit(failing_alloc);
+        fx.beam_chain.pending_blocks = orig;
+    }
+
+    // Stash the chain's allocator pointer so enqueuePendingBlock uses
+    // the failing one for `ensureUnusedCapacity`. The chain stores
+    // its allocator in a single field; flip it for the test only.
+    const orig_alloc = fx.beam_chain.allocator;
+    fx.beam_chain.allocator = failing_alloc;
+    defer fx.beam_chain.allocator = orig_alloc;
+
+    // Build the candidate clone using the parent (real) allocator so
+    // its construction itself doesn't OOM.
+    var clone: types.SignedBlock = undefined;
+    try types.sszClone(orig_alloc, types.SignedBlock, fx.mock_chain.blocks[1], &clone);
+    var clone_root: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, clone.block, &clone_root, orig_alloc);
+
+    // ensureUnusedCapacity(failing_alloc, 1) hits the FailingAllocator
+    // and returns error.OutOfMemory; enqueuePendingBlock catches it,
+    // deinits the candidate, bumps the metric, returns false.
+    const queued = fx.beam_chain.enqueuePendingBlock(clone, clone_root);
+    try std.testing.expect(!queued);
+
+    // Queue stayed empty (no eviction happened on the way in).
+    try std.testing.expectEqual(@as(usize, 0), fx.beam_chain.pending_blocks.items.len);
+
+    // Sanity: the FailingAllocator saw zero successful allocations
+    // (the only attempt — the capacity reservation — was rejected).
+    // The `allocations` counter on FailingAllocator only increments
+    // on success; the rejection still counted as the `fail_index = 0`
+    // branch, so this asserts the failure path was taken.
+    try std.testing.expectEqual(@as(usize, 0), failing.allocations);
+}
+
+// PR #841 review #4/#5: dedup compares cached roots, not re-hashed
+// blocks. The cap-1024 worst case used to do 1024 SSZ tree-hashes per
+// duplicate-check; now it does 1024 32-byte memcmp's. Lock the
+// behaviour in code so a future contributor cannot accidentally drop
+// `PendingBlockEntry.block_root` and silently regress the perf.
+test "enqueuePendingBlock #788: dedup uses cached root, not re-hash" {
+    var fx = try FutureSlotTestFixture.init(std.testing.allocator);
+    defer fx.deinit(std.testing.allocator);
+
+    const chain_allocator = fx.beam_chain.allocator;
+
+    // Enqueue one legitimate entry.
+    var clone1: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, fx.mock_chain.blocks[1], &clone1);
+    clone1.block.slot = 50;
+    var root1: types.Root = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, clone1.block, &root1, chain_allocator);
+    try std.testing.expect(fx.beam_chain.enqueuePendingBlock(clone1, root1));
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+
+    // The queued entry should carry its precomputed root verbatim
+    // (this is the data the dedup loop reads).
+    try std.testing.expect(
+        std.mem.eql(u8, &fx.beam_chain.pending_blocks.items[0].block_root, &root1),
+    );
+
+    // Enqueue a second clone of the SAME block (same root). The dedup
+    // loop must hit on memcmp without re-hashing either side, and the
+    // duplicate must be dropped (return false).
+    var clone2: types.SignedBlock = undefined;
+    try types.sszClone(chain_allocator, types.SignedBlock, clone1, &clone2);
+    const dedup_result = fx.beam_chain.enqueuePendingBlock(clone2, root1);
+    try std.testing.expect(!dedup_result);
+    try std.testing.expectEqual(@as(usize, 1), fx.beam_chain.pending_blocks.items.len);
+}
+
+// PR #841 review #13: lock the metrics scrape contract for the
+// future-block queue so a struct rename or serializer regression
+// fails CI here, not silently in production. Mirrors the slice-(b)
+// LockTimer → /metrics audit pattern (`pkgs/node/src/locking.zig`)
+// and the slice-c-2b commit-5 refcount-distribution audit.
+//
+// We don't need to drive a real chain end-to-end — just exercise the
+// Counter/Gauge handles the chain code uses and assert each metric
+// name + every label appears in the Prometheus body. If any of the
+// four metrics gets dropped from the `Metrics` struct, gets renamed,
+// or loses a label, this test fails immediately.
+test "#788 metrics: queue + drop counters appear in /metrics output" {
+    if (zeam_metrics.isZKVM()) return;
+
+    try zeam_metrics.init(std.heap.page_allocator);
+
+    // Set / bump every label so the scrape body contains a sample
+    // line for each. The `catch {}` mirrors production usage —
+    // production code never fails-closed on a metric write.
+    zeam_metrics.metrics.lean_pending_blocks_depth.set(7);
+    zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "cap" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "pre_finalized" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "too_far_future" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "duplicate" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_evicted_total.incr(.{ .reason = "append_oom" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "accepted" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "rejected" }) catch {};
+    zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "error" }) catch {};
+    zeam_metrics.metrics.lean_blocks_future_slot_dropped_total.incr();
+
+    var alloc_writer = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer alloc_writer.deinit();
+    try zeam_metrics.writeMetrics(&alloc_writer.writer);
+    const body = alloc_writer.writer.buffered();
+
+    // Top-level metric families must be advertised.
+    try std.testing.expect(std.mem.indexOf(u8, body, "lean_pending_blocks_depth") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "lean_pending_blocks_evicted_total") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "lean_pending_blocks_replayed_total") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "lean_blocks_future_slot_dropped_total") != null);
+
+    // Every label used by the production code must show up at least
+    // once — this is what catches a label rename / typo regression.
+    const evict_labels = [_][]const u8{
+        "reason=\"cap\"",
+        "reason=\"pre_finalized\"",
+        "reason=\"too_far_future\"",
+        "reason=\"duplicate\"",
+        "reason=\"append_oom\"",
+    };
+    for (evict_labels) |lbl| {
+        try std.testing.expect(std.mem.indexOf(u8, body, lbl) != null);
+    }
+    const replay_labels = [_][]const u8{
+        "result=\"accepted\"",
+        "result=\"rejected\"",
+        "result=\"error\"",
+    };
+    for (replay_labels) |lbl| {
+        try std.testing.expect(std.mem.indexOf(u8, body, lbl) != null);
+    }
+
+    // Concrete value lines: locks the gauge↑/counter↑writeMetrics
+    // contract beyond just "the name appears".
+    try std.testing.expect(std.mem.indexOf(u8, body, "lean_pending_blocks_depth 7") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "lean_blocks_future_slot_dropped_total 1") != null);
 }
 
 // TODO: Enable and update this test once the keymanager file-reading PR is added

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -10,6 +10,14 @@ pub const SECONDS_PER_INTERVAL_MS: isize = @divFloor(params.SECONDS_PER_SLOT * s
 // future block (queued via `pending_blocks`) or, for attestations, rejected.
 // One slot of tolerance covers the normal race between `onInterval` and a
 // neighbouring node's gossip arriving slightly early.
+//
+// leanSpec note: this is a zeam-specific constant, not spec-defined. leanSpec
+// uses GOSSIP_DISPARITY_INTERVALS = 1 (~800ms) for *attestations*
+// (forks/lstar/spec.py:1022) with an explicit anti-pre-publish argument; for
+// blocks no spec constant exists and we follow the Ethereum CL p2p-interface
+// convention of allowing future-slot blocks to be queued. 4 s vs 800 ms is
+// wider than the attestation analog but matches existing zeam behaviour from
+// before #788 (#788 preserves rather than introduces this value).
 pub const MAX_FUTURE_SLOT_TOLERANCE = 1;
 
 // Maximum number of slots in the future that a *block* may be queued for
@@ -23,6 +31,13 @@ pub const MAX_FUTURE_SLOT_TOLERANCE = 1;
 // worst observed lag (~160 slots in the linked devnet-4 incident) so blocks
 // can be replayed once the clock catches up. Anything beyond this is almost
 // certainly an actually-malicious or buggy peer and is dropped.
+//
+// Tuning note: 256 is empirical, derived from devnet-4's worst lag. There is
+// no leanSpec analog — the spec doesn't define a future-block queue depth
+// (cf. `MAX_FUTURE_SLOT_TOLERANCE` above where a partial analog exists). This
+// value SHOULD be revisited if `zeam_lock_hold_seconds` reaches new highs
+// under devnet-N (N > 4) or if `lean_blocks_future_slot_dropped_total` shows
+// sustained drops on a healthy network. Don't ossify the magic number.
 pub const MAX_FUTURE_SLOT_QUEUE_TOLERANCE: u64 = 256;
 
 // Maximum number of blocks held in the `pending_blocks` future-block queue.
@@ -33,6 +48,13 @@ pub const MAX_FUTURE_SLOT_QUEUE_TOLERANCE: u64 = 256;
 // count) this caps the queue at ~2MB which is negligible vs the rest of
 // chain state. Older entries (lower-slot, lower-receive-time) are evicted
 // first when the cap is hit.
+//
+// leanSpec analog: `subspecs/sync/config.py::MAX_CACHED_BLOCKS` (also 1024;
+// same magnitude, same FIFO-eviction policy on overflow). Naming differs
+// because `pending_blocks` is zeam's pre-existing identifier for the
+// future-block queue and renaming it would touch every callsite without
+// behavioural benefit; flag the spec mapping here so future maintainers
+// can find the spec source when leanSpec test vectors land.
 pub const MAX_PENDING_BLOCKS: usize = 1024;
 
 // Maximum depth for recursive block fetching
@@ -40,7 +62,11 @@ pub const MAX_PENDING_BLOCKS: usize = 1024;
 pub const MAX_BLOCK_FETCH_DEPTH = 512;
 
 // Maximum number of blocks to keep in the fetched blocks cache
-// This prevents unbounded memory growth from malicious peers sending orphaned blocks
+// This prevents unbounded memory growth from malicious peers sending orphaned blocks.
+//
+// leanSpec analog: `subspecs/sync/config.py::MAX_CACHED_BLOCKS` (this constant
+// is the direct Zig mirror of the spec name; see `MAX_PENDING_BLOCKS` for the
+// related future-block queue cap with a different scope).
 pub const MAX_CACHED_BLOCKS = 1024;
 
 // Periodic state pruning interval: prune non-canonical states every N slots

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -5,9 +5,35 @@ const params = @import("@zeam/params");
 pub const INTERVALS_PER_SLOT = 5;
 pub const SECONDS_PER_INTERVAL_MS: isize = @divFloor(params.SECONDS_PER_SLOT * std.time.ms_per_s, INTERVALS_PER_SLOT);
 
-// Maximum number of slots in the future that an attestation is allowed to reference
-// This prevents accepting attestations that are too far ahead of the current slot
+// Maximum number of slots in the future that an attestation/block is allowed to
+// reference for *immediate* acceptance. Anything beyond this is treated as a
+// future block (queued via `pending_blocks`) or, for attestations, rejected.
+// One slot of tolerance covers the normal race between `onInterval` and a
+// neighbouring node's gossip arriving slightly early.
 pub const MAX_FUTURE_SLOT_TOLERANCE = 1;
+
+// Maximum number of slots in the future that a *block* may be queued for
+// later replay from `pending_blocks`. Issue #788: under mutex contention
+// (#786) the local `onInterval` can be delayed long enough that the forkchoice
+// clock lags wall-time by tens of slots; gossip blocks for those slots arrive
+// at the wall-clock time and would otherwise be rejected with `FutureSlot`,
+// causing the fork choice head to fall back to the latest finalized
+// checkpoint when no descendants exist in the protoArray. Buffering up to
+// `MAX_FUTURE_SLOT_QUEUE_TOLERANCE` slots ahead lets the queue absorb the
+// worst observed lag (~160 slots in the linked devnet-4 incident) so blocks
+// can be replayed once the clock catches up. Anything beyond this is almost
+// certainly an actually-malicious or buggy peer and is dropped.
+pub const MAX_FUTURE_SLOT_QUEUE_TOLERANCE: u64 = 256;
+
+// Maximum number of blocks held in the `pending_blocks` future-block queue.
+// Bounded to prevent OOM from a malicious or buggy peer that gossips a wide
+// range of fake-future blocks. Sized to comfortably exceed the worst observed
+// catch-up window (#788) without giving an attacker meaningful memory
+// pressure: at ~2KB per `SignedBlock` envelope (varies with attestation
+// count) this caps the queue at ~2MB which is negligible vs the rest of
+// chain state. Older entries (lower-slot, lower-receive-time) are evicted
+// first when the cap is hit.
+pub const MAX_PENDING_BLOCKS: usize = 1024;
 
 // Maximum depth for recursive block fetching
 // When fetching parent blocks, we stop after this many levels to avoid infinite loops


### PR DESCRIPTION
## Summary

Fixes #788 — `zeam_0` periodically resetting its fork-choice head to the latest finalized checkpoint while the network advanced 100+ slots beyond, dropping out of attestation duties for tens of slots at a time.

## Root cause (re-derived from logs + code, not just the issue body)

Under mutex contention (#786) the libxev `onInterval` tick is delayed long enough for the **forkchoice's local slot clock** (`fcStore.slot_clock.timeSlots`) to lag wall-time by tens of slots. Gossip blocks for those slots arrive at the wall-clock time and are validated against the lagged clock:

```zig
// pkgs/node/src/chain.zig (pre-fix)
const current_slot = self.forkChoice.fcStore.slot_clock.timeSlots.load(.monotonic);
if (block.slot > current_slot + MAX_FUTURE_SLOT_TOLERANCE /*=1*/) {
    return BlockValidationError.FutureSlot;  // dropped
}
```

With no new descendants entering `protoArray`, `forkchoice.computeFCHead` walks from `latest_justified` and finds no children → `head` falls back to the latest finalized checkpoint. That's the symptom #788 traces (`Current Slot: 200 | Head Slot: 93 | Behind: 107`).

The issue body's direction — "zeam's clock jumps **forward**" — turns out to be inverted; logs from the run show zeam's `current_slot` is wall-clock-correct, the **forkchoice clock** is what lags, and gossip blocks at slot `current_slot + N` (N > 1) are the ones being dropped. Same fix either way: stop dropping queueable future-slot blocks.

## Relationship to #803 (mutex contention work)

The slice work that closed out the mutex-contention root cause (#786) is **already merged**:

| Slice | PR | Status |
|---|---|---|
| (a-2) per-resource locks + `BorrowedState` | #805 | ✅ merged |
| (a-3) drop `BeamNode.mutex` + `BlockCache` | #820 | ✅ merged |
| (b) stress harness + metrics audit | #822 | ✅ merged |
| (c-1) chain-worker scaffold | #826 | ✅ merged |
| (c-2a) `RcBeamState` refcounted state | #827 | ✅ merged |
| (c-2b/c-2c) handler routing + state-rwlock drop + queue-saturation stress | #828 | ✅ merged |

So the question is no longer "are mutexes addressed" — they are. The remaining gap on the contention side is operational rather than code:

- **`--chain-worker` defaults to `off`** in main. PR #830 (`enum + flip default to on`) was closed without merging; the chain-worker queue path is in the binary but not active unless `--chain-worker=on` is passed. Until that flips on (or the CLI shape lands as #830 v2), production deployments are still on the synchronous path that originally exhibited the lag, so the symptom this PR addresses can still appear.
- **Slices (d) and (e) of the original 5-slice plan** (parallel net-fetch + missed-root prune; centralised gossip envelope hash-root cache) don't yet have open PRs.

Even once `--chain-worker=on` is the default, this PR is still useful: a queueable-future-slot pathway is correct independent of why the clock lagged (cold-start lag, GC pause, large STF block under any threading model, slow disk on db commit, …). The defensive layer + the contention work close the loop together.

## Fix

Extend the existing `pending_blocks` queue (which already handled the slot+1 per-interval boundary race) to absorb a longer clock-lag window, plus the supporting bookkeeping to keep it from becoming a memory or correctness foot-gun.

### `validateBlock` — three-way future-slot split

| `block.slot` vs `current_slot` | Outcome |
|---|---|
| `≤ current_slot + MAX_FUTURE_SLOT_TOLERANCE` (=1) | falls through; existing per-interval check either queues or processes inline |
| `≤ current_slot + MAX_FUTURE_SLOT_QUEUE_TOLERANCE` (=256, ~17 min at 4s/slot) | new error `FutureSlotQueueable`; gossip path clones + queues |
| `> MAX_FUTURE_SLOT_QUEUE_TOLERANCE` | `FutureSlot` (hard reject) + bumps `lean_blocks_future_slot_dropped_total` |

`MAX_FUTURE_SLOT_QUEUE_TOLERANCE = 256` was sized to comfortably exceed the worst lag observed on devnet-4 (~160 slots) without giving an attacker a meaningful queue to flood.

### `enqueuePendingBlock` — one place, every edge case

New helper that handles all queue-side concerns under `pending_blocks_lock`:

- **Capacity bound** — `MAX_PENDING_BLOCKS = 1024` (~2MB at typical block size). Cap-evicts **oldest by receive order** (FIFO-fair) so a flood of high-slot fake-future blocks cannot starve a legitimate near-future block out of the queue. The evicted block can always be re-fetched via `blocks_by_range` once we catch up.
- **Dedup by root** — peers re-gossip aggressively during a lag window; duplicates are dropped rather than re-run.
- **Pre-finalized eviction (gossip-path sweep)** — drops queued entries whose slot fell below `latest_finalized.slot`; they can never be canonical.
- **OOM-safe append** — allocator failure path frees the clone and bumps the eviction counter; never silently leaks.

### `processPendingBlocks` — drain-path sweep + replay metrics

The drain loop now also evicts pre-finalized entries during its scan so a queue full of dead entries from a previous lag window self-cleans. Updates `lean_pending_blocks_depth` after every drain so gauges don't go stale.

## Metrics

The slice-(b) lesson — *doc-only audits regress silently* — applies; every new path here gets an instrumented counter or gauge so an operator can spot the bug recurring without grepping logs:

- `lean_pending_blocks_depth` (gauge) — instantaneous queue depth.
- `lean_pending_blocks_evicted_total{reason}` — `cap` / `pre_finalized` / `duplicate` / `append_oom`.
- `lean_pending_blocks_replayed_total{result}` — `accepted` / `rejected` / `error`.
- `lean_blocks_future_slot_dropped_total` — **counts the symptom #788 was tracking**; should stay at 0 under healthy conditions, and a non-zero rate is a smoking gun for a recurrence.

## Edge cases covered (with tests)

All seven new tests live in `pkgs/node/src/chain.zig` and run as part of `zig build test`:

1. **`FutureSlotQueueable` for block within queue tolerance** — basic positive case.
2. **`FutureSlot` hard-reject for block beyond queue tolerance** — basic negative case.
3. **Queue-tolerance boundary is inclusive** — locks the on-by-one boundary in code so a future contributor can't accidentally re-introduce the #788 reset by drift-of-one.
4. **Dedup by root** — re-gossip during a lag window doesn't bloat the queue or duplicate work.
5. **Cap eviction drops oldest by receive order** — fills queue to `MAX_PENDING_BLOCKS`, asserts FIFO eviction at the cap-overflow point and the new entry lands at the tail.
6. **Pre-finalized blocks evicted on gossip-path enqueue** — exercises the in-helper sweep.
7. **Pre-finalized blocks evicted on drain-path scan** — exercises the `processPendingBlocks` sweep, ensuring entries that age out between arrival and drain are still cleaned up.

## Verification

- `zig build` — green.
- `zig build test` — all 14 test groups + 139 chain tests pass; new `chain.test.*#788*` tests confirmed OK locally.
- `cargo build / check -p libp2p-glue` — green (untouched).
- `lean_blocks_future_slot_dropped_total` will let us confirm the fix on devnet-4 by inspection rather than waiting for a head-reset to recur.

## Out of scope (deliberate)

- Flipping `--chain-worker` default to `on` (closed-without-merge #830). Independent operational change; orthogonal to whether the queue-on-future-slot path is correct.
- Slices (d) and (e) of the #803 plan (parallel net-fetch + missed-root prune; centralised gossip envelope hash-root cache). No open PRs; tracked under #803.
- `lean_gossip_mesh_running` boolean gauge (#818 review thread).
- Per-network-id labelled future-block metrics (single-instance node only today; see #818 for the matching atomic-array pattern when we go multi-network).

References: #788 (this), #786 (mutex contention root cause; addressed by merged slices of #803), #803 (slice work).