### PR TITLE
chain: log duplicate-AttestationData STF rejects with full context

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2361,27 +2361,11 @@ pub const BeamChain = struct {
             }
 
             // Each unique AttestationData must appear at most once per block.
-            //
-            // Issue #837 ask #5: log the duplicate's distinguishing
-            // fields (slot + checkpoint roots) so the next reproduction
-            // has enough on-the-wire context to diagnose without
-            // pulling block bytes from a peer. Two `AttestationData`
-            // values are equal iff every field (slot, head, target,
-            // source) matches; logging the slot + checkpoint roots
-            // tells operators which validators voted on the same
-            // checkpoint pair.
-            //
-            // The format string is intentionally split across logical
-            // chunks (block-level / data / head / target / source) so
-            // it stays diff-friendly and operators can grep individual
-            // fields. `blockroot=` / `checkpoint_root=` mirror the
-            // naming used elsewhere in this file (e.g. line ~1867's
-            // gossip log).
             {
-                var att_data_set = std.AutoHashMap(types.AttestationData, usize).init(self.allocator);
-                defer att_data_set.deinit();
+                var att_data_map = std.AutoHashMap(types.AttestationData, usize).init(self.allocator);
+                defer att_data_map.deinit();
                 for (aggregated_attestations, 0..) |agg_att, idx| {
-                    const result = try att_data_set.getOrPut(agg_att.data);
+                    const result = try att_data_map.getOrPut(agg_att.data);
                     if (result.found_existing) {
                         const first_idx = result.value_ptr.*;
                         self.logger.err(
@@ -2409,10 +2393,10 @@ pub const BeamChain = struct {
                     }
                     result.value_ptr.* = idx;
                 }
-                if (att_data_set.count() > self.config.spec.max_attestations_data) {
+                if (att_data_map.count() > self.config.spec.max_attestations_data) {
                     self.logger.err(
                         "block contains {d} distinct AttestationData entries (max {d}) for block root=0x{x}",
-                        .{ att_data_set.count(), self.config.spec.max_attestations_data, &freshFcBlock.blockRoot },
+                        .{ att_data_map.count(), self.config.spec.max_attestations_data, &freshFcBlock.blockRoot },
                     );
                     return BlockProcessingError.TooManyAttestationData;
                 }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2361,18 +2361,53 @@ pub const BeamChain = struct {
             }
 
             // Each unique AttestationData must appear at most once per block.
+            //
+            // Issue #837 ask #5: log the duplicate's distinguishing
+            // fields (slot + checkpoint roots) so the next reproduction
+            // has enough on-the-wire context to diagnose without
+            // pulling block bytes from a peer. Two `AttestationData`
+            // values are equal iff every field (slot, head, target,
+            // source) matches; logging the slot + checkpoint roots
+            // tells operators which validators voted on the same
+            // checkpoint pair.
+            //
+            // The format string is intentionally split across logical
+            // chunks (block-level / data / head / target / source) so
+            // it stays diff-friendly and operators can grep individual
+            // fields. `blockroot=` / `checkpoint_root=` mirror the
+            // naming used elsewhere in this file (e.g. line ~1867's
+            // gossip log).
             {
-                var att_data_set = std.AutoHashMap(types.AttestationData, void).init(self.allocator);
+                var att_data_set = std.AutoHashMap(types.AttestationData, usize).init(self.allocator);
                 defer att_data_set.deinit();
-                for (aggregated_attestations) |agg_att| {
+                for (aggregated_attestations, 0..) |agg_att, idx| {
                     const result = try att_data_set.getOrPut(agg_att.data);
                     if (result.found_existing) {
+                        const first_idx = result.value_ptr.*;
                         self.logger.err(
-                            "block contains duplicate AttestationData entries for block root=0x{x}",
-                            .{&freshFcBlock.blockRoot},
+                            "duplicate AttestationData rejected: blockroot=0x{x} slot={d} proposer={d}" ++
+                                " duplicate_indices=[{d},{d}] data.slot={d}" ++
+                                " data.head.blockroot=0x{x}@{d}" ++
+                                " data.target.checkpoint_root=0x{x}@{d}" ++
+                                " data.source.checkpoint_root=0x{x}@{d}",
+                            .{
+                                &freshFcBlock.blockRoot,
+                                block.slot,
+                                block.proposer_index,
+                                first_idx,
+                                idx,
+                                agg_att.data.slot,
+                                &agg_att.data.head.root,
+                                agg_att.data.head.slot,
+                                &agg_att.data.target.root,
+                                agg_att.data.target.slot,
+                                &agg_att.data.source.root,
+                                agg_att.data.source.slot,
+                            },
                         );
                         return BlockProcessingError.DuplicateAttestationData;
                     }
+                    result.value_ptr.* = idx;
                 }
                 if (att_data_set.count() > self.config.spec.max_attestations_data) {
                     self.logger.err(


### PR DESCRIPTION
Splits the chain.zig portion of #848 review #6 into its own PR so the wedge-fix for #837 stays focused on `pkgs/node/src/node.zig` + `pkgs/metrics/src/lib.zig`.

## What this changes

When a block is rejected for containing duplicate `AttestationData` entries, log every distinguishing field of the duplicate so the reproduction has enough on-the-wire context to diagnose without pulling block bytes from a peer.

Two `AttestationData` values are equal iff every field (`slot`, `head`, `target`, `source`) matches, so the new log line includes:

- `blockroot`, `slot`, `proposer_index` of the offending block
- the two indices `[i, j]` inside the block whose data hashed to the same value
- `data.slot`
- `data.head.blockroot @ slot`
- `data.target.checkpoint_root @ slot`
- `data.source.checkpoint_root @ slot`

Pre-fix log:

    block contains duplicate AttestationData entries for block root=0x…

Post-fix log:

    duplicate AttestationData rejected: blockroot=0x… slot=N proposer=P duplicate_indices=[i,j] data.slot=S data.head.blockroot=0x…@H data.target.checkpoint_root=0x…@T data.source.checkpoint_root=0x…@U

## Review nits applied (point #9 from #848)

- Format string split across 5 logical chunks (block-level / data / head / target / source) so it stays diff-friendly and operators can grep individual fields.
- `root=` normalised to `blockroot=` / `checkpoint_root=` to match neighbouring logs in `chain.zig` (e.g. line ~1867 gossip block log).
- `block.proposer_index` is `ValidatorIndex` = `u64`, so `{d}` is correct.

## Refs

- Refs #837 ask #5
- Refs #848 review #6 (split-out)
