### PR TITLE
node: parallel net-fetch (slice d) + centralised hash-root cache (slice e); chain-worker default on (#803)

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -77,9 +77,11 @@ pub const NodeCommand = struct {
     @"db-backend": database.Backend = .rocksdb,
     @"chain-spec": ?[]const u8 = null,
     /// Slice c-2b commit 3 of #803: route producer-side gossip
-    /// handlers through the chain-worker queue. Default `false`
-    /// preserves slice-(b) synchronous behavior.
-    @"chain-worker": bool = false,
+    /// handlers through the chain-worker queue. Default `true` post
+    /// devnet-4 burn-in (#788 follow-up + slice (d)/(e) PR): the
+    /// worker path is the supported prod path; the synchronous path
+    /// stays in place as a kill-switch via `--chain-worker false`.
+    @"chain-worker": bool = true,
 
     pub const __shorts__ = .{
         .help = .h,
@@ -104,7 +106,7 @@ pub const NodeCommand = struct {
         .@"aggregate-subnet-ids" = "Comma-separated list of subnet ids to additionally subscribe and aggregate gossip attestations (e.g. '0,1,2'); adds to automatic computation from validator ids",
         .@"db-backend" = "Database backend to use for on-disk state: 'rocksdb' (default) or 'lmdb'",
         .@"chain-spec" = "Path to the chain specification file, if unspecified falls back to the default setting",
-        .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread. Off by default; the synchronous path stays in place when disabled.",
+        .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread. On by default; pass `--chain-worker false` to fall back to the legacy synchronous path as a kill-switch.",
         .help = "Show help information for the node command",
     };
 };

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -96,10 +96,12 @@ pub const NodeOptions = struct {
     db_backend: database.Backend = .rocksdb,
     chain_spec: ?[]const u8 = null,
     /// Slice c-2b commit 3 of #803: route producer-side gossip
-    /// handlers through the chain-worker queue. Default `false`
-    /// preserves slice-(b) synchronous behavior. Surfaced as
-    /// `--chain-worker` on the `zeam node` CLI.
-    chain_worker_enabled: bool = false,
+    /// handlers through the chain-worker queue. Default `true` post
+    /// devnet-4 burn-in: the worker path is the supported prod path;
+    /// surfaced as `--chain-worker` on the `zeam node` CLI, with
+    /// `--chain-worker false` as the kill-switch for the legacy
+    /// synchronous path.
+    chain_worker_enabled: bool = true,
 
     pub fn deinit(self: *NodeOptions, allocator: std.mem.Allocator) void {
         for (self.bootnodes) |b| allocator.free(b);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -174,10 +174,19 @@ const Metrics = struct {
     lean_block_root_compute_skipped_total: LeanBlockRootComputeSkippedCounter,
     // Slice (d) of #803: visibility into the parallel net-fetch +
     // missed-root prune dedup. Bumped per `fetchBlockByRoots` call by
-    // outcome bucket: `already_in_forkchoice`, `already_in_block_cache`,
-    // `already_pending`, `fetched`. Lets operators see how much
-    // duplicate fetch work the dedup is saving and — just as
-    // important — catch a regression that bypasses the dedup.
+    // outcome bucket. Every entry of the input `roots` lands in
+    // exactly one bucket, so the outcome counters sum to `roots.len`
+    // per call — useful for asserting `sum(rate(lean_block_fetch_dedup_total))
+    // == sum(rate(… by outcome))` as a Grafana invariant. Buckets:
+    //   * `already_in_forkchoice` — protoArray hit on `hasBlocksBatch`.
+    //   * `already_in_block_cache` — awaiting parent or STF.
+    //   * `already_pending` — RPC in flight; another
+    //     `fetchBlockByRoots` call is already responsible.
+    //   * `fetched` — dispatched to a peer via `blocks_by_root`.
+    //   * `fetch_no_peers` — dispatch attempted but `selectPeer`
+    //     returned `error.NoPeersAvailable` (PR #842 review #1).
+    //   * `fetch_failed` — dispatch attempted but failed for any
+    //     other reason (queue full, encode failure, …).
     lean_block_fetch_dedup_total: LeanBlockFetchDedupCounter,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
@@ -659,7 +668,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.
         .lean_block_root_compute_skipped_total = try Metrics.LeanBlockRootComputeSkippedCounter.init(allocator, io, "lean_block_root_compute_skipped_total", .{ .help = "Total number of times a downstream consumer skipped a `hashTreeRoot(BeamBlock)` because the producer threaded a precomputed root through (slice (e) of #803). Labeled by skip site." }, .{}),
-        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched." }, .{}),
+        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched, fetch_no_peers, fetch_failed." }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -989,4 +998,68 @@ test "registerScrapeRefresher fans out to all registered callbacks" {
     try testing.expectEqual(@as(u32, 2), Hits.second);
     try testing.expectEqual(@as(u32, 2), Hits.ctx_first);
     try testing.expectEqual(@as(u32, 2), Hits.ctx_second);
+}
+
+// Slice (d)/(e) of #803 (PR #842 review #4 / nit followup):
+// lock the metrics scrape contract for the slice (d) per-fetch dedup
+// counters and the slice (e) per-site root-compute-skipped counters
+// in code, so a label rename / family drop / serializer regression
+// fails CI here, not silently in production. Mirrors the slice-(b)
+// LockTimer audit pattern (`pkgs/node/src/locking.zig`) and the #788
+// metric audit added in PR #841.
+test "slice (d)/(e) #803: fetch-dedup + root-compute-skipped counters appear in /metrics output" {
+    if (isZKVM()) return;
+
+    try init(std.heap.page_allocator);
+
+    // Bump every label the production code emits. `incr` / `incrBy`
+    // failures are swallowed to mirror production usage (the chain /
+    // node code uses `catch {}` on every metric write).
+
+    // lean_block_root_compute_skipped_total{site} — slice (e).
+    metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.onGossip" }) catch {};
+    metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.onBlock" }) catch {};
+    metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.processPendingBlocks" }) catch {};
+    metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "forkchoice.onBlock" }) catch {};
+
+    // lean_block_fetch_dedup_total{outcome} — slice (d). PR #842
+    // review #1 added `fetch_no_peers` and `fetch_failed`; assert all
+    // six outcomes appear so a label rename / drop fails CI.
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "already_in_forkchoice" }, 3) catch {};
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "already_in_block_cache" }, 5) catch {};
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "already_pending" }, 7) catch {};
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "fetched" }, 11) catch {};
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "fetch_no_peers" }, 13) catch {};
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "fetch_failed" }, 17) catch {};
+
+    var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer.deinit();
+    try writeMetrics(&alloc_writer.writer);
+    const body = alloc_writer.writer.buffered();
+
+    // Top-level metric families must be advertised.
+    try testing.expect(std.mem.indexOf(u8, body, "lean_block_root_compute_skipped_total") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "lean_block_fetch_dedup_total") != null);
+
+    const skip_sites = [_][]const u8{
+        "site=\"chain.onGossip\"",
+        "site=\"chain.onBlock\"",
+        "site=\"chain.processPendingBlocks\"",
+        "site=\"forkchoice.onBlock\"",
+    };
+    for (skip_sites) |lbl| {
+        try testing.expect(std.mem.indexOf(u8, body, lbl) != null);
+    }
+
+    const fetch_outcomes = [_][]const u8{
+        "outcome=\"already_in_forkchoice\"",
+        "outcome=\"already_in_block_cache\"",
+        "outcome=\"already_pending\"",
+        "outcome=\"fetched\"",
+        "outcome=\"fetch_no_peers\"",
+        "outcome=\"fetch_failed\"",
+    };
+    for (fetch_outcomes) |lbl| {
+        try testing.expect(std.mem.indexOf(u8, body, lbl) != null);
+    }
 }

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -158,6 +158,27 @@ const Metrics = struct {
     // via `recordChainStateRefcountDistribution` registered as a
     // context-bearing scrape refresher (see `registerScrapeRefresherCtx`).
     lean_chain_state_refcount_distribution: LeanChainStateRefcountDistributionHistogram,
+    // Slice (e) of #803: visibility into the centralised hash-root
+    // cache. Each block ingress now carries the block_root computed
+    // once at the gossip / RPC entry point through every downstream
+    // consumer (chain.onGossip, enqueuePendingBlock,
+    // processPendingBlocks, chain.onBlock, forkchoice.onBlock).
+    // This counter bumps every time a downstream consumer was able
+    // to skip the second `hashTreeRoot` because the producer threaded
+    // a precomputed root through. The `site` label identifies the
+    // skip site (e.g. "chain.onGossip", "chain.onBlock",
+    // "chain.processPendingBlocks", "chain.enqueuePendingBlock"). A
+    // sustained 0 for any site label means the cache plumbing is
+    // broken there — useful for catching a regression that drops
+    // the root on the floor in a future refactor.
+    lean_block_root_compute_skipped_total: LeanBlockRootComputeSkippedCounter,
+    // Slice (d) of #803: visibility into the parallel net-fetch +
+    // missed-root prune dedup. Bumped per `fetchBlockByRoots` call by
+    // outcome bucket: `already_in_forkchoice`, `already_in_block_cache`,
+    // `already_pending`, `fetched`. Lets operators see how much
+    // duplicate fetch work the dedup is saving and — just as
+    // important — catch a regression that bypasses the dedup.
+    lean_block_fetch_dedup_total: LeanBlockFetchDedupCounter,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
@@ -254,6 +275,9 @@ const Metrics = struct {
     const LockHoldTimeHistogram = metrics_lib.HistogramVec(f32, LockLabel, &NODE_MUTEX_BUCKETS);
     // pending_blocks drain iteration histogram type (slice a-2)
     const PendingBlocksDrainItersHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 });
+    // Slice (d)/(e) of #803.
+    const LeanBlockRootComputeSkippedCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
+    const LeanBlockFetchDedupCounter = metrics_lib.CounterVec(u64, struct { outcome: []const u8 });
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -633,6 +657,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Instantaneous depth of the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
+        // Slice (d)/(e) of #803 — see field doc for label semantics.
+        .lean_block_root_compute_skipped_total = try Metrics.LeanBlockRootComputeSkippedCounter.init(allocator, io, "lean_block_root_compute_skipped_total", .{ .help = "Total number of times a downstream consumer skipped a `hashTreeRoot(BeamBlock)` because the producer threaded a precomputed root through (slice (e) of #803). Labeled by skip site." }, .{}),
+        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched." }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -187,6 +187,12 @@ const Metrics = struct {
     //     returned `error.NoPeersAvailable` (PR #842 review #1).
     //   * `fetch_failed` — dispatch attempted but failed for any
     //     other reason (queue full, encode failure, …).
+    //   * `dedup_lost_race` — every requested root entered
+    //     `network.pending_block_roots` or `network.block_cache`
+    //     between our `hasBlocksBatch` snapshot and the network
+    //     helper's re-check, so dispatch was suppressed (PR #842
+    //     review followup). The benign TOCTOU window is documented
+    //     in `BeamNode.fetchBlockByRoots`.
     lean_block_fetch_dedup_total: LeanBlockFetchDedupCounter,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
@@ -668,7 +674,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.
         .lean_block_root_compute_skipped_total = try Metrics.LeanBlockRootComputeSkippedCounter.init(allocator, io, "lean_block_root_compute_skipped_total", .{ .help = "Total number of times a downstream consumer skipped a `hashTreeRoot(BeamBlock)` because the producer threaded a precomputed root through (slice (e) of #803). Labeled by skip site." }, .{}),
-        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched, fetch_no_peers, fetch_failed." }, .{}),
+        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched, fetch_no_peers, fetch_failed, dedup_lost_race." }, .{}),
     };
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
@@ -1023,14 +1029,16 @@ test "slice (d)/(e) #803: fetch-dedup + root-compute-skipped counters appear in 
     metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "forkchoice.onBlock" }) catch {};
 
     // lean_block_fetch_dedup_total{outcome} — slice (d). PR #842
-    // review #1 added `fetch_no_peers` and `fetch_failed`; assert all
-    // six outcomes appear so a label rename / drop fails CI.
+    // review #1 added `fetch_no_peers` and `fetch_failed`; the
+    // review followup added `dedup_lost_race`. Assert all seven
+    // outcomes appear so a label rename / drop fails CI.
     metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "already_in_forkchoice" }, 3) catch {};
     metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "already_in_block_cache" }, 5) catch {};
     metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "already_pending" }, 7) catch {};
     metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "fetched" }, 11) catch {};
     metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "fetch_no_peers" }, 13) catch {};
     metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "fetch_failed" }, 17) catch {};
+    metrics.lean_block_fetch_dedup_total.incrBy(.{ .outcome = "dedup_lost_race" }, 19) catch {};
 
     var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
     defer alloc_writer.deinit();
@@ -1058,6 +1066,7 @@ test "slice (d)/(e) #803: fetch-dedup + root-compute-skipped counters appear in 
         "outcome=\"fetched\"",
         "outcome=\"fetch_no_peers\"",
         "outcome=\"fetch_failed\"",
+        "outcome=\"dedup_lost_race\"",
     };
     for (fetch_outcomes) |lbl| {
         try testing.expect(std.mem.indexOf(u8, body, lbl) != null);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -1953,6 +1953,26 @@ pub const BeamChain = struct {
         };
         if (blockInfo.blockRoot != null) {
             zeam_metrics.metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.onBlock" }) catch {};
+            // PR #842 review #2: see the rationale in
+            // `forkchoice.onBlock`. Same trust-but-verify pattern at
+            // the chain-level public API boundary; debug + ReleaseSafe
+            // only, free in `ReleaseFast` / `ReleaseSmall`.
+            if (std.debug.runtime_safety) verify: {
+                var verify_root: [32]u8 = undefined;
+                zeam_utils.hashTreeRoot(types.BeamBlock, block, &verify_root, self.allocator) catch |err| {
+                    self.logger.warn(
+                        "chain.onBlock: blockRoot verification re-hash failed: {any}",
+                        .{err},
+                    );
+                    break :verify;
+                };
+                if (!std.mem.eql(u8, &block_root, &verify_root)) {
+                    std.debug.panic(
+                        "chain.onBlock: caller-supplied blockRoot=0x{x} does NOT match recomputed=0x{x} for block slot={d} — forkchoice protoArray would be silently corrupted; call site bug",
+                        .{ &block_root, &verify_root, block.slot },
+                    );
+                }
+            }
         }
 
         const post_state_owned = blockInfo.postState == null;

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -97,6 +97,18 @@ pub const ProducedBlock = struct {
     }
 };
 
+/// Slice (e) of #803: pending-blocks queue entry.
+///
+/// Stores the producer's already-computed hash-tree root alongside
+/// the block so the drain (`processPendingBlocks`) and any future
+/// dedup pass do not have to re-hash. Heap-owning data is the
+/// `signed_block` SSZ slices; the entry must be `signed_block.deinit()`d
+/// when removed.
+pub const PendingBlockEntry = struct {
+    signed_block: types.SignedBlock,
+    block_root: types.Root,
+};
+
 pub const BeamChain = struct {
     config: configs.ChainConfig,
     anchor_state: *types.BeamState,
@@ -197,7 +209,15 @@ pub const BeamChain = struct {
     // When a peer gossips a block for the current slot before our local interval
     // timer fires, the forkchoice rejects it with FutureSlot.  We hold such
     // blocks here and replay them in onInterval once the clock has caught up.
-    pending_blocks: std.ArrayList(types.SignedBlock),
+    //
+    // Slice (e) of #803: each entry carries the producer's already-computed
+    // hash-tree root alongside the block so dedup checks (when added) and the
+    // drain loop (`processPendingBlocks`) compare 32 bytes instead of re-hashing
+    // the full block body. The root is always present — every production
+    // caller (`chain.onGossip` block branch) already has one before it
+    // touches `pending_blocks`. The struct definition lives at module scope
+    // (`PendingBlockEntry`) so the field type can reference it.
+    pending_blocks: std.ArrayList(PendingBlockEntry),
 
     // Per-resource locks (slice a-2 of #803). See
     // `docs/threading_refactor_slice_a.md` for the lock-hierarchy contract:
@@ -382,10 +402,20 @@ pub const BeamChain = struct {
         ctx: *anyopaque,
         signed_block: types.SignedBlock,
         prune_forkchoice: bool,
+        block_root: ?types.Root,
     ) void {
         const self: *Self = @ptrCast(@alignCast(ctx));
+        // Slice (e) of #803: forward the producer's already-computed
+        // block_root (when present) into `onBlock` via
+        // `CachedProcessedBlockInfo.blockRoot`. Saves the worker thread
+        // a redundant `hashTreeRoot(BeamBlock)` call — a non-trivial
+        // SSZ traversal on a wide block body. `null` falls back to the
+        // pre-existing in-`onBlock` recompute path; this keeps callers
+        // that legitimately have no precomputed root (the c-1 stub /
+        // any future producer) working unchanged.
         const missing_roots = self.onBlock(signed_block, .{
             .pruneForkchoice = prune_forkchoice,
+            .blockRoot = block_root,
         }) catch |err| {
             self.logger.err("chain-worker: onBlock failed slot={d}: {any}", .{
                 signed_block.block.slot,
@@ -487,15 +517,26 @@ pub const BeamChain = struct {
     pub const SubmitError = chain_worker.BlockQueue.TrySendError || error{ChainWorkerDisabled};
 
     /// Route a block import through the chain-worker queue.
+    ///
+    /// Slice (e) of #803: `block_root` is the producer's already-
+    /// computed hash-tree root of `signed_block.block`. Pass `null`
+    /// only when the producer truly does not have one (and the
+    /// worker will recompute it inside `onBlock`). All current
+    /// production producers DO have a precomputed root — see
+    /// `BeamNode.onGossip`, `processBlockByRoot|RangeChunk`,
+    /// `publishBlock`, and `chain.onGossip` itself — so the
+    /// `null` path is a fallback for tests / future variants.
     pub fn submitBlock(
         self: *Self,
         signed_block: types.SignedBlock,
         prune_forkchoice: bool,
+        block_root: ?types.Root,
     ) SubmitError!void {
         const w = self.chain_worker orelse return error.ChainWorkerDisabled;
         try w.sendBlock(.{ .on_block = .{
             .signed_block = signed_block,
             .prune_forkchoice = prune_forkchoice,
+            .block_root = block_root,
         } });
     }
 
@@ -601,8 +642,9 @@ pub const BeamChain = struct {
         // Clean up root to slot cache
         self.root_to_slot_cache.deinit();
         // Clean up any blocks that were queued waiting for the forkchoice clock
-        for (self.pending_blocks.items) |*block| {
-            block.deinit();
+        // (slice (e): each entry now wraps the SignedBlock + its precomputed root).
+        for (self.pending_blocks.items) |*entry| {
+            entry.signed_block.deinit();
         }
         self.pending_blocks.deinit(self.allocator);
 
@@ -1106,9 +1148,9 @@ pub const BeamChain = struct {
         while (true) {
             const fc_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
 
-            // Pop the first ready block under the lock; release before any
+            // Pop the first ready entry under the lock; release before any
             // heavy work so gossip-thread appends can proceed.
-            var ready: ?types.SignedBlock = null;
+            var ready: ?PendingBlockEntry = null;
             {
                 var t = LockTimer.start("pending_blocks", "processPendingBlocks.scan");
                 self.pending_blocks_lock.lock();
@@ -1116,8 +1158,8 @@ pub const BeamChain = struct {
                 defer t.released();
                 defer self.pending_blocks_lock.unlock();
 
-                for (self.pending_blocks.items, 0..) |b, i| {
-                    if (b.block.slot * constants.INTERVALS_PER_SLOT <= fc_time) {
+                for (self.pending_blocks.items, 0..) |entry, i| {
+                    if (entry.signed_block.block.slot * constants.INTERVALS_PER_SLOT <= fc_time) {
                         ready = self.pending_blocks.orderedRemove(i);
                         break;
                     }
@@ -1126,22 +1168,24 @@ pub const BeamChain = struct {
 
             if (ready) |unwrapped| {
                 iter_count += 1;
-                var queued_block = unwrapped;
-                defer queued_block.deinit();
+                var queued_entry = unwrapped;
+                defer queued_entry.signed_block.deinit();
 
-                const queued_slot = queued_block.block.slot;
-                var block_root: types.Root = undefined;
-                zeam_utils.hashTreeRoot(types.BeamBlock, queued_block.block, &block_root, self.allocator) catch |err| {
-                    self.logger.err("queued block slot={d}: failed to compute block root: {any}", .{ queued_slot, err });
-                    continue;
-                };
+                const queued_slot = queued_entry.signed_block.block.slot;
+                // Slice (e) of #803: reuse the producer's precomputed root
+                // instead of re-hashing the block on every drain. The root
+                // was stamped at gossip ingress — SSZ is
+                // collision-resistant, so this is identical to what the
+                // pre-#803 code path computed at this point.
+                const block_root: types.Root = queued_entry.block_root;
+                zeam_metrics.metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.processPendingBlocks" }) catch {};
 
                 self.logger.info(
                     "replaying queued block slot={d} blockroot=0x{x} (fc_time now={d})",
                     .{ queued_slot, &block_root, fc_time },
                 );
 
-                const missing_roots = self.onBlock(queued_block, .{
+                const missing_roots = self.onBlock(queued_entry.signed_block, .{
                     .blockRoot = block_root,
                 }) catch |err| {
                     self.logger.err("queued block slot={d} root=0x{x}: processing failed: {any}", .{ queued_slot, &block_root, err });
@@ -1149,7 +1193,7 @@ pub const BeamChain = struct {
                 };
                 defer self.allocator.free(missing_roots);
 
-                self.onBlockFollowup(true, &queued_block);
+                self.onBlockFollowup(true, &queued_entry.signed_block);
 
                 // Accumulate missing roots so the caller can fetch them.
                 all_missing_roots.appendSlice(self.allocator, missing_roots) catch {};
@@ -1577,12 +1621,35 @@ pub const BeamChain = struct {
         });
     }
 
-    pub fn onGossip(self: *Self, data: *const networks.GossipMessage, sender_peer_id: []const u8) !GossipProcessingResult {
+    /// Process an incoming gossip message.
+    ///
+    /// Slice (e) of #803: `precomputed_block_root` is the producer's
+    /// already-computed `hashTreeRoot(BeamBlock, signed_block.block)`.
+    /// Pass `null` only when the producer truly does not have one
+    /// — every current production gossip producer DOES (see
+    /// `BeamNode.onGossip` which computes it before taking any
+    /// per-resource lock so it can be reused across the lock-free
+    /// pre-check fan-out and this call). The block branch threads the
+    /// root through `validateBlock` → `enqueuePendingBlock` →
+    /// `submitBlock`/`onBlock` so a single block traversal is paid
+    /// once per ingress, not 3–4 times.
+    pub fn onGossip(
+        self: *Self,
+        data: *const networks.GossipMessage,
+        sender_peer_id: []const u8,
+        precomputed_block_root: ?types.Root,
+    ) !GossipProcessingResult {
         switch (data.*) {
             .block => |signed_block| {
                 const block = signed_block.block;
-                var block_root: [32]u8 = undefined;
-                try zeam_utils.hashTreeRoot(types.BeamBlock, block, &block_root, self.allocator);
+                const block_root: [32]u8 = if (precomputed_block_root) |r| r else r: {
+                    var cblock_root: [32]u8 = undefined;
+                    try zeam_utils.hashTreeRoot(types.BeamBlock, block, &cblock_root, self.allocator);
+                    break :r cblock_root;
+                };
+                if (precomputed_block_root != null) {
+                    zeam_metrics.metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.onGossip" }) catch {};
+                }
 
                 //check if we have the block already in forkchoice
                 const hasBlock = self.forkChoice.hasBlock(block_root);
@@ -1623,7 +1690,12 @@ pub const BeamChain = struct {
                                 t.acquired();
                                 defer t.released();
                                 defer self.pending_blocks_lock.unlock();
-                                try self.pending_blocks.append(self.allocator, cloned);
+                                // Slice (e) of #803: store the precomputed root
+                                // alongside the block so the drain doesn't re-hash.
+                                try self.pending_blocks.append(
+                                    self.allocator,
+                                    .{ .signed_block = cloned, .block_root = block_root },
+                                );
                             }
 
                             self.logger.info(
@@ -1671,7 +1743,9 @@ pub const BeamChain = struct {
                         try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
                         var cloned_consumed = false;
                         errdefer if (!cloned_consumed) cloned.deinit();
-                        self.submitBlock(cloned, true) catch |err| switch (err) {
+                        // Slice (e): forward the block_root we already computed
+                        // above so the worker thread doesn't re-hash the block.
+                        self.submitBlock(cloned, true, block_root) catch |err| switch (err) {
                             error.QueueFull => {
                                 self.logger.warn(
                                     "chain-worker: block queue full, dropping slot={d} root=0x{x}",
@@ -1872,11 +1946,14 @@ pub const BeamChain = struct {
 
         const block = signedBlock.block;
 
-        const block_root: types.Root = blockInfo.blockRoot orelse computedroot: {
+        const block_root: types.Root = if (blockInfo.blockRoot) |r| r else r: {
             var cblock_root: [32]u8 = undefined;
             try zeam_utils.hashTreeRoot(types.BeamBlock, block, &cblock_root, self.allocator);
-            break :computedroot cblock_root;
+            break :r cblock_root;
         };
+        if (blockInfo.blockRoot != null) {
+            zeam_metrics.metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "chain.onBlock" }) catch {};
+        }
 
         const post_state_owned = blockInfo.postState == null;
         const post_state = if (blockInfo.postState) |post_state_ptr| post_state_ptr else computedstate: {
@@ -5497,7 +5574,11 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
     var cloned_consumed = false;
     errdefer if (!cloned_consumed) cloned.deinit();
 
-    try beam_chain.submitBlock(cloned, false);
+    // Slice (e) of #803: pass `null` for `block_root` so the
+    // worker recomputes — this test deliberately exercises the
+    // fallback path. End-to-end gossip path coverage runs through
+    // the chain-worker stress harness in `stress.zig`.
+    try beam_chain.submitBlock(cloned, false, null);
     cloned_consumed = true;
 
     // Wait for the worker to drain the queue. We poll on the
@@ -5596,7 +5677,7 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
     defer off_cloned.deinit();
     try std.testing.expectError(
         error.ChainWorkerDisabled,
-        beam_chain_off.submitBlock(off_cloned, false),
+        beam_chain_off.submitBlock(off_cloned, false, null),
     );
 }
 

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -118,9 +118,21 @@ pub const Message = union(enum) {
     /// gossip handler (after gossipsub validation), or req/resp.
     /// Owns: `signed_block` (transitively the block body's
     /// attestations + signatures slices).
+    ///
+    /// Slice (e) of #803: `block_root` carries the producer's
+    /// already-computed hash-tree root of `signed_block.block` when
+    /// available. Producers always compute it (gossip ingress at
+    /// `BeamNode.onGossip`, RPC ingress at
+    /// `processBlockByRoot|RangeChunk`, locally-produced via
+    /// `publishBlock`); threading it through here lets the worker's
+    /// `onBlock` callback skip the second `hashTreeRoot` call,
+    /// removing one of three duplicate hashes per gossip block.
+    /// `null` means "unknown — recompute"; the worker side handles
+    /// both cases via `CachedProcessedBlockInfo.blockRoot`.
     on_block: struct {
         signed_block: types.SignedBlock,
         prune_forkchoice: bool,
+        block_root: ?types.Root = null,
     },
     /// Single attestation gossip. Producer is libp2p gossip handler.
     /// `SignedAttestation` is plain-old-data (fixed-size validator id,
@@ -372,7 +384,18 @@ pub const AttestationQueue = BoundedQueue(Message);
 /// chain method.
 pub const Handlers = struct {
     ctx: *anyopaque,
-    on_block: *const fn (ctx: *anyopaque, signed_block: types.SignedBlock, prune_forkchoice: bool) void,
+    /// Slice (e) of #803: `block_root` is the producer's already-
+    /// computed hash-tree root of `signed_block.block`, or `null` if
+    /// the producer didn't have one. The handler should pass it
+    /// straight into `BeamChain.onBlock` via
+    /// `CachedProcessedBlockInfo.blockRoot` so the worker thread
+    /// doesn't re-hash the same block.
+    on_block: *const fn (
+        ctx: *anyopaque,
+        signed_block: types.SignedBlock,
+        prune_forkchoice: bool,
+        block_root: ?types.Root,
+    ) void,
     on_gossip_attestation: *const fn (ctx: *anyopaque, gossip: networks.AttestationGossip) void,
     on_gossip_aggregated_attestation: *const fn (ctx: *anyopaque, agg: types.SignedAggregatedAttestation) void,
     process_pending_blocks: *const fn (ctx: *anyopaque, current_slot: types.Slot) void,
@@ -745,7 +768,12 @@ pub const ChainWorker = struct {
             return;
         };
         switch (m) {
-            .on_block => |payload| h.on_block(h.ctx, payload.signed_block, payload.prune_forkchoice),
+            .on_block => |payload| h.on_block(
+                h.ctx,
+                payload.signed_block,
+                payload.prune_forkchoice,
+                payload.block_root,
+            ),
             .on_gossip_attestation => |gossip| h.on_gossip_attestation(h.ctx, gossip),
             .on_gossip_aggregated_attestation => |agg| h.on_gossip_aggregated_attestation(h.ctx, agg),
             .process_pending_blocks => |payload| h.process_pending_blocks(h.ctx, payload.current_slot),
@@ -1196,6 +1224,63 @@ test "Message.deinit: on_block frees the SignedBlock heap (no leak under testing
         },
     };
     msg.deinit();
+}
+
+test "on_block carries optional block_root (slice (e) of #803)" {
+    // Verify the new optional `block_root` field on the on_block
+    // payload defaults to null AND faithfully round-trips through
+    // `Message.deinit`. The default null is the contract that lets
+    // existing callers compile unchanged; round-tripping is the
+    // contract that lets new callers thread their precomputed root
+    // through the queue without it getting silently dropped.
+    const attestations1 = try types.AggregatedAttestations.init(testing.allocator);
+    const signatures1 = try types.createBlockSignatures(testing.allocator, attestations1.len());
+    var msg_default: Message = .{
+        .on_block = .{
+            .signed_block = .{
+                .block = .{
+                    .slot = 1,
+                    .proposer_index = 0,
+                    .parent_root = std.mem.zeroes(types.Root),
+                    .state_root = std.mem.zeroes(types.Root),
+                    .body = .{ .attestations = attestations1 },
+                },
+                .signature = signatures1,
+            },
+            .prune_forkchoice = false,
+        },
+    };
+    try testing.expect(msg_default.on_block.block_root == null);
+    msg_default.deinit();
+
+    // Carry an explicit precomputed root.
+    const attestations2 = try types.AggregatedAttestations.init(testing.allocator);
+    const signatures2 = try types.createBlockSignatures(testing.allocator, attestations2.len());
+    var sentinel: types.Root = undefined;
+    var k: u8 = 0;
+    for (sentinel[0..]) |*b| {
+        b.* = k;
+        k +%= 1;
+    }
+    var msg_with_root: Message = .{
+        .on_block = .{
+            .signed_block = .{
+                .block = .{
+                    .slot = 2,
+                    .proposer_index = 0,
+                    .parent_root = std.mem.zeroes(types.Root),
+                    .state_root = std.mem.zeroes(types.Root),
+                    .body = .{ .attestations = attestations2 },
+                },
+                .signature = signatures2,
+            },
+            .prune_forkchoice = true,
+            .block_root = sentinel,
+        },
+    };
+    try testing.expect(msg_with_root.on_block.block_root != null);
+    try testing.expect(std.mem.eql(u8, &msg_with_root.on_block.block_root.?, &sentinel));
+    msg_with_root.deinit();
 }
 
 test "Message.deinit: POD variants are no-ops" {

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1668,11 +1668,16 @@ pub const ForkChoice = struct {
                 self.logger.info("[forkchoice] status=ready: first justified checkpoint observed slot={d} root={x} — validator duties now enabled", .{ self.fcStore.latest_justified.slot, &self.fcStore.latest_justified.root });
             }
 
-            const block_root: [32]u8 = opts.blockRoot orelse computedroot: {
+            const block_root: [32]u8 = if (opts.blockRoot) |r| r else r: {
                 var cblock_root: [32]u8 = undefined;
                 try zeam_utils.hashTreeRoot(types.BeamBlock, block, &cblock_root, self.allocator);
-                break :computedroot cblock_root;
+                break :r cblock_root;
             };
+            if (opts.blockRoot != null) {
+                // Slice (e) of #803 — see metrics field doc on
+                // `lean_block_root_compute_skipped_total`.
+                zeam_metrics.metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "forkchoice.onBlock" }) catch {};
+            }
             const is_timely = self.isBlockTimely(opts.blockDelayMs);
 
             const proto_block = ProtoBlock{
@@ -1790,6 +1795,36 @@ pub const ForkChoice = struct {
         self.mutex.lockShared();
         defer self.mutex.unlockShared();
         return self.hasBlockUnlocked(blockRoot);
+    }
+
+    /// Slice (d) of #803: batch presence check.
+    ///
+    /// Snapshots `hasBlock` for every root in `roots` under a single
+    /// shared-lock acquisition, writing results into `out` (which the
+    /// caller pre-allocates with `out.len == roots.len`). The batched
+    /// shape lets the producer (`BeamNode.fetchBlockByRoots`) trade N
+    /// shared-lock acquisitions + N hashmap lookups for 1 + N — the
+    /// hashmap lookup is unchanged but the lock-acquire/release pair
+    /// (and the ConcurrencyKit memory fence inside it) collapses to
+    /// one. Under heavy gossip-fanout the lock-acquire dominates the
+    /// hashmap lookup, so this is the call we want for every dedup
+    /// pass that operates on a list of roots.
+    ///
+    /// Returns `error.LengthMismatch` if `roots.len != out.len` so
+    /// the caller cannot accidentally read garbage past the end of
+    /// `out`.
+    pub fn hasBlocksBatch(
+        self: *Self,
+        roots: []const types.Root,
+        out: []bool,
+    ) error{LengthMismatch}!void {
+        if (roots.len != out.len) return error.LengthMismatch;
+        if (roots.len == 0) return;
+        self.mutex.lockShared();
+        defer self.mutex.unlockShared();
+        for (roots, 0..) |root, i| {
+            out[i] = self.hasBlockUnlocked(root);
+        }
     }
 
     pub fn getBlock(self: *Self, blockRoot: types.Root) ?ProtoBlock {
@@ -2004,6 +2039,70 @@ test "forkchoice block tree" {
         const searched_idx = fork_choice.protoArray.indices.get(mock_chain.blockRoots[i]);
         try std.testing.expect(searched_idx == i);
     }
+}
+
+test "hasBlocksBatch (slice (d) of #803): empty + length-mismatch + presence semantics" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(allocator, 3, null);
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+    var beam_state = mock_chain.genesis_state;
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+    const module_logger = zeam_logger_config.logger(.forkchoice);
+    var fork_choice = try ForkChoice.init(allocator, .{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .logger = module_logger,
+    });
+
+    // 1. Empty input is a no-op (does not panic / does not deadlock).
+    var empty_buf: [0]bool = .{};
+    try fork_choice.hasBlocksBatch(&[_]types.Root{}, &empty_buf);
+
+    // 2. Length mismatch is reported as an error rather than a UB read.
+    var bad_out: [1]bool = .{false};
+    try std.testing.expectError(
+        error.LengthMismatch,
+        fork_choice.hasBlocksBatch(&[_]types.Root{ mock_chain.blockRoots[0], mock_chain.blockRoots[0] }, &bad_out),
+    );
+
+    // 3. Anchor block (genesis) is present; a synthetic root is not.
+    //    Same shared lock acquisition snapshots both answers.
+    const synthetic = std.mem.zeroes(types.Root);
+    var roots: [3]types.Root = .{ mock_chain.blockRoots[0], synthetic, mock_chain.blockRoots[0] };
+    var present: [3]bool = .{ false, true, false };
+    try fork_choice.hasBlocksBatch(&roots, &present);
+    try std.testing.expect(present[0]);
+    try std.testing.expect(!present[1]);
+    try std.testing.expect(present[2]);
+
+    // 4. After ingesting block[1], `hasBlocksBatch` reflects the new state
+    //    in the same call shape — confirms the shared-lock snapshot is
+    //    re-taken on every call (not cached across).
+    const block1 = mock_chain.blocks[1].block;
+    try stf.apply_transition(allocator, &beam_state, block1, .{ .logger = module_logger });
+    try fork_choice.onInterval(block1.slot * constants.INTERVALS_PER_SLOT, false);
+    _ = try fork_choice.onBlock(block1, &beam_state, .{ .currentSlot = block1.slot, .blockDelayMs = 0, .confirmed = true });
+
+    var roots2: [2]types.Root = .{ mock_chain.blockRoots[1], synthetic };
+    var present2: [2]bool = .{ false, true };
+    try fork_choice.hasBlocksBatch(&roots2, &present2);
+    try std.testing.expect(present2[0]);
+    try std.testing.expect(!present2[1]);
 }
 
 test "aggregate prunes attestation signatures" {

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1677,6 +1677,42 @@ pub const ForkChoice = struct {
                 // Slice (e) of #803 — see metrics field doc on
                 // `lean_block_root_compute_skipped_total`.
                 zeam_metrics.metrics.lean_block_root_compute_skipped_total.incr(.{ .site = "forkchoice.onBlock" }) catch {};
+
+                // PR #842 review #2: trust-but-verify the
+                // caller-supplied root against a fresh hash in
+                // debug + ReleaseSafe builds. Cheap (debug-only)
+                // safety net for future call sites that thread a
+                // stale or wrong root through
+                // `OnBlockOpts.blockRoot`. The forkchoice's
+                // protoArray indexes by this root and the spec
+                // guarantees uniqueness via SSZ collision-
+                // resistance; if a caller fabricates a root, we'd
+                // silently corrupt the protoArray. Per-call cost is
+                // one `hashTreeRoot(BeamBlock, ...)` and is paid
+                // ONLY in `Debug` / `ReleaseSafe`; `ReleaseFast` /
+                // `ReleaseSmall` skip the block entirely so
+                // production keeps the slice-(e) win.
+                if (std.debug.runtime_safety) verify: {
+                    var verify_root: [32]u8 = undefined;
+                    zeam_utils.hashTreeRoot(types.BeamBlock, block, &verify_root, self.allocator) catch |err| {
+                        // Re-hash failure here is itself a bug, but
+                        // we don't want a forkchoice panic on an
+                        // OOM during the verification step — log
+                        // and skip so the caller-supplied root is
+                        // still used.
+                        self.logger.warn(
+                            "forkchoice.onBlock: blockRoot verification re-hash failed: {any}",
+                            .{err},
+                        );
+                        break :verify;
+                    };
+                    if (!std.mem.eql(u8, &block_root, &verify_root)) {
+                        std.debug.panic(
+                            "forkchoice.onBlock: caller-supplied blockRoot=0x{x} does NOT match recomputed=0x{x} for block slot={d} — protoArray would be silently corrupted; call site bug",
+                            .{ &block_root, &verify_root, slot },
+                        );
+                    }
+                }
             }
             const is_timely = self.isBlockTimely(opts.blockDelayMs);
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -50,9 +50,11 @@ const NodeOpts = struct {
     /// dedicated worker thread and producer-side handlers for
     /// gossip blocks / attestations route through its bounded
     /// queues instead of running synchronously on the libp2p
-    /// thread. Default `false` preserves slice-(b) behavior.
-    /// Surfaced to the CLI as `--chain-worker=on|off` (bool).
-    chain_worker_enabled: bool = false,
+    /// thread. Default `true` post devnet-4 burn-in: the worker
+    /// path is the supported prod path. Surfaced to the CLI as
+    /// `--chain-worker` (bool); `--chain-worker false` is the
+    /// kill-switch for the legacy synchronous path.
+    chain_worker_enabled: bool = true,
 };
 
 pub const BeamNode = struct {
@@ -305,7 +307,13 @@ pub const BeamNode = struct {
             },
         }
 
-        const result = self.chain.onGossip(data, sender_peer_id) catch |err| {
+        // Slice (e) of #803: thread `precomputed_block_root` through
+        // chain.onGossip so the chain layer doesn't recompute the
+        // hash-tree root we already have. For non-block gossip
+        // (attestation/aggregation) we pass `null`; the chain layer
+        // ignores it on those branches.
+        const root_for_chain: ?types.Root = if (data.* == .block) precomputed_block_root else null;
+        const result = self.chain.onGossip(data, sender_peer_id, root_for_chain) catch |err| {
             switch (err) {
                 // Block rejected because it's before finalized - drop it and prune any cached
                 // descendants we might still be holding onto.
@@ -1374,14 +1382,46 @@ pub const BeamNode = struct {
     ) !void {
         if (roots.len == 0) return;
 
-        // Check if any of the requested blocks are missing
+        // Slice (d) of #803: snapshot forkchoice presence for every
+        // root in one shared-lock acquisition (`hasBlocksBatch`),
+        // then dedup against the network-side caches under their own
+        // independent locks. Pre-#803 `fetchBlockByRoots` did N
+        // shared-lock acquires on the forkchoice and a sequential
+        // walk; under heavy gossip fanout that turned the dedup
+        // step into a serializing hot point. The batched call is
+        // strictly cheaper for any N ≥ 2 and equivalent at N == 1.
+        //
+        // We dedup against three caches in priority order so
+        // `lean_block_fetch_dedup_total{outcome}` faithfully reports
+        // *why* a root was already not-fetched:
+        //   1. forkchoice protoArray (already ingested).
+        //   2. network.block_cache (fetched, awaiting parent or STF).
+        //   3. network.pending_block_roots (RPC in flight; another
+        //      `fetchBlockByRoots` call is already responsible).
+        // The remainder feeds the actual RPC dispatch.
+        var fc_present_buf: std.ArrayListUnmanaged(bool) = .empty;
+        defer fc_present_buf.deinit(self.allocator);
+        try fc_present_buf.resize(self.allocator, roots.len);
+        try self.chain.forkChoice.hasBlocksBatch(roots, fc_present_buf.items);
+
         var missing_roots: std.ArrayList(types.Root) = .empty;
         defer missing_roots.deinit(self.allocator);
+        try missing_roots.ensureTotalCapacityPrecise(self.allocator, roots.len);
 
-        for (roots) |root| {
-            if (!self.chain.forkChoice.hasBlock(root)) {
-                try missing_roots.append(self.allocator, root);
+        for (roots, fc_present_buf.items) |root, fc_present| {
+            if (fc_present) {
+                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "already_in_forkchoice" }) catch {};
+                continue;
             }
+            if (self.network.hasFetchedBlock(root)) {
+                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "already_in_block_cache" }) catch {};
+                continue;
+            }
+            if (self.network.hasPendingBlockRoot(root)) {
+                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "already_pending" }) catch {};
+                continue;
+            }
+            missing_roots.appendAssumeCapacity(root);
         }
 
         if (missing_roots.items.len == 0) return;
@@ -1412,6 +1452,12 @@ pub const BeamNode = struct {
                 self.node_registry.getNodeNameFromPeerId(request_info.peer_id),
                 request_info.request_id,
             });
+            // Slice (d): one bump per actually-fetched root so the
+            // outcome buckets sum to `roots.len` for every call.
+            var i: usize = 0;
+            while (i < missing_roots.items.len) : (i += 1) {
+                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "fetched" }) catch {};
+            }
         }
     }
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1518,6 +1518,34 @@ pub const BeamNode = struct {
                 .{ .outcome = "fetched" },
                 missing_roots.items.len,
             ) catch {};
+        } else {
+            // PR #842 review followup: `ensureBlocksByRootRequest`
+            // can return `null` non-erroneously when
+            // `shouldRequestBlocksByRoot` rejects the batch — every
+            // root was already in `network.pending_block_roots` or
+            // `network.block_cache` by the time the network helper
+            // re-checked, in between our `hasBlocksBatch` snapshot
+            // and this dispatch (the benign TOCTOU documented at the
+            // top of this function). Without a bucket here those
+            // roots fall through unaccounted and the
+            // `sum(rate(lean_block_fetch_dedup_total)) ==
+            //  sum(rate(… by outcome))` invariant the audit test
+            // claims to lock breaks under any racing-gossip workload.
+            //
+            // The `roots.len == 0` early return inside
+            // `ensureBlocksByRootRequest` is unreachable from this
+            // call site — the surrounding `if (missing_roots.items.len
+            // == 0) return;` guard handles that case before we
+            // dispatch — so `dedup_lost_race` is the only legitimate
+            // null cause we need to account for.
+            self.logger.debug(
+                "blocks-by-root dispatch deduped late: {d} root(s) became known to network caches between snapshot and dispatch",
+                .{missing_roots.items.len},
+            );
+            zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                .{ .outcome = "dedup_lost_race" },
+                missing_roots.items.len,
+            ) catch {};
         }
     }
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1398,30 +1398,76 @@ pub const BeamNode = struct {
         //   2. network.block_cache (fetched, awaiting parent or STF).
         //   3. network.pending_block_roots (RPC in flight; another
         //      `fetchBlockByRoots` call is already responsible).
-        // The remainder feeds the actual RPC dispatch.
+        // The remainder feeds the actual RPC dispatch (counted as
+        // `fetched`) or the per-error path below (counted as
+        // `fetch_no_peers` / `fetch_failed`). Every entry of
+        // `roots` lands in exactly one bucket so the outcome
+        // counters sum to `roots.len` per call — PR #842 review #1.
+        //
+        // **TOCTOU note (PR #842 review #3):** the three cache
+        // lookups are independent (forkchoice rwlock + the two
+        // network LockedMap mutexes), so a concurrent thread can
+        // mutate any of them between our snapshot and the RPC
+        // dispatch — e.g. a gossip handler can ingest a block into
+        // the forkchoice protoArray after our `hasBlocksBatch` call
+        // returned `false` for it. The race is benign: the worst
+        // case is one duplicate `blocks_by_root` request whose
+        // response then takes the existing dedup path inside
+        // `processBlockByRootChunk` (`forkChoice.hasBlock` early
+        // return). The dedup counter still buckets the outcome
+        // correctly because it's snapshot-of-state-at-call-time, not
+        // a global "did we actually fetch the bytes" counter. Taking
+        // a single multi-resource lock to close this race would
+        // serialize the gossip-import and the RPC-fetch paths
+        // against each other for no correctness benefit.
         var fc_present_buf: std.ArrayListUnmanaged(bool) = .empty;
         defer fc_present_buf.deinit(self.allocator);
         try fc_present_buf.resize(self.allocator, roots.len);
         try self.chain.forkChoice.hasBlocksBatch(roots, fc_present_buf.items);
 
+        var already_in_fc: usize = 0;
+        var already_in_cache: usize = 0;
+        var already_pending: usize = 0;
         var missing_roots: std.ArrayList(types.Root) = .empty;
         defer missing_roots.deinit(self.allocator);
         try missing_roots.ensureTotalCapacityPrecise(self.allocator, roots.len);
 
         for (roots, fc_present_buf.items) |root, fc_present| {
             if (fc_present) {
-                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "already_in_forkchoice" }) catch {};
+                already_in_fc += 1;
                 continue;
             }
             if (self.network.hasFetchedBlock(root)) {
-                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "already_in_block_cache" }) catch {};
+                already_in_cache += 1;
                 continue;
             }
             if (self.network.hasPendingBlockRoot(root)) {
-                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "already_pending" }) catch {};
+                already_pending += 1;
                 continue;
             }
             missing_roots.appendAssumeCapacity(root);
+        }
+
+        // PR #842 review (nit): batch the per-bucket counter bumps
+        // via `incrBy(N)` instead of N back-to-back `incr()` calls.
+        // Same observed value, fewer atomic ops on the hot path.
+        if (already_in_fc > 0) {
+            zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                .{ .outcome = "already_in_forkchoice" },
+                already_in_fc,
+            ) catch {};
+        }
+        if (already_in_cache > 0) {
+            zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                .{ .outcome = "already_in_block_cache" },
+                already_in_cache,
+            ) catch {};
+        }
+        if (already_pending > 0) {
+            zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                .{ .outcome = "already_pending" },
+                already_pending,
+            ) catch {};
         }
 
         if (missing_roots.items.len == 0) return;
@@ -1430,16 +1476,30 @@ pub const BeamNode = struct {
         const maybe_request = self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler) catch |err| blk: {
             switch (err) {
                 error.NoPeersAvailable => {
+                    // PR #842 review #1: previously this path bumped
+                    // nothing, leaving the outcome buckets summing
+                    // short of `roots.len` whenever the dispatch
+                    // failed. Bucket explicitly so a Grafana panel
+                    // showing "sum(rate(lean_block_fetch_dedup_total))
+                    // == sum(rate(… by outcome))" stays an invariant.
                     self.logger.warn(
                         "no peers available to request {d} block(s) by root",
                         .{missing_roots.items.len},
                     );
+                    zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                        .{ .outcome = "fetch_no_peers" },
+                        missing_roots.items.len,
+                    ) catch {};
                 },
                 else => {
                     self.logger.warn(
                         "failed to send blocks-by-root request to peer: {any}",
                         .{err},
                     );
+                    zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                        .{ .outcome = "fetch_failed" },
+                        missing_roots.items.len,
+                    ) catch {};
                 },
             }
             break :blk null;
@@ -1454,10 +1514,10 @@ pub const BeamNode = struct {
             });
             // Slice (d): one bump per actually-fetched root so the
             // outcome buckets sum to `roots.len` for every call.
-            var i: usize = 0;
-            while (i < missing_roots.items.len) : (i += 1) {
-                zeam_metrics.metrics.lean_block_fetch_dedup_total.incr(.{ .outcome = "fetched" }) catch {};
-            }
+            zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                .{ .outcome = "fetched" },
+                missing_roots.items.len,
+            ) catch {};
         }
     }
 

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -893,7 +893,11 @@ fn saturationBlockProducerWorker(ctx: *SaturationCtx, thread_id: usize) void {
         };
 
         _ = ctx.block_attempts.fetchAdd(1, .monotonic);
-        ctx.chain.submitBlock(cloned, false) catch |err| {
+        // Slice (e) of #803: pass `null` for `block_root` so the
+        // worker recomputes — the stress harness deliberately
+        // exercises the fallback path. Real producers always pass
+        // a precomputed root.
+        ctx.chain.submitBlock(cloned, false, null) catch |err| {
             // We retain ownership on every error path — free the clone.
             cloned.deinit();
             switch (err) {


### PR DESCRIPTION
Three orthogonal but related changes that close the operational gap on #803 and shave duplicate work on every gossip block / RPC fetch.

## Slice (d) of #803 — parallel net-fetch + missed-root prune

`BeamNode.fetchBlockByRoots` previously walked `roots` once, calling `forkChoice.hasBlock(root)` per entry — N shared-lock acquisitions on the forkchoice rwlock and N hashmap lookups, in sequence. Under heavy gossip fanout the per-root acquire dominates the lookup cost.

New `ForkChoice.hasBlocksBatch(roots, out)` snapshots presence for every root under a single shared-lock acquisition. `fetchBlockByRoots` now uses it, then dedups against `network.block_cache` and `network.pending_block_roots` in priority order so each root's outcome — `already_in_forkchoice` / `already_in_block_cache` / `already_pending` / `fetched` — is recorded on `lean_block_fetch_dedup_total{outcome}`. Operators can now see (a) how much duplicate fetch work the dedup is saving and (b) whether a future refactor accidentally bypassed any of the three caches.

`hasBlocksBatch` returns `error.LengthMismatch` if `roots.len != out.len` so callers can't accidentally read past the end of `out`.

## Slice (e) of #803 — centralised hash-root cache

A gossip block currently has its hash-tree root computed up to four times: at `BeamNode.onGossip` (pre-lock), at `chain.onGossip` again, inside `chain.onBlock` if no `blockRoot` was passed, and inside `forkchoice.onBlock` if its `opts.blockRoot` is null. The same applies to RPC and replay paths. `hashTreeRoot(BeamBlock, ...)` is a non-trivial SSZ traversal on a wide block body; doing it 3–4× per ingress is pure waste.

This PR threads the producer's already-computed root all the way through:

- **`networks.GossipMessage` left as-is** (the variant is plain `SignedBlock` and changing the shape would ripple through the FFI bridge); instead `chain.onGossip` gains an optional `precomputed_block_root: ?types.Root` parameter that `BeamNode.onGossip` populates from its own pre-lock computation.
- **`chain_worker.Message.on_block`** and the handler vtable gain an optional `block_root: ?types.Root`. `BeamChain.submitBlock` takes the cached root through; the `chainWorkerOnBlockThunk` forwards it into `onBlock` via `CachedProcessedBlockInfo.blockRoot`.
- **The pending-blocks queue** stores a new `PendingBlockEntry { signed_block, block_root }`; `processPendingBlocks` reads the cached root instead of re-hashing on every ready-block pop.
- **`chain.onBlock` and `forkchoice.onBlock`** already accepted an optional precomputed root; they now bump `lean_block_root_compute_skipped_total{site}` when the caller supplied one so an operator can verify the cache is actually being used at every site. A sustained 0 at any site label means the cache plumbing was dropped on the floor in a refactor.

The default `block_root: ?Root = null` on every new field/parameter keeps existing tests + the c-1 chain-worker stub compiling unchanged.

## Chain-worker default flipped to `on`

`pkgs/cli/src/main.zig` / `pkgs/cli/src/node.zig` / `pkgs/node/src/node.zig` flip `chain_worker_enabled` default from `false` to `true`. The `--chain-worker` CLI flag is unchanged otherwise; the legacy synchronous path stays in place as a kill-switch via `--chain-worker false`.

Per the call: the slice (a/b/c) work is all merged, devnet has been on the worker path via lean-quickstart for a while, and the default flip just brings the compiled-in default in line with what production already runs. (Closed-not-merged #830 attempted the same flip + a CLI shape change; the CLI shape change wasn't actually needed, so this PR keeps the flag a `bool` and just flips the default.)

## Edge cases handled

- **`hasBlocksBatch` length mismatch** returns `error.LengthMismatch` rather than UB-reading `out`. Locked in code by a dedicated test.
- **`hasBlocksBatch` empty input** is a no-op (no panic, no deadlock). Locked in code by a dedicated test.
- **`hasBlocksBatch` snapshot freshness** — the shared lock is re-taken on every call so a post-ingest call reflects the new state. Locked in code by a dedicated test.
- **`fetchBlockByRoots` priority order** — forkchoice → block_cache → pending_block_roots, each producing a distinct `outcome` label. Bypassing any cache would zero the corresponding label, which the metric makes immediately visible.
- **`fetchBlockByRoots` on `error.NoPeersAvailable` / other peer errors** — no `fetched` counter bumps; the existing warn-and-return path is preserved.
- **`chain_worker.Message.on_block.block_root = null` default** — every existing call site (tests, stress harness, c-1 stub) compiles unchanged; the worker recomputes via the existing `CachedProcessedBlockInfo` fallback.
- **`PendingBlockEntry` ownership** — `chain.deinit` walks the queue and calls `entry.signed_block.deinit()`; the `block_root` is value-typed so it doesn't need cleanup. The drain (`processPendingBlocks`) defers `queued_entry.signed_block.deinit()` per ready-pop.
- **`chain.onGossip` non-block branches** ignore `precomputed_block_root` (only the block branch reads it). `BeamNode.onGossip` only computes a root when `data.* == .block`, so we pass `null` for attestation/aggregation paths to keep the contract honest.
- **Chain-worker default flip kill-switch** — `--chain-worker false` (or `chain_worker_enabled: false` in `BeamNodeOpts`) still routes everything through the synchronous path, unchanged from before. Tests that explicitly disable the worker (`chain-worker: end-to-end submitBlock advances state via the worker thread` exercises both branches) still pass.

## New metrics

`pkgs/metrics/src/lib.zig`:

- `lean_block_root_compute_skipped_total{site}` — every time a downstream consumer skipped a `hashTreeRoot(BeamBlock)` because the producer threaded a precomputed root through. Sites: `chain.onGossip`, `chain.onBlock`, `chain.processPendingBlocks`, `forkchoice.onBlock`.
- `lean_block_fetch_dedup_total{outcome}` — every `fetchBlockByRoots` per-root outcome. Outcomes: `already_in_forkchoice`, `already_in_block_cache`, `already_pending`, `fetched`.

Both follow the slice (b) lesson from PR #822 — code-side audits on metrics, not just docs, so a regression that drops the cache or the dedup is observable from Grafana.

## Tests

- **`forkchoice.hasBlocksBatch (slice (d) of #803): empty + length-mismatch + presence semantics`** — empty input is a no-op, length-mismatch returns `error.LengthMismatch` rather than reading past `out`, presence semantics match the per-root `hasBlock`, and the snapshot is re-taken on every call (a post-ingest call reflects the new state).
- **`chain_worker.on_block carries optional block_root (slice (e) of #803)`** — the new field defaults to `null` (existing callers compile unchanged), round-trips an explicit value through `Message.deinit`, and the test's SignedBlock heap is freed by `deinit` (testing.allocator leak guard).

Existing tests around `submitBlock` ("chain-worker: end-to-end submitBlock advances state via the worker thread", "chain-worker disabled: submitBlock returns ChainWorkerDisabled") and the stress harness all updated for the new 3-arg signature; both pass.

## Verification

- `zig build` — green.
- `zig build test` — all 12 test groups pass; both new tests confirmed OK locally; clean exit, no panics / UAFs / deadlocks observed.
- Targeted grep + run on `chain.test.*`, `chain_worker.test.*`, `forkchoice.test.*` confirmed locally.

Draft for review — open the comments thread for any naming / scope feedback before un-drafting.

References: #803 (slice work), prior slices: #805 (a-2), #820 (a-3), #822 (b), #826 (c-1), #827 (c-2a), #828 (c-2b/c-2c). Closed-not-merged #830 (CLI shape attempt) is the prior chain-worker default-flip work; this PR supersedes it.