### PR TITLE
network: pre-validate BlocksByRoot RPC bytes to stop SSZ-panic DoS

### DIFF
--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -427,7 +427,22 @@ pub const LeanSupportedProtocol = enum(u32) {
 /// FFI thread and brings down the whole zeam process. We return an error
 /// instead so the request handler's existing catch path can send an RPC
 /// error back and keep the node alive.
+///
+/// Intentionally module-private: this is a wire-shape shim for
+/// `ReqRespRequest.deserialize` only and exists purely to dodge an upstream
+/// SSZ panic surface (see #843). Once the bounds checks land in `ssz.zig`
+/// itself this whole helper goes away. If a future caller in `pkgs/network/`
+/// needs the same validation, lift it then — don't widen the API now and
+/// invite reuse of a fix that is meant to be temporary.
 fn validateBlocksByRootRequestBytes(bytes: []const u8) !void {
+    // The body-length checks below assume the SSZ wire size of `Root` is 32
+    // bytes (i.e. `Root` is `[32]u8` with no padding). If anyone ever wraps
+    // `Root` in a struct with padding or otherwise drifts the in-memory size,
+    // `@sizeOf(types.Root)` and the SSZ wire size diverge silently and these
+    // checks misclassify well-formed payloads as malformed (or vice versa).
+    // Catch that at compile time rather than waiting for it to reach Hive.
+    comptime std.debug.assert(@sizeOf(types.Root) == 32);
+
     if (bytes.len < 4) return error.MalformedReqRespRequest;
     const offset = std.mem.readInt(u32, bytes[0..4], .little);
     if (offset != 4) return error.MalformedReqRespRequest;
@@ -1107,11 +1122,22 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
         );
     }
 
+    // Cases 2-4 below also call `ReqRespRequest.deserialize` end-to-end, not
+    // just the validator helper directly. Without that we'd only be testing
+    // the validator function in isolation — if a future contributor wired the
+    // pre-validation switch to the wrong protocol tag (e.g. only `.status`),
+    // the per-shape checks would still pass while the production path
+    // silently regressed back to a panicking SSZ codec. The end-to-end calls
+    // lock that wiring in place.
     {
         var bad_offset: [36]u8 = undefined;
         std.mem.writeInt(u32, bad_offset[0..4], 8, .little);
         @memset(bad_offset[4..], 0);
         try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&bad_offset));
+        try std.testing.expectError(
+            error.MalformedReqRespRequest,
+            ReqRespRequest.deserialize(allocator, .blocks_by_root, &bad_offset),
+        );
     }
 
     {
@@ -1119,6 +1145,10 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
         std.mem.writeInt(u32, ragged[0..4], 4, .little);
         @memset(ragged[4..], 0);
         try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&ragged));
+        try std.testing.expectError(
+            error.MalformedReqRespRequest,
+            ReqRespRequest.deserialize(allocator, .blocks_by_root, &ragged),
+        );
     }
 
     {
@@ -1129,6 +1159,10 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
         std.mem.writeInt(u32, oversize[0..4], 4, .little);
         @memset(oversize[4..], 0);
         try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(oversize));
+        try std.testing.expectError(
+            error.MalformedReqRespRequest,
+            ReqRespRequest.deserialize(allocator, .blocks_by_root, oversize),
+        );
     }
 
     // Sanity: the well-formed empty list still deserializes cleanly so we

--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -414,6 +414,30 @@ pub const LeanSupportedProtocol = enum(u32) {
     }
 };
 
+/// Validate the wire shape of a `BlocksByRootV1` request payload.
+///
+/// `BlockByRootRequest = struct { roots: List<Root, MAX_REQUEST_BLOCKS> }`
+/// serialises as a 4-byte little-endian offset prefix followed by the packed
+/// list body of `N × 32` bytes. The struct has only one variable-length field,
+/// so the offset must point exactly at the end of the offset section, i.e.
+/// must equal `4`.
+///
+/// Anything else is malformed: a peer-supplied garbage offset would otherwise
+/// trigger a slice-bounds panic deep inside the SSZ decoder, which aborts the
+/// FFI thread and brings down the whole zeam process. We return an error
+/// instead so the request handler's existing catch path can send an RPC
+/// error back and keep the node alive.
+fn validateBlocksByRootRequestBytes(bytes: []const u8) !void {
+    if (bytes.len < 4) return error.MalformedReqRespRequest;
+    const offset = std.mem.readInt(u32, bytes[0..4], .little);
+    if (offset != 4) return error.MalformedReqRespRequest;
+    const body = bytes[offset..];
+    if (body.len % @sizeOf(types.Root) != 0) return error.MalformedReqRespRequest;
+    if (body.len / @sizeOf(types.Root) > consensus_params.MAX_REQUEST_BLOCKS) {
+        return error.MalformedReqRespRequest;
+    }
+}
+
 pub const ReqRespRequest = union(LeanSupportedProtocol) {
     blocks_by_root: types.BlockByRootRequest,
     status: types.Status,
@@ -476,6 +500,28 @@ pub const ReqRespRequest = union(LeanSupportedProtocol) {
     }
 
     pub fn deserialize(allocator: Allocator, method: LeanSupportedProtocol, bytes: []const u8) !Self {
+        // Pre-validate the wire shape before handing it to the SSZ codec.
+        //
+        // The vendored ssz.zig has bounds checks on its array/list deserializer
+        // (out-of-range offsets surface as `error.OffsetExceedsSize`) but not yet
+        // on the variable-field offsets inside its container/struct deserializer.
+        // A malformed `BlocksByRootV1` request that puts garbage in the offset
+        // prefix slips past the upfront `minInLength`/`maxInLength` check
+        // (24 bytes is comfortably inside `[4, 4 + 32 * MAX_REQUEST_BLOCKS]`)
+        // and slice-overruns inside the wrapping struct's deserializer, which
+        // panics the FFI thread and aborts the whole zeam process — any peer
+        // can DoS the node by sending one bad RPC. Reject malformed input
+        // here so the callsite's existing error path can send an RPC error
+        // back without crashing.
+        //
+        // `Status` and `BlocksByRange` are fixed-size containers; ssz.zig's
+        // upfront length check already rejects malformed input for those, so
+        // no extra pre-validation is needed for them.
+        switch (method) {
+            .status, .blocks_by_range => {},
+            .blocks_by_root => try validateBlocksByRootRequestBytes(bytes),
+        }
+
         return switch (method) {
             inline else => |tag| {
                 const PayloadType = unionPayloadType(Self, tag);
@@ -1023,4 +1069,76 @@ test LeanNetworkTopic {
     try std.testing.expectEqual(topic.gossip_topic, decoded_topic.gossip_topic);
     try std.testing.expectEqual(topic.encoding, decoded_topic.encoding);
     try std.testing.expect(std.mem.eql(u8, topic.fork_digest, decoded_topic.fork_digest));
+}
+
+test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panicking" {
+    // Regression test for the Hive `reqresp/blocks_by_root/malformed_request`
+    // failure (May 7 2026, image 993f193 / v0.4.15). The simulator sent a
+    // 24-byte payload whose first 4 bytes decode to a u32 offset of
+    // ~2.88e9 — well past the payload length. The vendored ssz.zig
+    // container deserializer at lib.zig:604 then sliced
+    // `bytes[indices[0]..end]` without bounds-checking and panicked
+    // ("start index 2880154539 is larger than end index 64"), which
+    // killed the FFI thread and aborted the whole process. Any peer
+    // could DoS zeam with a single bad request.
+    //
+    // After the fix `ReqRespRequest.deserialize` rejects this with
+    // `error.MalformedReqRespRequest` so the request-handler's existing
+    // catch path can return an RPC error to the peer and keep the node
+    // alive. We exercise four shapes here:
+    //   1. The exact-on-the-wire panic trigger from the Hive run
+    //      (4-byte offset of 0xABABAAAB followed by 20 garbage bytes).
+    //   2. Any non-`4` offset (the only legal value for a single-variable
+    //      -field container).
+    //   3. A body length that isn't a multiple of `sizeOf(Root) = 32`.
+    //   4. A body whose root count exceeds `MAX_REQUEST_BLOCKS`.
+    // For each, we additionally call `ReqRespRequest.deserialize` to
+    // confirm the panic path is no longer reachable end-to-end.
+    const allocator = std.testing.allocator;
+
+    {
+        var malformed: [24]u8 = undefined;
+        std.mem.writeInt(u32, malformed[0..4], 0xABABAAAB, .little);
+        @memset(malformed[4..], 0xAB);
+        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&malformed));
+        try std.testing.expectError(
+            error.MalformedReqRespRequest,
+            ReqRespRequest.deserialize(allocator, .blocks_by_root, &malformed),
+        );
+    }
+
+    {
+        var bad_offset: [36]u8 = undefined;
+        std.mem.writeInt(u32, bad_offset[0..4], 8, .little);
+        @memset(bad_offset[4..], 0);
+        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&bad_offset));
+    }
+
+    {
+        var ragged: [37]u8 = undefined;
+        std.mem.writeInt(u32, ragged[0..4], 4, .little);
+        @memset(ragged[4..], 0);
+        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&ragged));
+    }
+
+    {
+        const oversize_count = consensus_params.MAX_REQUEST_BLOCKS + 1;
+        const oversize_len = 4 + oversize_count * @sizeOf(types.Root);
+        const oversize = try allocator.alloc(u8, oversize_len);
+        defer allocator.free(oversize);
+        std.mem.writeInt(u32, oversize[0..4], 4, .little);
+        @memset(oversize[4..], 0);
+        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(oversize));
+    }
+
+    // Sanity: the well-formed empty list still deserializes cleanly so we
+    // haven't made the validator over-strict.
+    {
+        var empty: [4]u8 = undefined;
+        std.mem.writeInt(u32, empty[0..4], 4, .little);
+        try validateBlocksByRootRequestBytes(&empty);
+        var req = try ReqRespRequest.deserialize(allocator, .blocks_by_root, &empty);
+        defer req.deinit();
+        try std.testing.expectEqual(@as(usize, 0), req.blocks_by_root.roots.constSlice().len);
+    }
 }


### PR DESCRIPTION
## Scope (read first)

**This PR closes the Hive `reqresp/blocks_by_root/malformed_request` failure, *not* the underlying class of bug.** The same `ssz.zig` container-deserializer panic shape still reaches `ReqRespResponse.deserialize` (any `BlocksByRoot`/`BlocksByRange` response from a malicious peer can crash us identically) and `deserializeGossipMessage` (one bad gossip envelope can take down every zeam node on the mesh in lock-step). Until #843 lands and we drop this shim, zeam remains trivially DoS-able on the response and gossip paths. This PR removes the surface that Hive currently exercises and nothing more — by design, narrowest possible patch.

## Summary

The Hive `reqresp/blocks_by_root/malformed_request` test on 2026-05-07 (suite `1778164266-…`, image `993f193` / v0.4.15) crashed zeam mid-test:

```
[reqresp] Received request from 16Uiu…QQNhc for protocol /…/blocks_by_root/1/ssz_snappy (25 bytes)
thread 62 panic: start index 2880154539 is larger than end index 64
…/ssz/src/lib.zig:604:63: 0x21a6ebc in deserialize__anon_695038 (zeam)
…/pkgs/network/src/interface.zig:485:36: 0x23c2eab in deserialize (zeam)
```

The simulator sent a 24-byte `BlocksByRootV1` payload whose first 4 bytes decoded to a u32 offset of `0xABABAAAB`. The vendored `ssz.zig` container deserializer at `lib.zig:604` sliced `bytes[indices[0]..end]` without bounds-checking, and the resulting slice-bounds panic killed the FFI thread and aborted the whole zeam process. Any peer can DoS zeam with one bad RPC.

`ssz.zig` already bounds-checks its **array/list** deserializer (`OffsetExceedsSize` / `OffsetOrdering` at `lib.zig:467-471`) but not its **container-with-variable-field** path. Generalising the fix into the SSZ library is tracked in #843 and would let us drop this shim once the dep is bumped — but that's a broader audit (the same shape exists in the slice path at `lib.zig:520-532`, the union path at `lib.zig:613`, and the struct first-pass at `lib.zig:574-584`), so this PR patches just the one production-reachable surface that Hive exercises.

## What this PR does

1. **`ReqRespRequest.deserialize` pre-validates `BlocksByRootV1` request bytes** before handing them to the SSZ codec. Rejects anything that couldn't have been a valid encoding (sub-4-byte payload, offset ≠ 4, ragged tail, root count > `MAX_REQUEST_BLOCKS`) with `error.MalformedReqRespRequest`. The validator is intentionally stricter than panic-prevention alone — it also rejects ragged-tail and wrong-offset shapes that `ssz.zig` would silently accept (e.g. an `offset = 8` buffer where the inner List decoder would just truncate the leftover) so that the wire-shape contract for `BlockByRootRequest` is enforced in one place.
2. **No change for `Status` / `BlocksByRangeRequest`** — they're fixed-size containers, ssz.zig's upfront `minInLength`/`maxInLength` check already rejects malformed input for those.
3. **No call-site change.** The existing handler at `ethlibp2p.zig:512` already catches deserialize errors, sends an RPC error response back to the peer, and returns without killing the thread. This PR turns a fatal panic into a normal "reject one peer's bad request" code path.
4. **Regression test** in `pkgs/network/src/interface.zig` exercising:
   - The exact 24-byte payload reproduced from the Hive log.
   - Any non-`4` offset (the only legal value here).
   - A ragged body that isn't a multiple of `sizeOf(Root)`.
   - A body whose root count exceeds `MAX_REQUEST_BLOCKS`.
   - Sanity: a well-formed empty list still deserializes cleanly.

   All four malformed-shape cases now also call `ReqRespRequest.deserialize` end-to-end (not only the validator helper directly), so a future contributor accidentally wiring the pre-validation switch to the wrong protocol tag fails the test instead of silently regressing the production path back to the panicking SSZ codec.

5. **Compile-time guard** that `@sizeOf(types.Root) == 32`. The body-length checks (`body.len % @sizeOf(types.Root)` and the `MAX_REQUEST_BLOCKS` bound) assume the in-memory size of `Root` matches its SSZ wire size; if anyone ever wraps `Root` in a struct with padding or otherwise changes the alias, this catches the divergence at compile time rather than letting it reach Hive.

## Why a shim and not the upstream fix

The `ssz.zig` fix is the right long-term answer — but it's not a one-liner:

- `lib.zig:520-532` (slice variable-size list) needs the same guards.
- `lib.zig:613, 623` (union deserializer) panics on `serialized.len < 1`.
- `lib.zig:574-584` (struct first-pass) panics on short inputs.

That's a separate PR against `blockblaz/ssz.zig` plus a `build.zig.zon` bump in zeam, plus an audit of every SSZ callsite that decodes peer-supplied bytes (`SignedBlock` from `BlocksByRoot`/`BlocksByRange` responses, gossip messages, etc.). Tracked in #843. This PR closes the immediate DoS without blocking on that broader work.

## Verification

- `zig build test --summary all` — all suites pass.
- `zig build simtest --summary all` — all suites pass.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `zig fmt --check .` — all clean.

## Hive

After this lands plus a v0.4.17 image, the `reqresp/blocks_by_root/malformed_request` failure for `zeam_devnet4` should go away. The other two `zeam_devnet4` failures in the same suite are tracked separately:

- `reqresp/blocks_by_root/max_request_limit` (9-second handler latency → simulator timeout) — #844.
- `reqresp/status/advanced_head` — multi-client failure (gean, lantern, nlean, qlean, zeam all fail with the same symptom), looks simulator-side rather than zeam-specific.

## Refs

- Closes the Hive `reqresp/blocks_by_root/malformed_request` failure for zeam.
- Refs #843 (generalise the bounds checks in `ssz.zig` — until that lands, the response and gossip paths remain vulnerable to the same DoS shape).
- Refs #844 (separate slow-handler issue exposed by the same suite).
