### PR TITLE
node: decouple slot-tick advance from per-interval errors

### DIFF
--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1685,6 +1685,17 @@ pub const BeamNode = struct {
             const interval: usize = @intCast(current_interval);
             const slot: types.Slot = @intCast(@divFloor(interval, constants.INTERVALS_PER_SLOT));
 
+            // Mark this interval as attempted *before* doing any per-interval
+            // work. This decouples the slot-tick advance from any inner failure
+            // (chain tick, validator duty, aggregation publish) so a transient
+            // error on slot N interval K cannot wedge the loop into replaying
+            // the same interval forever, freezing the clock for the
+            // aggregator (#847). Per-interval duties (block/attestation/
+            // aggregation production) are not idempotent and must not run
+            // twice for the same `current_interval`; this advance guarantees
+            // exactly-once even when a later step in the iteration errors out.
+            self.last_interval = current_interval;
+
             {
                 // Slice (a-3): no outer mutex. `chain.onInterval` /
                 // `chain.processPendingBlocks` take their own per-resource
@@ -1695,8 +1706,10 @@ pub const BeamNode = struct {
 
                 self.chain.onInterval(interval) catch |e| {
                     self.logger.err("error ticking chain to time(intervals)={d} err={any}", .{ interval, e });
-                    // no point going further if chain is not ticked properly
-                    return e;
+                    // forkchoice tick is idempotent: subsequent intervals will
+                    // re-try the underlying tick. Skip the rest of this
+                    // interval's work and let the loop advance (#847).
+                    continue;
                 };
 
                 // Replay blocks that were queued waiting for the forkchoice clock to advance,
@@ -1721,32 +1734,36 @@ pub const BeamNode = struct {
             if (self.validator) |*validator| {
                 // we also tick validator per interval in case it would
                 // need to sync its future duties when its an independent validator
-                var validator_output = validator.onInterval(interval) catch |e| {
+                //
+                // Validator duty failures (proposal, attestation construction)
+                // are local to this slot — drop them and keep the clock
+                // moving rather than wedge the tick loop on a transient
+                // state-lookup failure (#847).
+                var validator_output = validator.onInterval(interval) catch |e| blk: {
                     self.logger.err("error ticking validator to time(intervals)={d} err={any}", .{ interval, e });
-                    return e;
+                    break :blk null;
                 };
 
                 if (validator_output) |*output| {
                     defer output.deinit();
                     for (output.gossip_messages.items) |gossip_msg| {
-                        // Process based on message type
+                        // Publish failures are best-effort: logging and moving on
+                        // keeps the slot-tick advancing instead of stalling on a
+                        // transient gossip / state lookup error (#847).
                         switch (gossip_msg) {
                             .block => |signed_block| {
                                 self.publishBlock(signed_block) catch |e| {
                                     self.logger.err("error publishing block from validator: err={any}", .{e});
-                                    return e;
                                 };
                             },
                             .attestation => |signed_attestation| {
                                 self.publishAttestation(signed_attestation) catch |e| {
                                     self.logger.err("error publishing attestation from validator: err={any}", .{e});
-                                    return e;
                                 };
                             },
                             .aggregation => |signed_aggregation| {
                                 self.publishAggregation(signed_aggregation) catch |e| {
                                     self.logger.err("error publishing aggregation from validator: err={any}", .{e});
-                                    return e;
                                 };
                             },
                         }
@@ -1768,20 +1785,24 @@ pub const BeamNode = struct {
             }
 
             if (interval_in_slot == 2) {
-                if (self.chain.maybeAggregateOnInterval(interval) catch |e| {
+                // Aggregator-only path: building or publishing an aggregation
+                // can fail with `MissingState` / `UnknownSourceBlock` /
+                // `UnknownHeadBlock` when the local store has gaps from a
+                // prior STF reject cascade. Skip this slot's aggregation
+                // and keep ticking — the next slot's aggregation will
+                // re-derive from current state (#847).
+                const maybe_aggregations = self.chain.maybeAggregateOnInterval(interval) catch |e| blk: {
                     self.logger.err("error producing aggregations at slot={d} interval={d}: {any}", .{ slot, interval, e });
-                    return e;
-                }) |aggregations| {
+                    break :blk null;
+                };
+                if (maybe_aggregations) |aggregations| {
                     defer self.allocator.free(aggregations);
                     self.publishProducedAggregations(aggregations) catch |e| {
                         self.logger.err("error producing/publishing aggregations at slot={d} interval={d}: {any}", .{ slot, interval, e });
-                        return e;
                     };
                 }
             }
         }
-
-        self.last_interval = itime_intervals;
     }
 
     /// Re-send our status to every connected peer.


### PR DESCRIPTION
## Summary

Closes #847.

The aggregator's slot-tick / `onInterval` loop was wedged whenever a per-interval duty errored. After a `MissingPreState` cascade left the local store with gaps, `publishProducedAggregations` (and the sibling validator-output publish paths) would fail with `MissingState` / `UnknownSourceBlock` / `UnknownHeadBlock`, the catch handlers would `return e;` from `BeamNode.onInterval`, and `self.last_interval = itime_intervals;` at the bottom of the function never ran.

The next clock tick restarted the catch-up loop from `last_interval + 1` — the same interval that just failed — re-fired the same publish, hit the same error, returned again. Wall-clock kept moving, gossip and req/resp kept working, but the slot/interval counter never advanced. The bug was aggregator-only because only the aggregator runs the interval-2 aggregation path; a regular validator on the same input recovered cleanly (zeam_0 vs zeam_1 in #847).

## Fix

Two changes in `BeamNode.onInterval`:

1. Move `self.last_interval = current_interval` to the **top of each iteration**. Per-interval duties (proposal, attestation, aggregation) are not idempotent and must run exactly once for a given `current_interval`; advancing first guarantees that.
2. Convert every per-interval `return e;` into log-and-continue:
   - `chain.onInterval` failure → `continue` (forkchoice tick is idempotent; the next interval re-ticks it for free)
   - `validator.onInterval` / `publishBlock` / `publishAttestation` / `publishAggregation` / `maybeAggregateOnInterval` / `publishProducedAggregations` failure → log and move on (slot-local, self-heals next slot)

Together these guarantee the slot-tick loop always advances regardless of which downstream path errors.

## What this PR does NOT do

This PR addresses ask #1 from #847 (decouple the tick from STF/aggregation errors). The other two asks are deliberately out of scope:

- **Ask #2 — bounded `MissingPreState` retry budget.** Belongs in `chain_worker` / forkchoice replay logic, not the tick loop. Once the tick is decoupled, the symptom from #847 is gone; the retry budget is a separate hardening.
- **Ask #3 — `lean_clock_loop_stalled_seconds` gauge.** Better filed as its own observability change so it can be reviewed against the existing `lean_tick_interval_duration_seconds` histogram and `lean_current_slot` gauge.

## Test plan

- [x] `zig build test --summary all` (incl. `pkgs/node/src/lib.zig` ~4m suite)
- [x] `zig build simtest --summary all`
- [x] `zig fmt --check .`
- [x] `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings`
- [ ] Devnet rerun: deploy on devnet-4, induce a `MissingPreState` cascade on an aggregator, confirm the slot counter keeps advancing instead of freezing at the failing interval.