### PR TITLE
ssz, network: bounds-check SSZ deserialize; vendor patched ssz (#843)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,7 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ssz = .{
-            .url = "git+https://github.com/blockblaz/ssz.zig#404762835d6890fdf3e71e79c81fc8798a43b6c7",
-            .hash = "ssz-0.0.9-Lfwd6676AgAVislFL76qdTcxDnpYCyJRVBNClx1phXd2",
+            .path = "pkgs/third_party/ssz",
         },
         .zigcli = .{
             .url = "git+https://github.com/jiacai2050/zigcli#621920da8f2235c6b9c15addf353e7747e1e899c",

--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -414,45 +414,6 @@ pub const LeanSupportedProtocol = enum(u32) {
     }
 };
 
-/// Validate the wire shape of a `BlocksByRootV1` request payload.
-///
-/// `BlockByRootRequest = struct { roots: List<Root, MAX_REQUEST_BLOCKS> }`
-/// serialises as a 4-byte little-endian offset prefix followed by the packed
-/// list body of `N × 32` bytes. The struct has only one variable-length field,
-/// so the offset must point exactly at the end of the offset section, i.e.
-/// must equal `4`.
-///
-/// Anything else is malformed: a peer-supplied garbage offset would otherwise
-/// trigger a slice-bounds panic deep inside the SSZ decoder, which aborts the
-/// FFI thread and brings down the whole zeam process. We return an error
-/// instead so the request handler's existing catch path can send an RPC
-/// error back and keep the node alive.
-///
-/// Intentionally module-private: this is a wire-shape shim for
-/// `ReqRespRequest.deserialize` only and exists purely to dodge an upstream
-/// SSZ panic surface (see #843). Once the bounds checks land in `ssz.zig`
-/// itself this whole helper goes away. If a future caller in `pkgs/network/`
-/// needs the same validation, lift it then — don't widen the API now and
-/// invite reuse of a fix that is meant to be temporary.
-fn validateBlocksByRootRequestBytes(bytes: []const u8) !void {
-    // The body-length checks below assume the SSZ wire size of `Root` is 32
-    // bytes (i.e. `Root` is `[32]u8` with no padding). If anyone ever wraps
-    // `Root` in a struct with padding or otherwise drifts the in-memory size,
-    // `@sizeOf(types.Root)` and the SSZ wire size diverge silently and these
-    // checks misclassify well-formed payloads as malformed (or vice versa).
-    // Catch that at compile time rather than waiting for it to reach Hive.
-    comptime std.debug.assert(@sizeOf(types.Root) == 32);
-
-    if (bytes.len < 4) return error.MalformedReqRespRequest;
-    const offset = std.mem.readInt(u32, bytes[0..4], .little);
-    if (offset != 4) return error.MalformedReqRespRequest;
-    const body = bytes[offset..];
-    if (body.len % @sizeOf(types.Root) != 0) return error.MalformedReqRespRequest;
-    if (body.len / @sizeOf(types.Root) > consensus_params.MAX_REQUEST_BLOCKS) {
-        return error.MalformedReqRespRequest;
-    }
-}
-
 pub const ReqRespRequest = union(LeanSupportedProtocol) {
     blocks_by_root: types.BlockByRootRequest,
     status: types.Status,
@@ -515,35 +476,20 @@ pub const ReqRespRequest = union(LeanSupportedProtocol) {
     }
 
     pub fn deserialize(allocator: Allocator, method: LeanSupportedProtocol, bytes: []const u8) !Self {
-        // Pre-validate the wire shape before handing it to the SSZ codec.
-        //
-        // The vendored ssz.zig has bounds checks on its array/list deserializer
-        // (out-of-range offsets surface as `error.OffsetExceedsSize`) but not yet
-        // on the variable-field offsets inside its container/struct deserializer.
-        // A malformed `BlocksByRootV1` request that puts garbage in the offset
-        // prefix slips past the upfront `minInLength`/`maxInLength` check
-        // (24 bytes is comfortably inside `[4, 4 + 32 * MAX_REQUEST_BLOCKS]`)
-        // and slice-overruns inside the wrapping struct's deserializer, which
-        // panics the FFI thread and aborts the whole zeam process — any peer
-        // can DoS the node by sending one bad RPC. Reject malformed input
-        // here so the callsite's existing error path can send an RPC error
-        // back without crashing.
-        //
-        // `Status` and `BlocksByRange` are fixed-size containers; ssz.zig's
-        // upfront length check already rejects malformed input for those, so
-        // no extra pre-validation is needed for them.
-        switch (method) {
-            .status, .blocks_by_range => {},
-            .blocks_by_root => try validateBlocksByRootRequestBytes(bytes),
-        }
-
         return switch (method) {
             inline else => |tag| {
                 const PayloadType = unionPayloadType(Self, tag);
                 var payload = try initPayload(tag, allocator);
                 var succeeded = false;
                 defer if (!succeeded) deinitPayload(tag, &payload);
-                try ssz.deserialize(PayloadType, bytes, &payload, allocator);
+                ssz.deserialize(PayloadType, bytes, &payload, allocator) catch |err| {
+                    if (comptime tag == .blocks_by_root) {
+                        if (err == error.OutOfMemory) return err;
+                        return error.MalformedReqRespRequest;
+                    } else {
+                        return err;
+                    }
+                };
                 succeeded = true;
                 return @unionInit(Self, @tagName(tag), payload);
             },
@@ -1087,47 +1033,18 @@ test LeanNetworkTopic {
 }
 
 test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panicking" {
-    // Regression test for the Hive `reqresp/blocks_by_root/malformed_request`
-    // failures. The regression test merged with #845 used a hand-crafted
-    // 24-byte approximation; this test pins the real simulator input.
+    // Regression for Hive `reqresp/blocks_by_root/malformed_request` and for
+    // ssz.zig container bounds (#843). Malformed offsets must surface as
+    // `error.MalformedReqRespRequest`, not panic the FFI thread.
     //
-    // The Hive simulator sends `encode_request_raw(&[0xab; 64])`:
-    //   - Wire:  25 bytes = varint(64) || snappy_frame_compress([0xab; 64])
-    //   - After zeam's snappy frame decode: 64 bytes all `0xAB`
-    //   - SSZ offset field (bytes 0..4 LE): 0xABABABAB = 2880154539
-    //
-    // Without the guard added in #845, the ssz.zig container deserializer at
-    // lib.zig:604 sliced `bytes[2880154539..]` on a 64-byte buffer and
-    // panicked, killing the FFI thread and aborting zeam.
-    //
-    // Scope: this test exercises the post-decompression validation path only.
-    // The snappy framing layer and the varint length pre-checks are not
-    // covered here; a full end-to-end harness (not yet in this project)
-    // would be needed to lock those against regression too.
-    //
-    // Incidents: image 993f193 (v0.4.15, May 7 2026)
-    //            image 14222bc (v0.4.16, May 7 2026, Hive test-506)
-    //
-    // The `@sizeOf(types.Root) == 32` compile-time assert inside
-    // `validateBlocksByRootRequestBytes` ensures the 32-byte step assumption
-    // used in cases 3, 6, and 7 holds. If `Root` ever gets padding the build
-    // will fail at compile time rather than silently misclassifying payloads.
-    //
-    // All rejection cases also call `ReqRespRequest.deserialize` end-to-end.
-    // Without the end-to-end call, a future contributor who mis-wires the
-    // pre-validation switch (e.g. only `.status`, not `.blocks_by_root`)
-    // would leave the production SSZ panic path reachable while the
-    // per-shape validator checks still pass. The end-to-end calls lock that
-    // wiring. The `errdefer req.deinit()` inside `deserialize` means any
-    // allocation made before the validator fires is cleaned up on error;
-    // `std.testing.allocator` enforces this by detecting leaks at test exit.
+    // Hive sends `encode_request_raw(&[0xab; 64])` → after snappy decode,
+    // 64 bytes all `0xAB` and offset LE `0xABABABAB`.
+    comptime std.debug.assert(@sizeOf(types.Root) == 32);
     const allocator = std.testing.allocator;
 
     {
         // Case 1: exact decompressed bytes from the Hive malformed_request test.
-        // 64 bytes all 0xAB → offset 0xABABABAB (2880154539), way past the end.
         var malformed = [_]u8{0xAB} ** 64;
-        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&malformed));
         try std.testing.expectError(
             error.MalformedReqRespRequest,
             ReqRespRequest.deserialize(allocator, .blocks_by_root, &malformed),
@@ -1135,13 +1052,9 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     }
 
     {
-        // Case 2: non-uniform garbage — offset 0xDEADBEEF, mixed body bytes.
-        // Guards against an (unlikely) optimisation that only rejects
-        // homogeneous byte patterns.
         var mixed: [36]u8 = undefined;
         std.mem.writeInt(u32, mixed[0..4], 0xDEADBEEF, .little);
         @memset(mixed[4..], 0x5A);
-        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&mixed));
         try std.testing.expectError(
             error.MalformedReqRespRequest,
             ReqRespRequest.deserialize(allocator, .blocks_by_root, &mixed),
@@ -1149,11 +1062,9 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     }
 
     {
-        // Case 3: offset = 0 (null-prefix / classic adversarial first try).
         var zero_offset: [36]u8 = undefined;
         std.mem.writeInt(u32, zero_offset[0..4], 0, .little);
         @memset(zero_offset[4..], 0);
-        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&zero_offset));
         try std.testing.expectError(
             error.MalformedReqRespRequest,
             ReqRespRequest.deserialize(allocator, .blocks_by_root, &zero_offset),
@@ -1161,11 +1072,9 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     }
 
     {
-        // Case 4: offset = 8 (close to legal but wrong — "near-legal" family).
         var bad_offset: [36]u8 = undefined;
         std.mem.writeInt(u32, bad_offset[0..4], 8, .little);
         @memset(bad_offset[4..], 0);
-        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&bad_offset));
         try std.testing.expectError(
             error.MalformedReqRespRequest,
             ReqRespRequest.deserialize(allocator, .blocks_by_root, &bad_offset),
@@ -1177,7 +1086,6 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
         var ragged: [37]u8 = undefined;
         std.mem.writeInt(u32, ragged[0..4], 4, .little);
         @memset(ragged[4..], 0);
-        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&ragged));
         try std.testing.expectError(
             error.MalformedReqRespRequest,
             ReqRespRequest.deserialize(allocator, .blocks_by_root, &ragged),
@@ -1185,39 +1093,30 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     }
 
     {
-        // Case 6: root count exceeds MAX_REQUEST_BLOCKS.
         const oversize_count = consensus_params.MAX_REQUEST_BLOCKS + 1;
         const oversize_len = 4 + oversize_count * @sizeOf(types.Root);
         const oversize = try allocator.alloc(u8, oversize_len);
         defer allocator.free(oversize);
         std.mem.writeInt(u32, oversize[0..4], 4, .little);
         @memset(oversize[4..], 0);
-        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(oversize));
         try std.testing.expectError(
             error.MalformedReqRespRequest,
             ReqRespRequest.deserialize(allocator, .blocks_by_root, oversize),
         );
     }
 
-    // Sanity cases: the validator must not over-reject well-formed payloads.
     {
-        // Case 7: empty root list (offset=4, body empty). Valid.
         var empty: [4]u8 = undefined;
         std.mem.writeInt(u32, empty[0..4], 4, .little);
-        try validateBlocksByRootRequestBytes(&empty);
         var req = try ReqRespRequest.deserialize(allocator, .blocks_by_root, &empty);
         defer req.deinit();
         try std.testing.expectEqual(@as(usize, 0), req.blocks_by_root.roots.constSlice().len);
     }
 
     {
-        // Case 8: exactly one root (offset=4, body=32 bytes). Valid.
-        // Ensures the rejection path doesn't drift to over-rejecting
-        // legitimate non-empty requests.
         var one_root: [4 + 32]u8 = undefined;
         std.mem.writeInt(u32, one_root[0..4], 4, .little);
-        @memset(one_root[4..], 0); // zero root hash is a valid hash value
-        try validateBlocksByRootRequestBytes(&one_root);
+        @memset(one_root[4..], 0);
         var req = try ReqRespRequest.deserialize(allocator, .blocks_by_root, &one_root);
         defer req.deinit();
         try std.testing.expectEqual(@as(usize, 1), req.blocks_by_root.roots.constSlice().len);

--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -1088,41 +1088,44 @@ test LeanNetworkTopic {
 
 test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panicking" {
     // Regression test for the Hive `reqresp/blocks_by_root/malformed_request`
-    // failures (v0.4.15 and v0.4.16, both failed with the same Hive bytes).
+    // failures. The regression test merged with #845 used a hand-crafted
+    // 24-byte approximation; this test pins the real simulator input.
     //
     // The Hive simulator sends `encode_request_raw(&[0xab; 64])`:
-    //   - Wire: 25 bytes = varint(64) || snappy_compress([0xab; 64])
-    //   - Decompressed (what `validateBlocksByRootRequestBytes` receives):
-    //     64 bytes all `0xAB`
-    //   - SSZ offset field (bytes 0..4 little-endian): 0xABABABAB = 2880154539
+    //   - Wire:  25 bytes = varint(64) || snappy_frame_compress([0xab; 64])
+    //   - After zeam's snappy frame decode: 64 bytes all `0xAB`
+    //   - SSZ offset field (bytes 0..4 LE): 0xABABABAB = 2880154539
     //
-    // Without the guard the vendored ssz.zig container deserializer at
+    // Without the guard added in #845, the ssz.zig container deserializer at
     // lib.zig:604 sliced `bytes[2880154539..]` on a 64-byte buffer and
-    // panicked ("start index 2880154539 is larger than end index 64"),
-    // killing the FFI thread and aborting the whole process. Any peer
-    // could DoS zeam with a single malformed request.
+    // panicked, killing the FFI thread and aborting zeam.
     //
-    // Incidents: Hive suite 1778164266 (v0.4.15 / 993f193, May 7 2026)
-    //            Hive suite 1778192103 test-506 (v0.4.16 / 14222bc, May 7 2026)
+    // Scope: this test exercises the post-decompression validation path only.
+    // The snappy framing layer and the varint length pre-checks are not
+    // covered here; a full end-to-end harness (not yet in this project)
+    // would be needed to lock those against regression too.
     //
-    // After the fix `ReqRespRequest.deserialize` rejects these with
-    // `error.MalformedReqRespRequest` so the request-handler's existing
-    // catch path sends an RPC error to the peer and keeps the node alive.
-    // We exercise four shapes here:
-    //   1. The exact decompressed bytes from the Hive test
-    //      (64 bytes all 0xAB → offset 0xABABABAB, well past the buffer).
-    //   2. Any non-`4` offset (the only legal value for a single-variable
-    //      -field container).
-    //   3. A body length that isn't a multiple of `sizeOf(Root) = 32`.
-    //   4. A body whose root count exceeds `MAX_REQUEST_BLOCKS`.
-    // For each, we additionally call `ReqRespRequest.deserialize` to
-    // confirm the panic path is no longer reachable end-to-end.
+    // Incidents: image 993f193 (v0.4.15, May 7 2026)
+    //            image 14222bc (v0.4.16, May 7 2026, Hive test-506)
+    //
+    // The `@sizeOf(types.Root) == 32` compile-time assert inside
+    // `validateBlocksByRootRequestBytes` ensures the 32-byte step assumption
+    // used in cases 3, 6, and 7 holds. If `Root` ever gets padding the build
+    // will fail at compile time rather than silently misclassifying payloads.
+    //
+    // All rejection cases also call `ReqRespRequest.deserialize` end-to-end.
+    // Without the end-to-end call, a future contributor who mis-wires the
+    // pre-validation switch (e.g. only `.status`, not `.blocks_by_root`)
+    // would leave the production SSZ panic path reachable while the
+    // per-shape validator checks still pass. The end-to-end calls lock that
+    // wiring. The `errdefer req.deinit()` inside `deserialize` means any
+    // allocation made before the validator fires is cleaned up on error;
+    // `std.testing.allocator` enforces this by detecting leaks at test exit.
     const allocator = std.testing.allocator;
 
     {
-        // Case 1: exact Hive malformed_request bytes after snappy decompression.
-        // The simulator sends `encode_request_raw(&[0xab; 64])` which
-        // decompresses to 64 bytes all `0xAB`. Offset = 0xABABABAB ≠ 4.
+        // Case 1: exact decompressed bytes from the Hive malformed_request test.
+        // 64 bytes all 0xAB → offset 0xABABABAB (2880154539), way past the end.
         var malformed = [_]u8{0xAB} ** 64;
         try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&malformed));
         try std.testing.expectError(
@@ -1131,14 +1134,34 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
         );
     }
 
-    // Cases 2-4 below also call `ReqRespRequest.deserialize` end-to-end, not
-    // just the validator helper directly. Without that we'd only be testing
-    // the validator function in isolation — if a future contributor wired the
-    // pre-validation switch to the wrong protocol tag (e.g. only `.status`),
-    // the per-shape checks would still pass while the production path
-    // silently regressed back to a panicking SSZ codec. The end-to-end calls
-    // lock that wiring in place.
     {
+        // Case 2: non-uniform garbage — offset 0xDEADBEEF, mixed body bytes.
+        // Guards against an (unlikely) optimisation that only rejects
+        // homogeneous byte patterns.
+        var mixed: [36]u8 = undefined;
+        std.mem.writeInt(u32, mixed[0..4], 0xDEADBEEF, .little);
+        @memset(mixed[4..], 0x5A);
+        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&mixed));
+        try std.testing.expectError(
+            error.MalformedReqRespRequest,
+            ReqRespRequest.deserialize(allocator, .blocks_by_root, &mixed),
+        );
+    }
+
+    {
+        // Case 3: offset = 0 (null-prefix / classic adversarial first try).
+        var zero_offset: [36]u8 = undefined;
+        std.mem.writeInt(u32, zero_offset[0..4], 0, .little);
+        @memset(zero_offset[4..], 0);
+        try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&zero_offset));
+        try std.testing.expectError(
+            error.MalformedReqRespRequest,
+            ReqRespRequest.deserialize(allocator, .blocks_by_root, &zero_offset),
+        );
+    }
+
+    {
+        // Case 4: offset = 8 (close to legal but wrong — "near-legal" family).
         var bad_offset: [36]u8 = undefined;
         std.mem.writeInt(u32, bad_offset[0..4], 8, .little);
         @memset(bad_offset[4..], 0);
@@ -1150,6 +1173,7 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     }
 
     {
+        // Case 5: body length not a multiple of 32 (ragged root list).
         var ragged: [37]u8 = undefined;
         std.mem.writeInt(u32, ragged[0..4], 4, .little);
         @memset(ragged[4..], 0);
@@ -1161,6 +1185,7 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     }
 
     {
+        // Case 6: root count exceeds MAX_REQUEST_BLOCKS.
         const oversize_count = consensus_params.MAX_REQUEST_BLOCKS + 1;
         const oversize_len = 4 + oversize_count * @sizeOf(types.Root);
         const oversize = try allocator.alloc(u8, oversize_len);
@@ -1174,14 +1199,27 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
         );
     }
 
-    // Sanity: the well-formed empty list still deserializes cleanly so we
-    // haven't made the validator over-strict.
+    // Sanity cases: the validator must not over-reject well-formed payloads.
     {
+        // Case 7: empty root list (offset=4, body empty). Valid.
         var empty: [4]u8 = undefined;
         std.mem.writeInt(u32, empty[0..4], 4, .little);
         try validateBlocksByRootRequestBytes(&empty);
         var req = try ReqRespRequest.deserialize(allocator, .blocks_by_root, &empty);
         defer req.deinit();
         try std.testing.expectEqual(@as(usize, 0), req.blocks_by_root.roots.constSlice().len);
+    }
+
+    {
+        // Case 8: exactly one root (offset=4, body=32 bytes). Valid.
+        // Ensures the rejection path doesn't drift to over-rejecting
+        // legitimate non-empty requests.
+        var one_root: [4 + 32]u8 = undefined;
+        std.mem.writeInt(u32, one_root[0..4], 4, .little);
+        @memset(one_root[4..], 0); // zero root hash is a valid hash value
+        try validateBlocksByRootRequestBytes(&one_root);
+        var req = try ReqRespRequest.deserialize(allocator, .blocks_by_root, &one_root);
+        defer req.deinit();
+        try std.testing.expectEqual(@as(usize, 1), req.blocks_by_root.roots.constSlice().len);
     }
 }

--- a/pkgs/network/src/interface.zig
+++ b/pkgs/network/src/interface.zig
@@ -1088,21 +1088,29 @@ test LeanNetworkTopic {
 
 test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panicking" {
     // Regression test for the Hive `reqresp/blocks_by_root/malformed_request`
-    // failure (May 7 2026, image 993f193 / v0.4.15). The simulator sent a
-    // 24-byte payload whose first 4 bytes decode to a u32 offset of
-    // ~2.88e9 — well past the payload length. The vendored ssz.zig
-    // container deserializer at lib.zig:604 then sliced
-    // `bytes[indices[0]..end]` without bounds-checking and panicked
-    // ("start index 2880154539 is larger than end index 64"), which
-    // killed the FFI thread and aborted the whole process. Any peer
-    // could DoS zeam with a single bad request.
+    // failures (v0.4.15 and v0.4.16, both failed with the same Hive bytes).
     //
-    // After the fix `ReqRespRequest.deserialize` rejects this with
+    // The Hive simulator sends `encode_request_raw(&[0xab; 64])`:
+    //   - Wire: 25 bytes = varint(64) || snappy_compress([0xab; 64])
+    //   - Decompressed (what `validateBlocksByRootRequestBytes` receives):
+    //     64 bytes all `0xAB`
+    //   - SSZ offset field (bytes 0..4 little-endian): 0xABABABAB = 2880154539
+    //
+    // Without the guard the vendored ssz.zig container deserializer at
+    // lib.zig:604 sliced `bytes[2880154539..]` on a 64-byte buffer and
+    // panicked ("start index 2880154539 is larger than end index 64"),
+    // killing the FFI thread and aborting the whole process. Any peer
+    // could DoS zeam with a single malformed request.
+    //
+    // Incidents: Hive suite 1778164266 (v0.4.15 / 993f193, May 7 2026)
+    //            Hive suite 1778192103 test-506 (v0.4.16 / 14222bc, May 7 2026)
+    //
+    // After the fix `ReqRespRequest.deserialize` rejects these with
     // `error.MalformedReqRespRequest` so the request-handler's existing
-    // catch path can return an RPC error to the peer and keep the node
-    // alive. We exercise four shapes here:
-    //   1. The exact-on-the-wire panic trigger from the Hive run
-    //      (4-byte offset of 0xABABAAAB followed by 20 garbage bytes).
+    // catch path sends an RPC error to the peer and keeps the node alive.
+    // We exercise four shapes here:
+    //   1. The exact decompressed bytes from the Hive test
+    //      (64 bytes all 0xAB → offset 0xABABABAB, well past the buffer).
     //   2. Any non-`4` offset (the only legal value for a single-variable
     //      -field container).
     //   3. A body length that isn't a multiple of `sizeOf(Root) = 32`.
@@ -1112,9 +1120,10 @@ test "ReqRespRequest.deserialize rejects malformed BlocksByRoot without panickin
     const allocator = std.testing.allocator;
 
     {
-        var malformed: [24]u8 = undefined;
-        std.mem.writeInt(u32, malformed[0..4], 0xABABAAAB, .little);
-        @memset(malformed[4..], 0xAB);
+        // Case 1: exact Hive malformed_request bytes after snappy decompression.
+        // The simulator sends `encode_request_raw(&[0xab; 64])` which
+        // decompresses to 64 bytes all `0xAB`. Offset = 0xABABABAB ≠ 4.
+        var malformed = [_]u8{0xAB} ** 64;
         try std.testing.expectError(error.MalformedReqRespRequest, validateBlocksByRootRequestBytes(&malformed));
         try std.testing.expectError(
             error.MalformedReqRespRequest,

--- a/pkgs/third_party/ssz/.github/CODEOWNERS
+++ b/pkgs/third_party/ssz/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gballet

--- a/pkgs/third_party/ssz/.github/workflows/ci.yml
+++ b/pkgs/third_party/ssz/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Lint and test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Zig
+      uses: korandoru/setup-zig@v1
+      with:
+        zig-version: 0.16.0
+
+    - name: Build
+      run: zig build
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Zig
+      uses: korandoru/setup-zig@v1
+      with:
+        zig-version: 0.16.0
+
+    - name: Lint
+      run: zig fmt --check src/*.zig
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Zig
+      uses: korandoru/setup-zig@v1
+      with:
+        zig-version: 0.16.0
+
+    - name: Test
+      run: zig build test --summary all

--- a/pkgs/third_party/ssz/.gitignore
+++ b/pkgs/third_party/ssz/.gitignore
@@ -1,0 +1,3 @@
+.zig-cache
+zig-cache
+zig-out

--- a/pkgs/third_party/ssz/LICENSE
+++ b/pkgs/third_party/ssz/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/pkgs/third_party/ssz/README.md
+++ b/pkgs/third_party/ssz/README.md
@@ -1,0 +1,90 @@
+[![Lint and test](https://github.com/gballet/ssz.zig/actions/workflows/ci.yml/badge.svg)](https://github.com/gballet/ssz.zig/actions/workflows/ci.yml)
+
+# ssz.zig
+A [Zig](https://ziglang.org) implementation of the [SSZ serialization protocol](https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/simple-serialize.md).
+
+This is meant to work with zig version 0.15.x.
+
+## Serialization
+
+Use `serialize` to write a serialized object to a byte buffer.
+
+Currently supported types:
+
+ * `BitVector[N]`
+ * `uintN`
+ * `boolean`
+ * structures
+ * optionals
+ * `null`
+ * `Vector[N]`
+ * **tagged** unions
+ * `List[N]`
+ * `Bitlist[N]`
+
+Ziglang has the limitation that it's not possible to determine which union field is active without tags.
+
+## Deserialization
+
+Use `deserialize` to turn a byte array containing a serialized payload, into an object.
+
+`deserialize` does not allocate any new memory. Scalar values will be copied, and vector values use references to the serialized data. Make a copy of the data if you need to free the serialized payload. Future versions will include a version of `deserialize` that expects an allocator.
+
+Supported types:
+
+ * `uintN`
+ * `boolean`
+ * structures
+ * strings
+ * `BitVector[N]`
+ * `Vector[N]`
+ * unions
+ * optionals
+ * `List[N]`
+ * `Bitlist[N]`
+
+## Merkelization (experimental)
+
+Use `tree_root_hash` to calculate the root hash of an object.
+
+Supported types:
+
+ * `Bitvector[N]`
+ * `boolean`
+ * `uintN`
+ * `Vector[N]`
+ * structures
+ * strings
+ * optionals
+ * unions
+ * `List[N]`
+ * `Bitlist[N]`
+
+## Using Custom Hash Functions
+
+ssz.zig is hash-function agnostic. Pass your hasher as a type parameter:
+
+```zig
+const std = @import("std");
+const ssz = @import("ssz.zig");
+
+// Using SHA256 (from stdlib)
+const Sha256 = std.crypto.hash.sha2.Sha256;
+try ssz.hashTreeRoot(Sha256, MyType, value, &root, allocator);
+
+// Using a custom hasher (must implement init/update/final API)
+const MyHasher = ...; // Your hasher type
+try ssz.hashTreeRoot(MyHasher, MyType, value, &root, allocator);
+```
+
+**Required Hasher API:**
+```zig
+pub const Options = struct {};
+pub fn init(_: Options) Self;
+pub fn update(self: *Self, data: []const u8) void;
+pub fn final(self: *Self, out: *[Self.digest_length]u8) void; // out size matches 32 bytes for SSZ
+```
+
+## Contributing
+
+Simply create an issue or a PR.

--- a/pkgs/third_party/ssz/build.zig
+++ b/pkgs/third_party/ssz/build.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const mod = b.addModule("ssz.zig", .{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lib = b.addLibrary(.{
+        .name = "ssz",
+        .root_module = mod,
+    });
+    b.installArtifact(lib);
+
+    const main_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_main_tests = b.addRunArtifact(main_tests);
+
+    const tests_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tests.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{.{ .name = "ssz.zig", .module = mod }},
+        }),
+    });
+    const run_tests_tests = b.addRunArtifact(tests_tests);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&run_main_tests.step);
+    test_step.dependOn(&run_tests_tests.step);
+}

--- a/pkgs/third_party/ssz/build.zig.zon
+++ b/pkgs/third_party/ssz/build.zig.zon
@@ -1,0 +1,7 @@
+.{
+    .name = .ssz,
+    .fingerprint = 0x1d34bd0ceb1dfc2d,
+    .version = "0.0.9",
+    .minimum_zig_version = "0.16.0",
+    .paths = .{""},
+}

--- a/pkgs/third_party/ssz/src/beacon_tests.zig
+++ b/pkgs/third_party/ssz/src/beacon_tests.zig
@@ -1,0 +1,810 @@
+const libssz = @import("lib.zig");
+const utils = libssz.utils;
+const serialize = libssz.serialize;
+const deserialize = libssz.deserialize;
+const hashTreeRoot = libssz.hashTreeRoot;
+const std = @import("std");
+const ArrayList = std.ArrayList;
+const expect = std.testing.expect;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+// Beacon chain Validator struct for compatibility testing
+const Validator = struct {
+    pubkey: [48]u8,
+    withdrawal_credentials: [32]u8,
+    effective_balance: u64,
+    slashed: bool,
+    activation_eligibility_epoch: u64,
+    activation_epoch: u64,
+    exit_epoch: u64,
+    withdrawable_epoch: u64,
+};
+
+test "Validator struct serialization" {
+    const validator = Validator{
+        .pubkey = [_]u8{0xAA} ** 48,
+        .withdrawal_credentials = [_]u8{0xBB} ** 32,
+        .effective_balance = 32000000000,
+        .slashed = false,
+        .activation_eligibility_epoch = 0,
+        .activation_epoch = 0,
+        .exit_epoch = 18446744073709551615, // Max u64
+        .withdrawable_epoch = 18446744073709551615, // Max u64
+    };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(Validator, validator, &list, std.testing.allocator);
+
+    // Verify expected size: 48 + 32 + 8 + 1 + 8 + 8 + 8 + 8 = 121 bytes
+    try expect(list.items.len == 121);
+
+    // Test round-trip serialization
+    var deserialized: Validator = undefined;
+    try deserialize(Validator, list.items, &deserialized, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &validator.pubkey, &deserialized.pubkey));
+    try expect(std.mem.eql(u8, &validator.withdrawal_credentials, &deserialized.withdrawal_credentials));
+    try expect(validator.effective_balance == deserialized.effective_balance);
+    try expect(validator.slashed == deserialized.slashed);
+    try expect(validator.activation_eligibility_epoch == deserialized.activation_eligibility_epoch);
+    try expect(validator.activation_epoch == deserialized.activation_epoch);
+    try expect(validator.exit_epoch == deserialized.exit_epoch);
+    try expect(validator.withdrawable_epoch == deserialized.withdrawable_epoch);
+}
+
+test "Validator struct hash tree root" {
+    const validator = Validator{
+        .pubkey = [_]u8{0x01} ** 48,
+        .withdrawal_credentials = [_]u8{0x02} ** 32,
+        .effective_balance = 32000000000,
+        .slashed = true,
+        .activation_eligibility_epoch = 1,
+        .activation_epoch = 2,
+        .exit_epoch = 100,
+        .withdrawable_epoch = 200,
+    };
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Validator, validator, &hash, std.testing.allocator);
+
+    // Validate against expected hash
+    const expected_validator_hash = [_]u8{ 0x70, 0x68, 0xE5, 0x06, 0xCB, 0xFF, 0xCD, 0x31, 0xBD, 0x2D, 0x13, 0x42, 0x5E, 0x4F, 0xDE, 0x98, 0x6E, 0xF3, 0x5E, 0x6F, 0xB5, 0x0F, 0x35, 0x9D, 0x7A, 0x26, 0xB6, 0x33, 0x2E, 0xE2, 0xCB, 0x94 };
+    try expect(std.mem.eql(u8, &hash, &expected_validator_hash));
+
+    // Hash should be deterministic for the same validator
+    var hash2: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Validator, validator, &hash2, std.testing.allocator);
+    try expect(std.mem.eql(u8, &hash, &hash2));
+
+    // Different validator should produce different hash
+    const validator2 = Validator{
+        .pubkey = [_]u8{0xFF} ** 48,
+        .withdrawal_credentials = [_]u8{0x02} ** 32,
+        .effective_balance = 32000000000,
+        .slashed = true,
+        .activation_eligibility_epoch = 1,
+        .activation_epoch = 2,
+        .exit_epoch = 100,
+        .withdrawable_epoch = 200,
+    };
+
+    var hash3: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Validator, validator2, &hash3, std.testing.allocator);
+    try expect(!std.mem.eql(u8, &hash, &hash3));
+}
+
+test "Individual Validator serialization and hash" {
+    // Test individual validator
+    const validator = Validator{
+        .pubkey = [_]u8{0x01} ** 48,
+        .withdrawal_credentials = [_]u8{0x02} ** 32,
+        .effective_balance = 32000000000,
+        .slashed = true,
+        .activation_eligibility_epoch = 1,
+        .activation_epoch = 2,
+        .exit_epoch = 100,
+        .withdrawable_epoch = 200,
+    };
+
+    // Test serialization
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(Validator, validator, &list, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_validator_bytes = [_]u8{ 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x00, 0x40, 0x59, 0x73, 0x07, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, list.items, &expected_validator_bytes));
+
+    // Test hash tree root
+    var root: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Validator, validator, &root, std.testing.allocator);
+
+    // Validate against expected hash
+    const expected_validator_hash = [_]u8{ 0x70, 0x68, 0xE5, 0x06, 0xCB, 0xFF, 0xCD, 0x31, 0xBD, 0x2D, 0x13, 0x42, 0x5E, 0x4F, 0xDE, 0x98, 0x6E, 0xF3, 0x5E, 0x6F, 0xB5, 0x0F, 0x35, 0x9D, 0x7A, 0x26, 0xB6, 0x33, 0x2E, 0xE2, 0xCB, 0x94 };
+    try expect(std.mem.eql(u8, &root, &expected_validator_hash));
+}
+
+test "List[Validator] serialization and hash tree root" {
+    const MAX_VALIDATORS = 100;
+    const ValidatorList = utils.List(Validator, MAX_VALIDATORS);
+
+    var validator_list = try ValidatorList.init(std.testing.allocator);
+    defer validator_list.deinit();
+
+    // Add test validators
+    const validator1 = Validator{
+        .pubkey = [_]u8{0x01} ** 48,
+        .withdrawal_credentials = [_]u8{0x11} ** 32,
+        .effective_balance = 32000000000,
+        .slashed = false,
+        .activation_eligibility_epoch = 0,
+        .activation_epoch = 0,
+        .exit_epoch = 18446744073709551615,
+        .withdrawable_epoch = 18446744073709551615,
+    };
+
+    const validator2 = Validator{
+        .pubkey = [_]u8{0x02} ** 48,
+        .withdrawal_credentials = [_]u8{0x22} ** 32,
+        .effective_balance = 31000000000,
+        .slashed = false,
+        .activation_eligibility_epoch = 1,
+        .activation_epoch = 1,
+        .exit_epoch = 18446744073709551615,
+        .withdrawable_epoch = 18446744073709551615,
+    };
+
+    try validator_list.append(validator1);
+    try validator_list.append(validator2);
+
+    // Test serialization
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(ValidatorList, validator_list, &list, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_validator_list_bytes = [_]u8{ 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00, 0x40, 0x59, 0x73, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x76, 0xBE, 0x37, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+    try expect(std.mem.eql(u8, list.items, &expected_validator_list_bytes));
+
+    // Test deserialization
+    var deserialized_list = try ValidatorList.init(std.testing.allocator);
+    defer deserialized_list.deinit();
+    try deserialize(ValidatorList, list.items, &deserialized_list, std.testing.allocator);
+
+    try expect(validator_list.len() == deserialized_list.len());
+    try expect(validator_list.len() == 2);
+
+    // Verify each validator was deserialized correctly
+    for (0..validator_list.len()) |i| {
+        const orig = try validator_list.get(i);
+        const deser = try deserialized_list.get(i);
+
+        try expect(std.mem.eql(u8, &orig.pubkey, &deser.pubkey));
+        try expect(std.mem.eql(u8, &orig.withdrawal_credentials, &deser.withdrawal_credentials));
+        try expect(orig.effective_balance == deser.effective_balance);
+        try expect(orig.slashed == deser.slashed);
+        try expect(orig.activation_eligibility_epoch == deser.activation_eligibility_epoch);
+        try expect(orig.activation_epoch == deser.activation_epoch);
+        try expect(orig.exit_epoch == deser.exit_epoch);
+        try expect(orig.withdrawable_epoch == deser.withdrawable_epoch);
+    }
+
+    // Test hash tree root
+    var hash1: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ValidatorList, validator_list, &hash1, std.testing.allocator);
+
+    // Validate against expected hash
+    const expected_validator_list_hash = [_]u8{ 0x54, 0x80, 0xF8, 0x35, 0xD7, 0x52, 0xF7, 0x27, 0xC8, 0xF1, 0xE9, 0xCC, 0x0F, 0x84, 0x2B, 0x25, 0x76, 0xA5, 0x1A, 0xD2, 0xB7, 0xB5, 0x10, 0xF1, 0xA5, 0x39, 0xF7, 0xD8, 0xD0, 0x87, 0xC3, 0xC2 };
+    try expect(std.mem.eql(u8, &hash1, &expected_validator_list_hash));
+
+    var hash2: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ValidatorList, deserialized_list, &hash2, std.testing.allocator);
+
+    // Hash should be the same for original and deserialized lists
+    try expect(std.mem.eql(u8, &hash1, &hash2));
+}
+
+// BeamBlockBody types for testing
+const MAX_VALIDATORS_IN_BLOCK = 50;
+const ValidatorArray = utils.List(Validator, MAX_VALIDATORS_IN_BLOCK);
+const BeamBlockBody = struct {
+    validators: ValidatorArray,
+};
+
+test "BeamBlockBody with validator array - full cycle" {
+    // Create test validators
+    const validator1 = Validator{
+        .pubkey = [_]u8{0x01} ** 48,
+        .withdrawal_credentials = [_]u8{0x11} ** 32,
+        .effective_balance = 32000000000,
+        .slashed = false,
+        .activation_eligibility_epoch = 0,
+        .activation_epoch = 0,
+        .exit_epoch = 18446744073709551615,
+        .withdrawable_epoch = 18446744073709551615,
+    };
+
+    const validator2 = Validator{
+        .pubkey = [_]u8{0x02} ** 48,
+        .withdrawal_credentials = [_]u8{0x22} ** 32,
+        .effective_balance = 31000000000,
+        .slashed = true,
+        .activation_eligibility_epoch = 1,
+        .activation_epoch = 2,
+        .exit_epoch = 100,
+        .withdrawable_epoch = 200,
+    };
+
+    // Create validator array
+    var validators = try ValidatorArray.init(std.testing.allocator);
+    defer validators.deinit();
+    try validators.append(validator1);
+    try validators.append(validator2);
+
+    // Create BeamBlockBody
+    const beam_block_body = BeamBlockBody{
+        .validators = validators,
+    };
+
+    // Test serialization
+    var serialized_data: ArrayList(u8) = .empty;
+    defer serialized_data.deinit(std.testing.allocator);
+    try serialize(BeamBlockBody, beam_block_body, &serialized_data, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_beam_block_body_bytes = [_]u8{ 0x04, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x00, 0x40, 0x59, 0x73, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x76, 0xBE, 0x37, 0x07, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, serialized_data.items, &expected_beam_block_body_bytes));
+
+    // Test deserialization
+    var deserialized_body: BeamBlockBody = undefined;
+    deserialized_body.validators = try ValidatorArray.init(std.testing.allocator);
+    defer deserialized_body.validators.deinit();
+    try deserialize(BeamBlockBody, serialized_data.items, &deserialized_body, std.testing.allocator);
+
+    // Verify deserialization correctness
+    try expect(beam_block_body.validators.len() == deserialized_body.validators.len());
+    try expect(beam_block_body.validators.len() == 2);
+
+    for (0..beam_block_body.validators.len()) |i| {
+        const orig = try beam_block_body.validators.get(i);
+        const deser = try deserialized_body.validators.get(i);
+
+        try expect(std.mem.eql(u8, &orig.pubkey, &deser.pubkey));
+        try expect(std.mem.eql(u8, &orig.withdrawal_credentials, &deser.withdrawal_credentials));
+        try expect(orig.effective_balance == deser.effective_balance);
+        try expect(orig.slashed == deser.slashed);
+        try expect(orig.activation_eligibility_epoch == deser.activation_eligibility_epoch);
+        try expect(orig.activation_epoch == deser.activation_epoch);
+        try expect(orig.exit_epoch == deser.exit_epoch);
+        try expect(orig.withdrawable_epoch == deser.withdrawable_epoch);
+    }
+
+    // Test hash tree root consistency
+    var hash_original: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BeamBlockBody, beam_block_body, &hash_original, std.testing.allocator);
+
+    // Validate against expected hash
+    const expected_beam_block_body_hash = [_]u8{ 0x34, 0xF2, 0xBC, 0x58, 0xA0, 0xBF, 0x20, 0x72, 0x43, 0xF8, 0xC2, 0x5E, 0x0F, 0x83, 0x5E, 0x36, 0x90, 0x73, 0xD5, 0xAC, 0x97, 0x1E, 0x9A, 0x53, 0x71, 0x14, 0xA0, 0xFD, 0x1C, 0xC8, 0xD8, 0xE4 };
+    try expect(std.mem.eql(u8, &hash_original, &expected_beam_block_body_hash));
+
+    var hash_deserialized: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BeamBlockBody, deserialized_body, &hash_deserialized, std.testing.allocator);
+
+    // Hashes should be identical for original and deserialized data
+    try expect(std.mem.eql(u8, &hash_original, &hash_deserialized));
+
+    // Test hash determinism
+    var hash_duplicate: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BeamBlockBody, beam_block_body, &hash_duplicate, std.testing.allocator);
+    try expect(std.mem.eql(u8, &hash_original, &hash_duplicate));
+}
+
+test "Zeam-style List/Bitlist usage with tree root stability" {
+    const MAX_VALIDATORS = 2048;
+    const MAX_HISTORICAL_BLOCK_HASHES = 4096;
+
+    const Root = [32]u8;
+
+    const Mini3SFCheckpoint = struct {
+        root: Root,
+        slot: u64,
+    };
+
+    const Mini3SFVote = struct {
+        validator_id: u64,
+        slot: u64,
+        head: Mini3SFCheckpoint,
+        target: Mini3SFCheckpoint,
+        source: Mini3SFCheckpoint,
+    };
+
+    const Mini3SFVotes = utils.List(Mini3SFVote, MAX_VALIDATORS);
+    const HistoricalBlockHashes = utils.List(Root, MAX_HISTORICAL_BLOCK_HASHES);
+    const JustifiedSlots = utils.Bitlist(MAX_HISTORICAL_BLOCK_HASHES);
+
+    const ZeamBeamBlockBody = struct {
+        votes: Mini3SFVotes,
+    };
+
+    const BeamState = struct {
+        slot: u64,
+        historical_block_hashes: HistoricalBlockHashes,
+        justified_slots: JustifiedSlots,
+    };
+
+    var votes = try Mini3SFVotes.init(std.testing.allocator);
+    defer votes.deinit();
+    try votes.append(Mini3SFVote{
+        .validator_id = 1,
+        .slot = 10,
+        .head = Mini3SFCheckpoint{ .root = [_]u8{1} ** 32, .slot = 10 },
+        .target = Mini3SFCheckpoint{ .root = [_]u8{2} ** 32, .slot = 9 },
+        .source = Mini3SFCheckpoint{ .root = [_]u8{3} ** 32, .slot = 8 },
+    });
+
+    var hashes = try HistoricalBlockHashes.init(std.testing.allocator);
+    defer hashes.deinit();
+    try hashes.append([_]u8{0xaa} ** 32);
+    try hashes.append([_]u8{0xbb} ** 32);
+
+    var bitlist = try JustifiedSlots.init(std.testing.allocator);
+    defer bitlist.deinit();
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+
+    const body = ZeamBeamBlockBody{ .votes = votes };
+    const state = BeamState{
+        .slot = 42,
+        .historical_block_hashes = hashes,
+        .justified_slots = bitlist,
+    };
+
+    // Test serialization
+    var body_serialized: ArrayList(u8) = .empty;
+    defer body_serialized.deinit(std.testing.allocator);
+    try serialize(ZeamBeamBlockBody, body, &body_serialized, std.testing.allocator);
+
+    var state_serialized: ArrayList(u8) = .empty;
+    defer state_serialized.deinit(std.testing.allocator);
+    try serialize(BeamState, state, &state_serialized, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_zeam_body_bytes = [_]u8{ 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, body_serialized.items, &expected_zeam_body_bytes));
+
+    const expected_zeam_state_bytes = [_]u8{ 0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x50, 0x00, 0x00, 0x00, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0x0D };
+
+    try expect(std.mem.eql(u8, state_serialized.items, &expected_zeam_state_bytes));
+
+    // Test hash tree root determinism and validate against expected hashes
+    var body_hash1: [32]u8 = undefined;
+    var body_hash2: [32]u8 = undefined;
+    var state_hash1: [32]u8 = undefined;
+    var state_hash2: [32]u8 = undefined;
+
+    try hashTreeRoot(Sha256, ZeamBeamBlockBody, body, &body_hash1, std.testing.allocator);
+    try hashTreeRoot(Sha256, ZeamBeamBlockBody, body, &body_hash2, std.testing.allocator);
+    try hashTreeRoot(Sha256, BeamState, state, &state_hash1, std.testing.allocator);
+    try hashTreeRoot(Sha256, BeamState, state, &state_hash2, std.testing.allocator);
+
+    // Validate against expected hashes
+    const expected_zeam_body_hash = [_]u8{ 0xAA, 0x2C, 0x76, 0x39, 0x96, 0xA6, 0xDD, 0x26, 0x25, 0x13, 0x12, 0x8D, 0xEA, 0xDF, 0xCB, 0x69, 0xF1, 0xEC, 0xEB, 0x60, 0xA8, 0xFF, 0xAC, 0xC7, 0xA7, 0xE4, 0x28, 0x3C, 0x74, 0xAA, 0x6A, 0xE4 };
+    const expected_zeam_state_hash = [_]u8{ 0x3B, 0x61, 0xA7, 0x99, 0x37, 0xF0, 0x69, 0x79, 0x7D, 0x86, 0x41, 0xCA, 0x75, 0x25, 0x26, 0x5D, 0x54, 0x74, 0x5E, 0xB8, 0x2A, 0xA2, 0x1F, 0x20, 0xFA, 0x1D, 0x8A, 0x71, 0x02, 0x87, 0xF9, 0xD7 };
+
+    try expect(std.mem.eql(u8, &body_hash1, &body_hash2));
+    try expect(std.mem.eql(u8, &state_hash1, &state_hash2));
+    try expect(std.mem.eql(u8, &body_hash1, &expected_zeam_body_hash));
+    try expect(std.mem.eql(u8, &state_hash1, &expected_zeam_state_hash));
+}
+
+test "BeamState with historical roots - comprehensive test" {
+    const MAX_HISTORICAL_ROOTS = 10;
+
+    const Root = [32]u8;
+
+    // BeamState structure with historical roots
+    const BeamState = struct {
+        slot: u64,
+        proposer_index: u64,
+        parent_root: Root,
+        state_root: Root,
+        historical_roots: utils.List(Root, MAX_HISTORICAL_ROOTS),
+        validator_count: u64,
+        justified_checkpoint_root: Root,
+        finalized_checkpoint_root: Root,
+    };
+
+    var historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer historical_roots.deinit();
+
+    try historical_roots.append([_]u8{0x01} ** 32);
+    try historical_roots.append([_]u8{0x02} ** 32);
+    try historical_roots.append([_]u8{0x03} ** 32);
+    try historical_roots.append([_]u8{0xAA} ** 32);
+    try historical_roots.append([_]u8{0xBB} ** 32);
+    try historical_roots.append([_]u8{0xCC} ** 32);
+    try historical_roots.append([_]u8{0xDD} ** 32);
+    try historical_roots.append([_]u8{0xEE} ** 32);
+    try historical_roots.append([_]u8{0xFF} ** 32);
+    try historical_roots.append([_]u8{0x00} ** 32);
+
+    // Create BeamState instance
+    const beam_state = BeamState{
+        .slot = 12345,
+        .proposer_index = 42,
+        .parent_root = [_]u8{0x11} ** 32,
+        .state_root = [_]u8{0x22} ** 32,
+        .historical_roots = historical_roots,
+        .validator_count = 1000,
+        .justified_checkpoint_root = [_]u8{0x33} ** 32,
+        .finalized_checkpoint_root = [_]u8{0x44} ** 32,
+    };
+
+    // Test serialization
+    var serialized_data: ArrayList(u8) = .empty;
+    defer serialized_data.deinit(std.testing.allocator);
+    try serialize(BeamState, beam_state, &serialized_data, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_comprehensive_beam_state_bytes = [_]u8{ 0x39, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x9C, 0x00, 0x00, 0x00, 0xE8, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, serialized_data.items, &expected_comprehensive_beam_state_bytes));
+
+    // Test hash tree root calculation
+    var original_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BeamState, beam_state, &original_hash, std.testing.allocator);
+
+    // Validate against expected hash
+    const expected_comprehensive_beam_state_hash = [_]u8{ 0xBD, 0x36, 0x59, 0x5E, 0x3B, 0x4A, 0x51, 0x9C, 0xF3, 0x5F, 0x4F, 0x96, 0x88, 0x9E, 0x86, 0x10, 0xFF, 0x45, 0x20, 0x49, 0x15, 0xAE, 0x96, 0x2E, 0xF4, 0x0C, 0x81, 0x6B, 0xF7, 0x45, 0x4A, 0x17 };
+    try expect(std.mem.eql(u8, &original_hash, &expected_comprehensive_beam_state_hash));
+
+    // Test deserialization
+    var deserialized_state: BeamState = undefined;
+    deserialized_state.historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer deserialized_state.historical_roots.deinit();
+    try deserialize(BeamState, serialized_data.items, &deserialized_state, std.testing.allocator);
+
+    // Verify all fields match
+    try expect(beam_state.slot == deserialized_state.slot);
+    try expect(beam_state.proposer_index == deserialized_state.proposer_index);
+    try expect(beam_state.validator_count == deserialized_state.validator_count);
+
+    // Verify root fields
+    try expect(std.mem.eql(u8, &beam_state.parent_root, &deserialized_state.parent_root));
+    try expect(std.mem.eql(u8, &beam_state.state_root, &deserialized_state.state_root));
+    try expect(std.mem.eql(u8, &beam_state.justified_checkpoint_root, &deserialized_state.justified_checkpoint_root));
+    try expect(std.mem.eql(u8, &beam_state.finalized_checkpoint_root, &deserialized_state.finalized_checkpoint_root));
+
+    // Verify historical roots list
+    try expect(beam_state.historical_roots.len() == deserialized_state.historical_roots.len());
+    try expect(beam_state.historical_roots.len() == 10);
+
+    // Compare each historical root
+    for (0..beam_state.historical_roots.len()) |i| {
+        const original_root = try beam_state.historical_roots.get(i);
+        const deserialized_root = try deserialized_state.historical_roots.get(i);
+        try expect(std.mem.eql(u8, &original_root, &deserialized_root));
+    }
+
+    // Test hash tree root consistency
+    var deserialized_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BeamState, deserialized_state, &deserialized_hash, std.testing.allocator);
+
+    // Verify hash tree roots are identical
+    try expect(std.mem.eql(u8, &original_hash, &deserialized_hash));
+}
+
+test "BeamState with empty historical roots" {
+    const MAX_HISTORICAL_ROOTS = 8192;
+
+    const Root = [32]u8;
+
+    const SimpleBeamState = struct {
+        slot: u64,
+        historical_roots: utils.List(Root, MAX_HISTORICAL_ROOTS),
+        validator_count: u64,
+    };
+
+    // Create BeamState with empty historical roots
+    var empty_historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer empty_historical_roots.deinit();
+
+    const beam_state = SimpleBeamState{
+        .slot = 0,
+        .historical_roots = empty_historical_roots,
+        .validator_count = 0,
+    };
+
+    // Test serialization
+    var serialized_data: ArrayList(u8) = .empty;
+    defer serialized_data.deinit(std.testing.allocator);
+    try serialize(SimpleBeamState, beam_state, &serialized_data, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_empty_beam_state_bytes = [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, serialized_data.items, &expected_empty_beam_state_bytes));
+
+    // Test hash tree root calculation
+    var original_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, SimpleBeamState, beam_state, &original_hash, std.testing.allocator);
+
+    // Validate against actual hash
+    const expected_empty_beam_state_hash = [_]u8{ 0x58, 0xD2, 0x2B, 0xA0, 0x04, 0x45, 0xE8, 0xB7, 0x39, 0x5E, 0xC3, 0x93, 0x92, 0x45, 0xC6, 0xF1, 0x5A, 0x29, 0x91, 0xA5, 0x70, 0x3F, 0xC5, 0x05, 0x88, 0x10, 0x57, 0xDE, 0x9D, 0xF3, 0x64, 0x10 };
+
+    try expect(std.mem.eql(u8, &original_hash, &expected_empty_beam_state_hash));
+
+    // Test deserialization
+    var deserialized_state: SimpleBeamState = undefined;
+    deserialized_state.historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer deserialized_state.historical_roots.deinit();
+    try deserialize(SimpleBeamState, serialized_data.items, &deserialized_state, std.testing.allocator);
+
+    // Verify all fields match
+    try expect(beam_state.slot == deserialized_state.slot);
+    try expect(beam_state.validator_count == deserialized_state.validator_count);
+    try expect(beam_state.historical_roots.len() == deserialized_state.historical_roots.len());
+    try expect(beam_state.historical_roots.len() == 0);
+
+    // Test hash tree root consistency
+    var deserialized_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, SimpleBeamState, deserialized_state, &deserialized_hash, std.testing.allocator);
+
+    // Verify hash tree roots are identical
+    try expect(std.mem.eql(u8, &original_hash, &deserialized_hash));
+}
+
+test "BeamState with maximum historical roots" {
+    const MAX_HISTORICAL_ROOTS = 1024;
+
+    const Root = [32]u8;
+
+    const MaxBeamState = struct {
+        slot: u64,
+        historical_roots: utils.List(Root, MAX_HISTORICAL_ROOTS),
+    };
+
+    // Create BeamState with maximum historical roots
+    var max_historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer max_historical_roots.deinit();
+
+    // Fill to maximum capacity
+    for (0..MAX_HISTORICAL_ROOTS) |i| {
+        var root: Root = undefined;
+        // Create unique root for each index
+        for (0..32) |j| {
+            root[j] = @truncate((i * 32 + j) % 256);
+        }
+        try max_historical_roots.append(root);
+    }
+
+    const beam_state = MaxBeamState{
+        .slot = 999999,
+        .historical_roots = max_historical_roots,
+    };
+
+    // Test serialization
+    var serialized_data: ArrayList(u8) = .empty;
+    defer serialized_data.deinit(std.testing.allocator);
+    try serialize(MaxBeamState, beam_state, &serialized_data, std.testing.allocator);
+
+    // Validate against expected bytes (first few bytes)
+    const expected_max_beam_state_bytes_start = [_]u8{ 0x3F, 0x42, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, serialized_data.items[0..12], &expected_max_beam_state_bytes_start));
+
+    // Test hash tree root calculation
+    var original_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, MaxBeamState, beam_state, &original_hash, std.testing.allocator);
+
+    // Validate against actual hash
+    const expected_max_beam_state_hash = [_]u8{ 0x3F, 0xFC, 0x7A, 0xA4, 0x85, 0x21, 0xD4, 0x02, 0x36, 0x46, 0x19, 0x2E, 0x8D, 0x73, 0xBC, 0x11, 0x3D, 0x1D, 0xE7, 0xF4, 0xDE, 0xC4, 0xD9, 0x6E, 0x94, 0x52, 0xD2, 0xCB, 0x95, 0xE3, 0x22, 0x9A };
+
+    try expect(std.mem.eql(u8, &original_hash, &expected_max_beam_state_hash));
+
+    // Test deserialization
+    var deserialized_state: MaxBeamState = undefined;
+    deserialized_state.historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer deserialized_state.historical_roots.deinit();
+    try deserialize(MaxBeamState, serialized_data.items, &deserialized_state, std.testing.allocator);
+
+    // Verify maximum capacity
+    try expect(deserialized_state.historical_roots.len() == MAX_HISTORICAL_ROOTS);
+    try expect(beam_state.historical_roots.len() == deserialized_state.historical_roots.len());
+
+    // Compare each root
+    for (0..MAX_HISTORICAL_ROOTS) |i| {
+        const original_root = try beam_state.historical_roots.get(i);
+        const deserialized_root = try deserialized_state.historical_roots.get(i);
+        try expect(std.mem.eql(u8, &original_root, &deserialized_root));
+    }
+
+    // Test hash tree root consistency
+    var deserialized_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, MaxBeamState, deserialized_state, &deserialized_hash, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &original_hash, &deserialized_hash));
+}
+
+test "BeamState historical roots access and comparison" {
+    const MAX_HISTORICAL_ROOTS = 50;
+
+    const Root = [32]u8;
+
+    const AccessBeamState = struct {
+        slot: u64,
+        historical_roots: utils.List(Root, MAX_HISTORICAL_ROOTS),
+        metadata: u64,
+    };
+
+    var historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer historical_roots.deinit();
+
+    // Add roots with specific patterns
+    const test_patterns = [_][32]u8{
+        [_]u8{0x00} ** 32,
+        [_]u8{0xFF} ** 32,
+        [_]u8{0xAA} ** 32,
+        [_]u8{0x55} ** 32,
+        [_]u8{0x12} ** 32,
+        [_]u8{0x34} ** 32,
+        [_]u8{0x56} ** 32,
+        [_]u8{0x78} ** 32,
+        [_]u8{0x9A} ** 32,
+        [_]u8{0xBC} ** 32,
+    };
+
+    for (test_patterns) |pattern| {
+        try historical_roots.append(pattern);
+    }
+
+    const beam_state = AccessBeamState{
+        .slot = 54321,
+        .historical_roots = historical_roots,
+        .metadata = 0xDEADBEEF,
+    };
+
+    // Test serialization
+    var serialized_data: ArrayList(u8) = .empty;
+    defer serialized_data.deinit(std.testing.allocator);
+    try serialize(AccessBeamState, beam_state, &serialized_data, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_access_beam_state_bytes = [_]u8{ 0x31, 0xD4, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x56, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0x9A, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC, 0xBC };
+    try expect(std.mem.eql(u8, serialized_data.items, &expected_access_beam_state_bytes));
+
+    // Test hash tree root calculation
+    var original_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, AccessBeamState, beam_state, &original_hash, std.testing.allocator);
+
+    // Validate against expected hash
+    const expected_access_beam_state_hash = [_]u8{ 0x22, 0x3E, 0xCB, 0xDD, 0x62, 0x46, 0x7F, 0x7F, 0x0F, 0xA8, 0x2C, 0x91, 0x54, 0x1F, 0xF4, 0xEA, 0xBF, 0x92, 0xB6, 0xB7, 0x67, 0x57, 0x02, 0x67, 0x16, 0xEF, 0x3A, 0xB0, 0x96, 0x4E, 0x91, 0x9E };
+    try expect(std.mem.eql(u8, &original_hash, &expected_access_beam_state_hash));
+
+    // Test deserialization
+    var deserialized_state: AccessBeamState = undefined;
+    deserialized_state.historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer deserialized_state.historical_roots.deinit();
+    try deserialize(AccessBeamState, serialized_data.items, &deserialized_state, std.testing.allocator);
+
+    // Test individual root access and comparison
+    for (0..test_patterns.len) |i| {
+        const original_root = try beam_state.historical_roots.get(i);
+        const deserialized_root = try deserialized_state.historical_roots.get(i);
+        const expected_pattern = test_patterns[i];
+
+        // Verify root matches expected pattern
+        try expect(std.mem.eql(u8, &original_root, &expected_pattern));
+        try expect(std.mem.eql(u8, &deserialized_root, &expected_pattern));
+        try expect(std.mem.eql(u8, &original_root, &deserialized_root));
+    }
+
+    // Test edge cases
+    try expect(beam_state.historical_roots.len() == test_patterns.len);
+    try expect(deserialized_state.historical_roots.len() == test_patterns.len);
+
+    // Test metadata preservation
+    try expect(beam_state.metadata == deserialized_state.metadata);
+    try expect(beam_state.slot == deserialized_state.slot);
+
+    // Test hash tree root consistency
+    var deserialized_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, AccessBeamState, deserialized_state, &deserialized_hash, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &original_hash, &deserialized_hash));
+}
+
+test "SimpleBeamState with empty historical roots" {
+    const MAX_HISTORICAL_ROOTS = 8192;
+    const Root = [32]u8;
+
+    const SimpleBeamState = struct {
+        slot: u64,
+        historical_roots: utils.List(Root, MAX_HISTORICAL_ROOTS),
+        validator_count: u64,
+    };
+
+    // Create BeamState with empty historical roots
+    var empty_historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer empty_historical_roots.deinit();
+
+    const beam_state = SimpleBeamState{
+        .slot = 0,
+        .historical_roots = empty_historical_roots,
+        .validator_count = 0,
+    };
+
+    // Test serialization
+    var serialized_data: ArrayList(u8) = .empty;
+    defer serialized_data.deinit(std.testing.allocator);
+    try serialize(SimpleBeamState, beam_state, &serialized_data, std.testing.allocator);
+
+    // Validate against expected bytes
+    const expected_simple_beam_state_bytes = [_]u8{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    try expect(std.mem.eql(u8, serialized_data.items, &expected_simple_beam_state_bytes));
+
+    // Test hash tree root calculation
+    var original_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, SimpleBeamState, beam_state, &original_hash, std.testing.allocator);
+
+    // Validate against actual hash
+    const expected_simple_beam_state_hash = [_]u8{ 0x58, 0xD2, 0x2B, 0xA0, 0x04, 0x45, 0xE8, 0xB7, 0x39, 0x5E, 0xC3, 0x93, 0x92, 0x45, 0xC6, 0xF1, 0x5A, 0x29, 0x91, 0xA5, 0x70, 0x3F, 0xC5, 0x05, 0x88, 0x10, 0x57, 0xDE, 0x9D, 0xF3, 0x64, 0x10 };
+    try expect(std.mem.eql(u8, &original_hash, &expected_simple_beam_state_hash));
+
+    // Test deserialization
+    var deserialized_state: SimpleBeamState = undefined;
+    deserialized_state.historical_roots = try utils.List(Root, MAX_HISTORICAL_ROOTS).init(std.testing.allocator);
+    defer deserialized_state.historical_roots.deinit();
+    try deserialize(SimpleBeamState, serialized_data.items, &deserialized_state, std.testing.allocator);
+
+    // Verify all fields match
+    try expect(beam_state.slot == deserialized_state.slot);
+    try expect(beam_state.validator_count == deserialized_state.validator_count);
+    try expect(beam_state.historical_roots.len() == deserialized_state.historical_roots.len());
+    try expect(beam_state.historical_roots.len() == 0);
+
+    // Test hash tree root consistency
+    var deserialized_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, SimpleBeamState, deserialized_state, &deserialized_hash, std.testing.allocator);
+
+    // Verify hash tree roots are identical
+    try expect(std.mem.eql(u8, &original_hash, &deserialized_hash));
+}
+
+test "hashTreeRoot for pointer types" {
+    var hash: [32]u8 = undefined;
+
+    // Test pointer size .one - SUPPORTED
+    {
+        var value: u32 = 8;
+        try hashTreeRoot(Sha256, *u32, &value, &hash, std.testing.allocator);
+
+        var deserialized: u32 = undefined;
+        try deserialize(u32, hash[0..4], &deserialized, std.testing.allocator);
+        try expect(deserialized == value);
+    }
+
+    // Test pointer to array (size .slice) - SUPPORTED
+    {
+        var values = [4]u8{ 0xAA, 0xBB, 0xCC, 0xDD };
+        const values_ptr: *[4]u8 = &values;
+        try hashTreeRoot(Sha256, *[4]u8, values_ptr, &hash, std.testing.allocator);
+
+        var deserialized: [4]u8 = undefined;
+        try deserialize([4]u8, hash[0..4], &deserialized, std.testing.allocator);
+        try expect(std.mem.eql(u8, &deserialized, values_ptr));
+    }
+
+    // Test pointer size .many - should return error
+    {
+        var values = [4]u8{ 0xAA, 0xBB, 0xCC, 0xDD };
+        const values_ptr: [*]u8 = &values;
+        try std.testing.expectError(error.UnSupportedPointerType, hashTreeRoot(Sha256, [*]u8, values_ptr, &hash, std.testing.allocator));
+    }
+
+    // Test pointer size .c - should return error
+    {
+        var values = [4]u8{ 0xAA, 0xBB, 0xCC, 0xDD };
+        const values_ptr: [*c]u8 = &values;
+        try std.testing.expectError(error.UnSupportedPointerType, hashTreeRoot(Sha256, [*c]u8, values_ptr, &hash, std.testing.allocator));
+    }
+}

--- a/pkgs/third_party/ssz/src/lib.zig
+++ b/pkgs/third_party/ssz/src/lib.zig
@@ -1,0 +1,1036 @@
+//! This module provides functions for serializing and deserializing
+//! data structures with the SSZ method.
+
+const std = @import("std");
+pub const utils = @import("./utils.zig");
+pub const zeros = @import("./zeros.zig");
+const ArrayList = std.ArrayList;
+const builtin = std.builtin;
+const Allocator = std.mem.Allocator;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
+/// Number of bytes per chunk.
+const BYTES_PER_CHUNK = 32;
+
+pub fn serializedFixedSize(T: type) !usize {
+    const info = @typeInfo(T);
+    return switch (info) {
+        .int => @sizeOf(T),
+        .bool => @sizeOf(T),
+        .array => info.array.len * try serializedFixedSize(info.array.child),
+        .pointer => switch (info.pointer.size) {
+            .slice => error.NoSerializedFixedSizeAvailable,
+            // or should we just throw error for all of pointer
+            else => serializedFixedSize(info.pointer.child),
+        },
+        .optional => error.NoSerializedFixedSizeAvailable,
+        .null => @as(usize, 0),
+        .@"struct" => |str| size: {
+            var size: usize = 0;
+            inline for (str.fields) |field| {
+                size += try serializedFixedSize(field.type);
+            }
+            break :size size;
+        },
+        else => error.NoSerializedFixedSizeAvailable,
+    };
+}
+
+// Determine the serialized size of an object so that
+// the code serializing of variable-size objects can
+// determine the offset to the next object.
+pub fn serializedSize(T: type, data: T) !usize {
+    // Check for custom serializedSize method first for List types
+    if (comptime std.meta.hasFn(T, "serializedSize")) {
+        return data.serializedSize();
+    }
+
+    const info = @typeInfo(T);
+    return switch (info) {
+        .int => @sizeOf(T),
+        .bool => @sizeOf(T),
+        .array => size: {
+            var size: usize = 0;
+            const is_child_fixed = try isFixedSizeObject(info.array.child);
+            if (!is_child_fixed) {
+                size += 4 * data.len;
+            }
+            for (0..data.len) |i| {
+                size += try serializedSize(info.array.child, data[i]);
+            }
+            break :size size;
+        },
+        .pointer => switch (info.pointer.size) {
+            .slice => size: {
+                var size: usize = 0;
+                const is_child_fixed = try isFixedSizeObject(info.pointer.child);
+                if (!is_child_fixed) {
+                    size += 4 * data.len;
+                }
+                for (0..data.len) |i| {
+                    size += try serializedSize(info.pointer.child, data[i]);
+                }
+                break :size size;
+            },
+            else => serializedSize(info.pointer.child, data.*),
+        },
+        .optional => if (data == null)
+            @as(usize, 1)
+        else
+            1 + try serializedSize(info.optional.child, data.?),
+        .null => @as(usize, 0),
+        .@"struct" => |str| size: {
+            var size: usize = 0;
+            inline for (str.fields) |field| {
+                const is_field_fixed_size = try isFixedSizeObject(field.type);
+                if (is_field_fixed_size == false) {
+                    size += 4;
+                }
+                size += try serializedSize(field.type, @field(data, field.name));
+            }
+            break :size size;
+        },
+        else => error.NoSerializedSizeAvailable,
+    };
+}
+
+/// Returns true if an object is of fixed size
+pub fn isFixedSizeObject(T: type) !bool {
+    if (comptime std.meta.hasFn(T, "isFixedSizeObject")) {
+        return T.isFixedSizeObject();
+    }
+
+    const info = @typeInfo(T);
+    switch (info) {
+        .bool, .int, .null => return true,
+        .array => return isFixedSizeObject(info.array.child),
+        .@"struct" => |str| inline for (str.fields) |field| {
+            if (!try isFixedSizeObject(field.type)) {
+                return false;
+            }
+        },
+        .optional => return false,
+        .pointer => |ptr| switch (ptr.size) {
+            .many, .slice, .c => return false,
+            .one => return isFixedSizeObject(info.pointer.child),
+        },
+        else => return error.UnknownType,
+    }
+    return true;
+}
+
+/// Returns the maximum possible serialized byte length for type `T`.
+/// Useful for pre-allocating buffers or validating input bounds.
+/// For variable-length types (e.g. slice), use a type that encodes max length (e.g. List(T, N)) or returns error.
+pub fn maxInLength(T: type) !usize {
+    if (comptime std.meta.hasFn(T, "maxInLength")) {
+        return T.maxInLength();
+    }
+
+    const info = @typeInfo(T);
+    return switch (info) {
+        .int => @sizeOf(T),
+        .bool => @as(usize, 1),
+        .null => @as(usize, 0),
+        .array => |array| if (array.child == bool)
+            (array.len + 7) / 8
+        else blk: {
+            const child_max = try maxInLength(array.child);
+            if (try isFixedSizeObject(array.child)) {
+                break :blk array.len * child_max;
+            } else {
+                break :blk array.len * child_max + 4 * array.len;
+            }
+        },
+        .optional => 1 + try maxInLength(info.optional.child),
+        .pointer => |ptr| switch (ptr.size) {
+            .slice => error.NoMaxInLengthAvailable,
+            .one => maxInLength(ptr.child),
+            else => error.NoMaxInLengthAvailable,
+        },
+        .@"struct" => |str| blk: {
+            var total: usize = 0;
+            inline for (str.fields) |field| {
+                if (try isFixedSizeObject(field.type)) {
+                    total += try maxInLength(field.type);
+                } else {
+                    total += 4 + try maxInLength(field.type);
+                }
+            }
+            break :blk total;
+        },
+        .@"union" => |u| blk: {
+            if (u.tag_type == null) return error.UnionIsNotTagged;
+            var m: usize = 0;
+            inline for (u.fields) |f| {
+                const n = try maxInLength(f.type);
+                if (n > m) m = n;
+            }
+            break :blk 1 + m;
+        },
+        else => error.NoMaxInLengthAvailable,
+    };
+}
+
+/// Returns the minimum possible serialized byte length for type `T`.
+/// Used together with maxInLength to validate input bounds before deserializing.
+pub fn minInLength(T: type) !usize {
+    if (comptime std.meta.hasFn(T, "minInLength")) {
+        return T.minInLength();
+    }
+
+    const info = @typeInfo(T);
+    return switch (info) {
+        .int => @sizeOf(T),
+        .bool => @as(usize, 1),
+        .null => @as(usize, 0),
+        .array => |array| if (array.child == bool)
+            (array.len + 7) / 8
+        else if (try isFixedSizeObject(array.child))
+            array.len * try minInLength(array.child)
+        else
+            array.len * @sizeOf(u32) + array.len * try minInLength(array.child),
+        .optional => 1,
+        .pointer => |ptr| switch (ptr.size) {
+            .slice => error.NoMinInLengthAvailable,
+            .one => minInLength(ptr.child),
+            else => error.NoMinInLengthAvailable,
+        },
+        .@"struct" => |str| blk: {
+            var total: usize = 0;
+            inline for (str.fields) |field| {
+                if (try isFixedSizeObject(field.type)) {
+                    total += try minInLength(field.type);
+                } else {
+                    total += 4 + try minInLength(field.type);
+                }
+            }
+            break :blk total;
+        },
+        .@"union" => |u| blk: {
+            if (u.tag_type == null) return error.UnionIsNotTagged;
+            var m: usize = std.math.maxInt(usize);
+            inline for (u.fields) |f| {
+                const n = try minInLength(f.type);
+                if (n < m) m = n;
+            }
+            break :blk 1 + m;
+        },
+        else => error.NoMinInLengthAvailable,
+    };
+}
+
+/// Provides the generic serialization of any `data` var to SSZ. The
+/// serialization is written to the `ArrayList` `l`.
+pub fn serialize(T: type, data: T, l: *ArrayList(u8), allocator: Allocator) !void {
+    // shortcut if the type implements its own encode method
+    if (comptime std.meta.hasFn(T, "sszEncode")) {
+        return data.sszEncode(l, allocator);
+    }
+    const info = @typeInfo(T);
+    switch (info) {
+        .array => |array| {
+            // Bitvector[N] or vector?
+            if (array.child == bool) {
+                var byte: u8 = 0;
+                for (data, 0..) |bit, index| {
+                    if (bit) {
+                        byte |= @as(u8, 1) << @truncate(index);
+                    }
+
+                    if (index % 8 == 7) {
+                        try l.append(allocator, byte);
+                        byte = 0;
+                    }
+                }
+
+                // Write the last byte if the length
+                // is not byte-aligned
+                if (data.len % 8 != 0) {
+                    try l.append(allocator, byte);
+                }
+            } else {
+                // If the item type is fixed-size, serialize inline,
+                // otherwise, create an array of offsets and then
+                // serialize each object afterwards.
+                if (try isFixedSizeObject(array.child)) {
+                    for (data) |item| {
+                        try serialize(array.child, item, l, allocator);
+                    }
+                } else {
+                    // Size of the buffer before anything is
+                    // written to it.
+                    const base = l.items.len;
+                    var start = base;
+
+                    // Reserve the space for the offset
+                    _ = try l.addManyAsSlice(allocator, data.len * @sizeOf(u32));
+
+                    // Now serialize one item after the other
+                    // and update the offset list with its location.
+                    // The offset is relative to the start of this array's data.
+                    for (data) |item| {
+                        const relative_offset = l.items.len - base;
+                        std.mem.writeInt(u32, l.items[start .. start + 4][0..4], @truncate(relative_offset), std.builtin.Endian.little);
+                        _ = try serialize(array.child, item, l, allocator);
+                        start += 4;
+                    }
+                }
+            }
+        },
+        .bool => {
+            if (data) {
+                try l.append(allocator, 1);
+            } else {
+                try l.append(allocator, 0);
+            }
+        },
+        .int => |int| {
+            switch (int.bits) {
+                8, 16, 32, 64, 128, 256 => {},
+                else => return error.InvalidSerializedIntLengthType,
+            }
+            _ = std.mem.writeInt(T, try l.addManyAsArray(allocator, @sizeOf(T)), data, .little);
+        },
+        .pointer => |pointer| {
+            // Bitlist[N] or list?
+            switch (pointer.size) {
+                .slice => {
+                    if (pointer.child == bool) {
+                        @panic("use util.Bitlist instead of []bool");
+                    }
+                    if (@sizeOf(pointer.child) == 1) {
+                        _ = try l.appendSlice(allocator, data);
+                    } else {
+                        if (try isFixedSizeObject(pointer.child)) {
+                            for (data) |item| {
+                                try serialize(@TypeOf(item), item, l, allocator);
+                            }
+                        } else {
+                            // Size of the buffer before anything is
+                            // written to it.
+                            const base = l.items.len;
+                            var start = base;
+
+                            // Reserve the space for the offset
+                            _ = try l.addManyAsSlice(allocator, data.len * @sizeOf(u32));
+
+                            // Now serialize one item after the other
+                            // and update the offset list with its location.
+                            // The offset is relative to the start of this slice's data.
+                            for (data) |item| {
+                                const relative_offset = l.items.len - base;
+                                std.mem.writeInt(u32, l.items[start .. start + 4][0..4], @truncate(relative_offset), std.builtin.Endian.little);
+                                _ = try serialize(pointer.child, item, l, allocator);
+                                start += 4;
+                            }
+                        }
+                    }
+                },
+                .one => try serialize(pointer.child, data.*, l, allocator),
+                else => return error.UnSupportedPointerType,
+            }
+        },
+        .@"struct" => {
+            // First pass, accumulate the fixed sizes
+            comptime var var_start = 0;
+            inline for (info.@"struct".fields) |field| {
+                comptime {
+                    if (@typeInfo(field.type) == .int or @typeInfo(field.type) == .bool) {
+                        var_start += @sizeOf(field.type);
+                    } else if (try isFixedSizeObject(field.type)) {
+                        var_start += try serializedFixedSize(field.type);
+                    } else {
+                        var_start += 4;
+                    }
+                }
+            }
+
+            // Second pass: intertwine fixed fields and variables offsets
+            var var_acc = @as(usize, var_start); // variable part size accumulator
+            inline for (info.@"struct".fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .int, .bool => {
+                        try serialize(field.type, @field(data, field.name), l, allocator);
+                    },
+                    else => {
+                        if (try isFixedSizeObject(field.type)) {
+                            try serialize(field.type, @field(data, field.name), l, allocator);
+                        } else {
+                            try serialize(u32, @truncate(var_acc), l, allocator);
+                            var_acc += try serializedSize(field.type, @field(data, field.name));
+                        }
+                    },
+                }
+            }
+
+            // Third pass: add variable fields at the end
+            if (var_acc > var_start) {
+                inline for (info.@"struct".fields) |field| {
+                    switch (@typeInfo(field.type)) {
+                        .int, .bool => {
+                            // skip fixed-size fields
+                        },
+                        else => {
+                            if (!try isFixedSizeObject(field.type)) {
+                                try serialize(field.type, @field(data, field.name), l, allocator);
+                            }
+                        },
+                    }
+                }
+            }
+        },
+        // Nothing to be added to the payload
+        .null => {},
+        // Optionals are like unions, but their 0 value has to be 0.
+        .optional => {
+            if (data != null) {
+                _ = try l.append(allocator, 1);
+                try serialize(info.optional.child, data.?, l, allocator);
+            } else {
+                _ = try l.append(allocator, 0);
+            }
+        },
+        .@"union" => {
+            if (info.@"union".tag_type == null) {
+                return error.UnionIsNotTagged;
+            }
+            inline for (info.@"union".fields, 0..) |f, index| {
+                if (@intFromEnum(data) == index) {
+                    _ = std.mem.writeInt(u8, try l.addManyAsArray(allocator, 1), index, .little);
+                    try serialize(f.type, @field(data, f.name), l, allocator);
+                    return;
+                }
+            }
+        },
+        else => {
+            return error.UnknownType;
+        },
+    }
+}
+
+/// Takes a byte array containing the serialized payload of type `T` and
+/// deserializes it into the `T` object pointed at by `out`.
+/// The payload must be within [minInLength, maxInLength] bounds for `T`.
+pub fn deserialize(T: type, serialized: []const u8, out: *T, allocator: ?Allocator) !void {
+    const has_custom_decode = comptime std.meta.hasFn(T, "sszDecode");
+    const enforce_min = !has_custom_decode or comptime std.meta.hasFn(T, "minInLength");
+    const enforce_max = !has_custom_decode or comptime std.meta.hasFn(T, "maxInLength");
+
+    // Bounds check: ensure serialized length is within [minInLength, maxInLength]
+    const min_len: ?usize = if (enforce_min) blk: {
+        const m = minInLength(T) catch break :blk null;
+        break :blk m;
+    } else null;
+    if (min_len) |m| if (serialized.len < m) return error.PayloadTooSmall;
+
+    const max_len: ?usize = if (enforce_max) blk: {
+        const m = maxInLength(T) catch break :blk null;
+        break :blk m;
+    } else null;
+    if (max_len) |m| if (serialized.len > m) return error.PayloadTooLarge;
+
+    // shortcut if the type implements its own decode method
+    if (has_custom_decode) {
+        return T.sszDecode(serialized, out, allocator);
+    }
+
+    const info = @typeInfo(T);
+    switch (info) {
+        .array => {
+            // Bitvector[N] or regular vector?
+            if (info.array.child == bool) {
+                for (serialized, 0..) |byte, bindex| {
+                    var i = @as(u8, 0);
+                    var b = byte;
+                    while (bindex * 8 + i < out.len and i < 8) : (i += 1) {
+                        out[bindex * 8 + i] = b & 1 == 1;
+                        b >>= 1;
+                    }
+                }
+            } else {
+                const U = info.array.child;
+                if (try isFixedSizeObject(U)) {
+                    const pitch = try comptime serializedFixedSize(U);
+                    for (0..out.len) |i| {
+                        try deserialize(U, serialized[i * pitch .. (i + 1) * pitch], &out[i], allocator);
+                    }
+                } else {
+                    // first variable index is also the size of the list
+                    // of indices. Recast that list as a []const u32.
+                    if (serialized.len < 4) return error.OffsetExceedsSize;
+                    const offset_prefix = std.mem.readInt(u32, serialized[0..4], std.builtin.Endian.little);
+                    if (offset_prefix % @sizeOf(u32) != 0) return error.OffsetOrdering;
+                    const size = offset_prefix / @sizeOf(u32);
+                    if (size > serialized.len / @sizeOf(u32)) return error.OffsetExceedsSize;
+                    if (offset_prefix > serialized.len) return error.OffsetExceedsSize;
+                    const indices = std.mem.bytesAsSlice(u32, serialized[0..offset_prefix]);
+                    var i = @as(usize, 0);
+                    while (i < size) : (i += 1) {
+                        const end = if (i < size - 1) indices[i + 1] else serialized.len;
+                        const start = indices[i];
+                        if (start > serialized.len or end > serialized.len) {
+                            return error.OffsetExceedsSize;
+                        }
+                        if (start > end) return error.OffsetOrdering;
+                        if (i > 0 and start < indices[i - 1]) {
+                            return error.OffsetOrdering;
+                        }
+                        try deserialize(U, serialized[start..end], &out[i], allocator);
+                    }
+                }
+            }
+        },
+        .bool => out.* = (serialized[0] == 1),
+        .int => {
+            const N = @sizeOf(T);
+            out.* = std.mem.readInt(T, serialized[0..N], std.builtin.Endian.little);
+        },
+        .optional => {
+            const index: u8 = serialized[0];
+            if (index != 0) {
+                var x: info.optional.child = undefined;
+                try deserialize(info.optional.child, serialized[1..], &x, allocator);
+                out.* = x;
+            } else {
+                out.* = null;
+            }
+        },
+        .pointer => |ptr| switch (ptr.size) {
+            .slice => if (@sizeOf(ptr.child) == 1) {
+                // Data is not copied in this function, copy is therefore
+                // the responsibility of the caller.
+                if (ptr.is_const) {
+                    out.* = serialized[0..];
+                } else {
+                    if (allocator) |alloc| {
+                        out.* = try alloc.alloc(ptr.child, serialized.len);
+                    }
+                    @memcpy(out.*, serialized[0..]);
+                }
+            } else {
+                if (try isFixedSizeObject(ptr.child)) {
+                    const pitch = try serializedFixedSize(ptr.child);
+                    const n_items = serialized.len / pitch;
+                    if (allocator) |alloc| {
+                        out.* = try alloc.alloc(ptr.child, n_items);
+                    }
+                    for (0..n_items) |i| {
+                        try deserialize(ptr.child, serialized[i * pitch .. (i + 1) * pitch], &out.*[i], allocator);
+                    }
+                } else {
+                    // read the first index, determine when the "variable size" list ends,
+                    // and determine the size of the item as a result.
+                    if (serialized.len < 4) return error.OffsetExceedsSize;
+                    const first_offset_u32 = std.mem.readInt(u32, serialized[0..4], std.builtin.Endian.little);
+                    const first_offset = @as(usize, first_offset_u32);
+                    if (first_offset > serialized.len) return error.OffsetExceedsSize;
+                    if (first_offset % @sizeOf(u32) != 0) return error.OffsetOrdering;
+                    const n_items = first_offset / @sizeOf(u32);
+                    if (n_items == 0) return error.OffsetOrdering;
+
+                    var offset: usize = first_offset;
+                    var next_offset: usize = if (n_items == 1) serialized.len else blk: {
+                        if (serialized.len < 8) return error.OffsetExceedsSize;
+                        const n = std.mem.readInt(u32, serialized[4..8], std.builtin.Endian.little);
+                        break :blk @as(usize, n);
+                    };
+                    if (next_offset > serialized.len) return error.OffsetExceedsSize;
+                    if (offset > next_offset) return error.OffsetOrdering;
+
+                    if (allocator) |alloc| {
+                        out.* = try alloc.alloc(ptr.child, n_items);
+                    }
+                    for (0..n_items) |i| {
+                        try deserialize(ptr.child, serialized[offset..next_offset], &out.*[i], allocator);
+                        offset = next_offset;
+                        // next offset is either the next entry in the list of offsets,
+                        // or the end of the serialized payload.
+                        next_offset = if ((i + 2) * 4 >= first_offset)
+                            serialized.len
+                        else blk: {
+                            const rel = (i + 2) * 4;
+                            if (rel + 4 > serialized.len) return error.OffsetExceedsSize;
+                            const n = std.mem.readInt(u32, serialized[rel..][0..4], std.builtin.Endian.little);
+                            break :blk @as(usize, n);
+                        };
+                        if (next_offset > serialized.len) return error.OffsetExceedsSize;
+                        if (offset > next_offset) return error.OffsetOrdering;
+                    }
+                }
+            },
+            .one => {
+                if (allocator) |alloc| {
+                    out.* = try alloc.create(ptr.child);
+                }
+                return deserialize(ptr.child, serialized, out.*, allocator);
+            },
+            else => return error.UnSupportedPointerType,
+        },
+        .@"struct" => {
+            // Calculate the number of variable fields in the
+            // struct.
+            comptime var n_var_fields = 0;
+            comptime {
+                for (info.@"struct".fields) |field| {
+                    switch (@typeInfo(field.type)) {
+                        .int, .bool => {},
+                        else => {
+                            if (!try isFixedSizeObject(field.type)) {
+                                n_var_fields += 1;
+                            }
+                        },
+                    }
+                }
+            }
+
+            // 0 indices array causes compiletime error for places we access indices[]
+            // also use n_var_fields instead of indices.len
+            var indices: [n_var_fields + 1]u32 = undefined;
+
+            // First pass, read the value of each fixed-size field,
+            // and write down the start offset of each variable-sized
+            // field.
+            var i: usize = 0;
+            comptime var variable_field_index = 0;
+            inline for (info.@"struct".fields) |field| {
+                switch (@typeInfo(field.type)) {
+                    .bool, .int => {
+                        // Direct deserialize
+                        if (i + @sizeOf(field.type) > serialized.len) return error.OffsetExceedsSize;
+                        try deserialize(field.type, serialized[i .. i + @sizeOf(field.type)], &@field(out.*, field.name), allocator);
+                        i += @sizeOf(field.type);
+                    },
+                    else => {
+                        if (try comptime isFixedSizeObject(field.type)) {
+                            // Direct deserialize
+                            const field_serialized_size = try serializedFixedSize(field.type);
+                            if (i + field_serialized_size > serialized.len) return error.OffsetExceedsSize;
+                            try deserialize(field.type, serialized[i .. i + field_serialized_size], &@field(out.*, field.name), allocator);
+                            i += field_serialized_size;
+                        } else {
+                            if (i + 4 > serialized.len) return error.OffsetExceedsSize;
+                            try deserialize(u32, serialized[i .. i + 4], &indices[variable_field_index], allocator);
+                            i += 4;
+                            variable_field_index += 1;
+                        }
+                    },
+                }
+            }
+
+            // Second pass, deserialize each variable-sized value
+            // now that their offset is known.
+            comptime var last_index = 0;
+            inline for (info.@"struct".fields) |field| {
+                // comptime fields are currently not supported, and it's not even
+                // certain that they can ever be without a change in the language.
+                if (field.is_comptime) @panic("structure contains comptime field");
+
+                switch (@typeInfo(field.type)) {
+                    .bool, .int => {}, // covered by the previous pass
+                    else => if (!try comptime isFixedSizeObject(field.type)) {
+                        const start = @as(usize, indices[last_index]);
+                        const end: usize = if (last_index == n_var_fields - 1) serialized.len else @as(usize, indices[last_index + 1]);
+                        if (start > serialized.len or end > serialized.len) return error.OffsetExceedsSize;
+                        if (start > end) return error.OffsetOrdering;
+                        if (last_index > 0 and start < @as(usize, indices[last_index - 1])) return error.OffsetOrdering;
+                        if (last_index == 0 and start != i) return error.OffsetOrdering;
+                        try deserialize(field.type, serialized[start..end], &@field(out.*, field.name), allocator);
+                        last_index += 1;
+                    },
+                }
+            }
+        },
+        .@"union" => {
+            if (serialized.len < 1) return error.OffsetExceedsSize;
+            // Read the type index
+            var union_index: u8 = undefined;
+            try deserialize(u8, serialized[0..1], &union_index, allocator);
+
+            // Use the index to figure out which type must
+            // be deserialized.
+            inline for (info.@"union".fields, 0..) |field, index| {
+                if (index == union_index) {
+                    // &@field(out.*, field.name) can not be used directly,
+                    // because this field type hasn't been activated at this
+                    // stage.
+                    var data: field.type = undefined;
+                    try deserialize(field.type, serialized[1..], &data, allocator);
+                    out.* = @unionInit(T, field.name, data);
+                }
+            }
+        },
+        else => return error.NotImplemented,
+    }
+}
+
+pub fn mixInLength2(Hasher: type, root: [Hasher.digest_length]u8, length: usize, out: *[Hasher.digest_length]u8) void {
+    var hasher = Hasher.init(Hasher.Options{});
+    hasher.update(root[0..]);
+
+    var tmp = [_]u8{0} ** 32;
+    std.mem.writeInt(@TypeOf(length), tmp[0..@sizeOf(@TypeOf(length))], length, std.builtin.Endian.little);
+    hasher.update(tmp[0..]);
+    hasher.final(out[0..]);
+}
+
+fn mixInLength(Hasher: type, root: [Hasher.digest_length]u8, length: [32]u8, out: *[Hasher.digest_length]u8) void {
+    var hasher = Hasher.init(Hasher.Options{});
+    hasher.update(root[0..]);
+    hasher.update(length[0..]);
+    hasher.final(out[0..]);
+}
+
+test "mixInLength" {
+    var root: [32]u8 = undefined;
+    var length: [32]u8 = undefined;
+    var expected: [32]u8 = undefined;
+    var mixin: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(root[0..], "2279cf111c15f2d594e7a0055e8735e7409e56ed4250735d6d2f2b0d1bcf8297");
+    _ = try std.fmt.hexToBytes(length[0..], "deadbeef00000000000000000000000000000000000000000000000000000000");
+    _ = try std.fmt.hexToBytes(expected[0..], "0b665dda6e4c269730bc4bbe3e990a69d37fa82892bac5fe055ca4f02a98c900");
+    mixInLength(Sha256, root, length, &mixin);
+
+    try std.testing.expect(std.mem.eql(u8, mixin[0..], expected[0..]));
+}
+
+fn mixInSelector(Hasher: type, root: [Hasher.digest_length]u8, comptime selector: usize, out: *[Hasher.digest_length]u8) void {
+    var hasher = Hasher.init(Hasher.Options{});
+    hasher.update(root[0..]);
+    var tmp = [_]u8{0} ** 32;
+    std.mem.writeInt(@TypeOf(selector), tmp[0..@sizeOf(@TypeOf(selector))], selector, std.builtin.Endian.little);
+    hasher.update(tmp[0..]);
+    hasher.final(out[0..]);
+}
+
+test "mixInSelector" {
+    var root: [32]u8 = undefined;
+    var expected: [32]u8 = undefined;
+    var mixin: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(root[0..], "2279cf111c15f2d594e7a0055e8735e7409e56ed4250735d6d2f2b0d1bcf8297");
+    _ = try std.fmt.hexToBytes(expected[0..], "c483cb731afcfe9f2c596698eaca1c4e0dcb4a1136297adef74c31c268966eb5");
+    mixInSelector(Sha256, root, 25, &mixin);
+
+    try std.testing.expect(std.mem.eql(u8, mixin[0..], expected[0..]));
+}
+
+/// Calculates the number of leaves needed for the merkelization
+/// of this type.
+pub fn chunkCount(T: type) usize {
+    const info = @typeInfo(T);
+    switch (info) {
+        .int, .bool => return 1,
+        .pointer => return chunkCount(info.pointer.child),
+        // the chunk size of an array depends on its type
+        .array => switch (@typeInfo(info.array.child)) {
+            // Bitvector[N]
+            .bool => return (info.array.len + 255) / 256,
+            // Vector[B,N]
+            .int => return (info.array.len * @sizeOf(info.array.child) + 31) / 32,
+            // Vector[C,N]
+            else => return info.array.len,
+        },
+        .@"struct" => return info.@"struct".fields.len,
+        else => return error.NotSupported,
+    }
+}
+
+const chunk = [BYTES_PER_CHUNK]u8;
+const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+
+pub fn pack(T: type, values: T, l: *ArrayList(u8), allocator: Allocator) ![]chunk {
+    try serialize(T, values, l, allocator);
+    const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
+    _ = try l.appendSlice(allocator, zero_chunk[0..padding_size]);
+    return std.mem.bytesAsSlice(chunk, l.items);
+}
+
+test "pack u32" {
+    var expected: [32]u8 = undefined;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const out = try pack(u32, 0xdeadbeef, &list, std.testing.allocator);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "efbeadde00000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
+}
+
+test "pack bool" {
+    var expected: [32]u8 = undefined;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const out = try pack(bool, true, &list, std.testing.allocator);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "0100000000000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..]));
+}
+
+test "pack string" {
+    var expected: [128]u8 = undefined;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const out = try pack([]const u8, "a" ** 100, &list, std.testing.allocator);
+
+    _ = try std.fmt.hexToBytes(expected[0..], "6161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000000000000000000000000000000000000000000000000000000");
+
+    try std.testing.expect(expected.len == out.len * out[0].len);
+    try std.testing.expect(std.mem.eql(u8, out[0][0..], expected[0..32]));
+    try std.testing.expect(std.mem.eql(u8, out[1][0..], expected[32..64]));
+    try std.testing.expect(std.mem.eql(u8, out[2][0..], expected[64..96]));
+    try std.testing.expect(std.mem.eql(u8, out[3][0..], expected[96..]));
+}
+
+// merkleize recursively calculates the root hash of a Merkle tree.
+pub fn merkleize(Hasher: type, chunks: []chunk, limit: ?usize, out: *[Hasher.digest_length]u8) anyerror!void {
+    // Generate zero hashes for this hasher type at comptime
+    const hashes_of_zero = comptime zeros.buildHashesOfZero(Hasher, 32, 256);
+
+    // Calculate the number of chunks to be padded, check the limit
+    if (limit != null and chunks.len > limit.?) {
+        return error.ChunkSizeExceedsLimit;
+    }
+    const power = limit orelse chunks.len;
+    const size = if (power > 0) try std.math.ceilPowerOfTwo(usize, power) else 0;
+
+    // Perform the merkelization
+    switch (size) {
+        0 => std.mem.copyForwards(u8, out.*[0..], hashes_of_zero[0][0..]),
+        1 => std.mem.copyForwards(u8, out.*[0..], (if (chunks.len > 0) chunks[0] else hashes_of_zero[0])[0..]),
+        else => {
+            // Merkleize the left side. If the number of chunks
+            // isn't enough to fill the entire width, complete
+            // with zeroes.
+            var digest = Hasher.init(Hasher.Options{});
+            var buf: [32]u8 = undefined;
+            const split = if (size / 2 < chunks.len) size / 2 else chunks.len;
+            try merkleize(Hasher, chunks[0..split], size / 2, &buf);
+            digest.update(buf[0..]);
+
+            // Merkleize the right side. If the number of chunks only
+            // covers the first half, directly input the hashed zero-
+            // filled subtrie.
+            if (size / 2 < chunks.len) {
+                try merkleize(Hasher, chunks[size / 2 ..], size / 2, &buf);
+                digest.update(buf[0..]);
+            } else {
+                // Use depth-based indexing for zero hashes
+                // For a subtree of size/2 leaves, we need the zero hash at depth log2(size/2)
+                const subtree_size = size / 2;
+                const depth = std.math.log2_int(usize, subtree_size);
+                digest.update(hashes_of_zero[depth][0..]);
+            }
+            digest.final(out);
+        },
+    }
+}
+
+test "merkleize an empty slice" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const chunks = &[0][32]u8{};
+    var out: [32]u8 = undefined;
+    try merkleize(Sha256, chunks, null, &out);
+    try std.testing.expect(std.mem.eql(u8, out[0..], zero_chunk[0..]));
+}
+
+test "merkleize a string" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const chunks = try pack([]const u8, "a" ** 100, &list, std.testing.allocator);
+    var out: [32]u8 = undefined;
+    try merkleize(Sha256, chunks, null, &out);
+    // Build the expected tree
+    const leaf1 = [_]u8{0x61} ** 32; // "0xaaaaa....aa" 32 times
+    var leaf2: [32]u8 = [_]u8{0x61} ** 4 ++ [_]u8{0} ** 28;
+    var root: [32]u8 = undefined;
+    var internal_left: [32]u8 = undefined;
+    var internal_right: [32]u8 = undefined;
+    var hasher = Sha256.init(Sha256.Options{});
+    hasher.update(leaf1[0..]);
+    hasher.update(leaf1[0..]);
+    hasher.final(&internal_left);
+    hasher = Sha256.init(Sha256.Options{});
+    hasher.update(leaf1[0..]);
+    hasher.update(leaf2[0..]);
+    hasher.final(&internal_right);
+    hasher = Sha256.init(Sha256.Options{});
+    hasher.update(internal_left[0..]);
+    hasher.update(internal_right[0..]);
+    hasher.final(&root);
+
+    try std.testing.expect(std.mem.eql(u8, out[0..], root[0..]));
+}
+
+test "merkleize a boolean" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    var chunks = try pack(bool, false, &list, std.testing.allocator);
+    var expected = [_]u8{0} ** BYTES_PER_CHUNK;
+    var out: [BYTES_PER_CHUNK]u8 = undefined;
+    try merkleize(Sha256, chunks, null, &out);
+
+    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+
+    var list2: ArrayList(u8) = .empty;
+    defer list2.deinit(std.testing.allocator);
+
+    chunks = try pack(bool, true, &list2, std.testing.allocator);
+    expected[0] = 1;
+    try merkleize(Sha256, chunks, null, &out);
+    try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+}
+
+test "merkleize a bytes16 vector with one element" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    _ = try pack([16]u8, [_]u8{0xaa} ** 16, &list, std.testing.allocator);
+    // var expected: [32]u8 = [_]u8{0xaa} ** 16 ++ [_]u8{0x00} ** 16;
+    // var out: [32]u8 = undefined;
+    // try merkleize(sha256, chunks, null, &out);
+    // try std.testing.expect(std.mem.eql(u8, out[0..], expected[0..]));
+}
+
+fn packBits(bits: []const bool, l: *ArrayList(u8), allocator: Allocator) ![]chunk {
+    var byte: u8 = 0;
+    for (bits, 0..) |bit, bitidx| {
+        if (bit) {
+            byte |= @as(u8, 1) << @truncate(7 - bitidx % 8);
+        }
+        if (bitidx % 8 == 7 or bitidx == bits.len - 1) {
+            try l.append(allocator, byte);
+            byte = 0;
+        }
+    }
+
+    // pad the last chunk with 0s
+    const padding_size = (BYTES_PER_CHUNK - l.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
+    _ = try l.appendSlice(allocator, zero_chunk[0..padding_size]);
+
+    return std.mem.bytesAsSlice(chunk, l.items);
+}
+
+pub fn hashTreeRoot(Hasher: type, T: type, value: T, out: *[Hasher.digest_length]u8, allocator: Allocator) !void {
+    // Check if type has its own hashTreeRoot method at compile time
+    if (comptime std.meta.hasFn(T, "hashTreeRoot")) {
+        return value.hashTreeRoot(Hasher, out, allocator);
+    }
+
+    const type_info = @typeInfo(T);
+    switch (type_info) {
+        .int, .bool => {
+            var list: ArrayList(u8) = .empty;
+            defer list.deinit(allocator);
+            const chunks = try pack(T, value, &list, allocator);
+            try merkleize(Hasher, chunks, null, out);
+        },
+        .array => |a| {
+            // Check if the child is a basic type. If so, return
+            // the merkle root of its chunked serialization.
+            // Otherwise, it is a composite object and the chunks
+            // are the merkle roots of its elements.
+            switch (@typeInfo(a.child)) {
+                .int => {
+                    var list: ArrayList(u8) = .empty;
+                    defer list.deinit(allocator);
+                    const chunks = try pack(T, value, &list, allocator);
+                    try merkleize(Hasher, chunks, null, out);
+                },
+                .bool => {
+                    var list: ArrayList(u8) = .empty;
+                    defer list.deinit(allocator);
+                    const chunks = try packBits(value[0..], &list, allocator);
+                    try merkleize(Hasher, chunks, chunkCount(T), out);
+                },
+                .array => {
+                    var chunks: ArrayList(chunk) = .empty;
+                    defer chunks.deinit(allocator);
+                    var tmp: chunk = undefined;
+                    for (value) |item| {
+                        try hashTreeRoot(Hasher, @TypeOf(item), item, &tmp, allocator);
+                        try chunks.append(allocator, tmp);
+                    }
+                    try merkleize(Hasher, chunks.items, null, out);
+                },
+                else => return error.NotSupported,
+            }
+        },
+        .pointer => |ptr| {
+            switch (ptr.size) {
+                .one => try hashTreeRoot(Hasher, ptr.child, value.*, out, allocator),
+                .slice => {
+                    switch (@typeInfo(ptr.child)) {
+                        .int => {
+                            var list: ArrayList(u8) = .empty;
+                            defer list.deinit(allocator);
+                            const chunks = try pack(T, value, &list, allocator);
+                            var tmp: chunk = undefined;
+                            try merkleize(Hasher, chunks, null, &tmp);
+                            mixInLength2(Hasher, tmp, value.len, out);
+                        },
+                        // use bitlist
+                        .bool => return error.UnSupportedPointerType,
+                        // composite type
+                        else => {
+                            var chunks: ArrayList(chunk) = .empty;
+                            defer chunks.deinit(allocator);
+                            var tmp: chunk = undefined;
+                            for (value) |item| {
+                                try hashTreeRoot(Hasher, @TypeOf(item), item, &tmp, allocator);
+                                try chunks.append(allocator, tmp);
+                            }
+                            try merkleize(Hasher, chunks.items, null, &tmp);
+                            mixInLength2(Hasher, tmp, chunks.items.len, out);
+                        },
+                    }
+                },
+                else => return error.UnSupportedPointerType,
+            }
+        },
+        .@"struct" => |str| {
+            var chunks: ArrayList(chunk) = .empty;
+            defer chunks.deinit(allocator);
+            var tmp: chunk = undefined;
+            inline for (str.fields) |f| {
+                try hashTreeRoot(Hasher, f.type, @field(value, f.name), &tmp, allocator);
+                try chunks.append(allocator, tmp);
+            }
+            try merkleize(Hasher, chunks.items, null, out);
+        },
+        // An optional is a union with `None` as first value.
+        .optional => |opt| if (value != null) {
+            var tmp: chunk = undefined;
+            try hashTreeRoot(Hasher, opt.child, value.?, &tmp, allocator);
+            mixInSelector(Hasher, tmp, 1, out);
+        } else {
+            mixInSelector(Hasher, zero_chunk, 0, out);
+        },
+        .@"union" => |u| {
+            if (u.tag_type == null) {
+                return error.UnionIsNotTagged;
+            }
+            inline for (u.fields, 0..) |f, index| {
+                if (@intFromEnum(value) == index) {
+                    var tmp: chunk = undefined;
+                    try hashTreeRoot(Hasher, f.type, @field(value, f.name), &tmp, allocator);
+                    mixInSelector(Hasher, tmp, index, out);
+                }
+            }
+        },
+        else => return error.NotSupported,
+    }
+}
+
+// used at comptime to generate a bitvector from a byte vector
+fn bytesToBits(comptime N: usize, src: [N]u8) [N * 8]bool {
+    var bitvector: [N * 8]bool = undefined;
+    for (src, 0..) |byte, idx| {
+        var i = 0;
+        while (i < 8) : (i += 1) {
+            bitvector[i + idx * 8] = ((byte >> (7 - i)) & 1) == 1;
+        }
+    }
+    return bitvector;
+}

--- a/pkgs/third_party/ssz/src/tests.zig
+++ b/pkgs/third_party/ssz/src/tests.zig
@@ -1,0 +1,2305 @@
+const libssz = @import("lib.zig");
+const utils = libssz.utils;
+const serialize = libssz.serialize;
+const deserialize = libssz.deserialize;
+const serializedSize = libssz.serializedSize;
+const chunkCount = libssz.chunkCount;
+const hashTreeRoot = libssz.hashTreeRoot;
+const isFixedSizeObject = libssz.isFixedSizeObject;
+const std = @import("std");
+const ArrayList = std.ArrayList;
+const expect = std.testing.expect;
+const expectError = std.testing.expectError;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+const zeros = @import("zeros.zig");
+const hashes_of_zero = zeros.hashes_of_zero;
+const Allocator = std.mem.Allocator;
+
+test "serializes uint8" {
+    const data: u8 = 0x55;
+    const serialized_data = [_]u8{0x55};
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(u8, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+}
+
+test "serializes uint16" {
+    const data: u16 = 0x5566;
+    const serialized_data = [_]u8{ 0x66, 0x55 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(u16, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+}
+
+test "serializes uint32" {
+    const data: u32 = 0x55667788;
+    const serialized_data = [_]u8{ 0x88, 0x77, 0x66, 0x55 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(u32, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+}
+
+test "serializes a int32" {
+    const data: i32 = -(0x11223344);
+    const serialized_data = [_]u8{ 0xbc, 0xcc, 0xdd, 0xee };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(i32, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+}
+
+test "non-byte aligned int serialization fails" {
+    const data: u10 = 0x03ff;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try std.testing.expectError(error.InvalidSerializedIntLengthType, serialize(u10, data, &list, std.testing.allocator));
+}
+
+test "serializes bool" {
+    var data = false;
+    var serialized_data = [_]u8{0x00};
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(bool, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+
+    data = true;
+    serialized_data = [_]u8{0x01};
+
+    var list2: ArrayList(u8) = .empty;
+    defer list2.deinit(std.testing.allocator);
+    try serialize(bool, data, &list2, std.testing.allocator);
+    try expect(std.mem.eql(u8, list2.items, serialized_data[0..]));
+}
+
+test "serializes Bitvector[N] == [N]bool" {
+    const data7 = [_]bool{ true, false, true, true, false, false, false };
+    var serialized_data = [_]u8{0b00001101};
+    var exp = serialized_data[0..serialized_data.len];
+
+    var list7: ArrayList(u8) = .empty;
+    defer list7.deinit(std.testing.allocator);
+    try serialize([7]bool, data7, &list7, std.testing.allocator);
+    try expect(std.mem.eql(u8, list7.items, exp));
+
+    const data8 = [_]bool{ true, false, true, true, false, false, false, true };
+    serialized_data = [_]u8{0b10001101};
+    exp = serialized_data[0..serialized_data.len];
+
+    var list8: ArrayList(u8) = .empty;
+    defer list8.deinit(std.testing.allocator);
+    try serialize([8]bool, data8, &list8, std.testing.allocator);
+    try expect(std.mem.eql(u8, list8.items, exp));
+
+    const data12 = [_]bool{ true, false, true, true, false, false, false, true, false, true, false, true };
+
+    var list12: ArrayList(u8) = .empty;
+    defer list12.deinit(std.testing.allocator);
+    try serialize([12]bool, data12, &list12, std.testing.allocator);
+    try expect(list12.items.len == 2);
+    try expect(list12.items[0] == 141);
+    try expect(list12.items[1] == 10);
+}
+
+test "serializes string" {
+    const data = "zig zag";
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([]const u8, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, data));
+}
+
+test "serializes an array of shorts" {
+    const data = [_]u16{ 0xabcd, 0xef01 };
+    const serialized = [_]u8{ 0xcd, 0xab, 0x01, 0xef };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([]const u16, data[0..data.len], &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized[0..]));
+}
+
+test "serializes an array of structures" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const exp = [_]u8{ 8, 0, 0, 0, 23, 0, 0, 0, 6, 0, 0, 0, 20, 0, 99, 114, 111, 105, 115, 115, 97, 110, 116, 6, 0, 0, 0, 244, 1, 72, 101, 114, 114, 101, 110, 116, 111, 114, 116, 101 };
+
+    try serialize(@TypeOf(pastries), pastries, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, exp[0..]));
+}
+
+test "serializes a structure without variable fields" {
+    const data = .{
+        .uint8 = @as(u8, 1),
+        .uint32 = @as(u32, 3),
+        .boolean = true,
+    };
+    const serialized_data = [_]u8{ 1, 3, 0, 0, 0, 1 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(data), data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+}
+
+test "(de)serializes a structure with variable fields" {
+    // Taken from ssz.cr
+    const Person = struct {
+        name: []const u8,
+        age: u8,
+        company: []const u8,
+    };
+    var data = Person{
+        .name = "James",
+        .age = 32,
+        .company = "DEV Inc.",
+    };
+    const serialized_data = [_]u8{ 9, 0, 0, 0, 32, 14, 0, 0, 0, 74, 97, 109, 101, 115, 68, 69, 86, 32, 73, 110, 99, 46 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    // Note the `&data` - this is so that `data` is not considered const.
+    try serialize(@TypeOf(&data), &data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+    var out: @TypeOf(data) = undefined;
+    try deserialize(@TypeOf(data), list.items, &out, null);
+}
+
+test "serializes a structure with optional fields" {
+    const Employee = struct {
+        name: ?[]const u8,
+        age: u8,
+        company: ?[]const u8,
+    };
+    const data: Employee = .{
+        .name = "James",
+        .age = @as(u8, 32),
+        .company = null,
+    };
+
+    const serialized_data = [_]u8{ 9, 0, 0, 0, 32, 15, 0, 0, 0, 1, 74, 97, 109, 101, 115, 0 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(data), data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+
+    var deserialized: Employee = undefined;
+    try deserialize(Employee, list.items, &deserialized, null);
+    // only available in >=0.11
+    // try std.testing.expectEqualDeep(data, deserialized);
+    try expect(std.mem.eql(u8, data.name.?, deserialized.name.?));
+    try std.testing.expectEqual(data.age, deserialized.age);
+    try std.testing.expectEqual(deserialized.company, null);
+}
+
+test "serializes an optional object" {
+    const null_or_string: ?[]const u8 = null;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(null_or_string), null_or_string, &list, std.testing.allocator);
+    try expect(list.items.len == 1);
+}
+
+test "serializes a union" {
+    const Payload = union(enum) {
+        int: u64,
+        boolean: bool,
+    };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const exp = [_]u8{ 0, 210, 4, 0, 0, 0, 0, 0, 0 };
+    try serialize(Payload, Payload{ .int = 1234 }, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, exp[0..]));
+
+    var list2: ArrayList(u8) = .empty;
+    defer list2.deinit(std.testing.allocator);
+    const exp2 = [_]u8{ 1, 1 };
+    try serialize(Payload, Payload{ .boolean = true }, &list2, std.testing.allocator);
+    try expect(std.mem.eql(u8, list2.items, exp2[0..]));
+
+    // Make sure that the code won't try to serialize untagged
+    // payloads.
+    const UnTaggedPayload = union {
+        int: u64,
+        boolean: bool,
+    };
+
+    var list3: ArrayList(u8) = .empty;
+    defer list3.deinit(std.testing.allocator);
+    if (serialize(UnTaggedPayload, UnTaggedPayload{ .boolean = false }, &list3, std.testing.allocator)) {
+        @panic("didn't catch error");
+    } else |err| switch (err) {
+        error.UnionIsNotTagged => {},
+    }
+}
+
+test "(de)serializes a type with a custom serialization method" {
+    const MyCustomSerializingType = struct {
+        len: usize,
+        buffer: [100]u8,
+
+        const Self = @This();
+
+        pub fn sszEncode(self: *const Self, list: *ArrayList(u8), allocator: Allocator) !void {
+            try list.append(allocator, @truncate(self.len));
+            try list.appendSlice(allocator, self.buffer[0..self.len]);
+        }
+
+        pub fn sszDecode(serialized: []const u8, out: *Self, _: ?Allocator) !void {
+            if (serialized.len == 0) {
+                return error.IndexOutOfBounds;
+            }
+
+            out.len = @intCast(serialized[0]);
+            if (out.len > serialized.len - 1) {
+                return error.IndexOutOfBounds;
+            }
+
+            std.mem.copyForwards(u8, out.buffer[0..], serialized[1..]);
+        }
+    };
+
+    var before: MyCustomSerializingType = .{ .len = 10, .buffer = [_]u8{0} ** 100 };
+    before.buffer[0] = 1;
+    before.buffer[9] = 100;
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(MyCustomSerializingType, before, &list, std.testing.allocator);
+
+    try expect(list.items.len == 11);
+
+    var after: MyCustomSerializingType = undefined;
+    try deserialize(MyCustomSerializingType, list.items, &after, null);
+
+    try expect(before.len == after.len);
+    try expect(std.mem.eql(u8, before.buffer[0..before.len], after.buffer[0..after.len]));
+}
+
+test "deserializes an u8" {
+    const payload = [_]u8{0x55};
+    var i: u8 = 0;
+    try deserialize(u8, payload[0..payload.len], &i, null);
+    try expect(i == 0x55);
+}
+
+test "deserializes an u32" {
+    const payload = [_]u8{ 0x55, 0x66, 0x77, 0x88 };
+    var i: u32 = 0;
+    try deserialize(u32, payload[0..payload.len], &i, null);
+    try expect(i == 0x88776655);
+}
+
+test "deserializes a boolean" {
+    const payload_false = [_]u8{0};
+    var b = true;
+    try deserialize(bool, payload_false[0..1], &b, null);
+    try expect(b == false);
+
+    const payload_true = [_]u8{1};
+    try deserialize(bool, payload_true[0..1], &b, null);
+    try expect(b == true);
+}
+
+test "deserializes a Bitvector[N]" {
+    const exp = [_]bool{ true, false, true, true, false, false, false };
+    var out = [_]bool{ false, false, false, false, false, false, false };
+    const serialized_data = [_]u8{0b00001101};
+    try deserialize([7]bool, serialized_data[0..1], &out, null);
+    comptime var i = 0;
+    inline while (i < 7) : (i += 1) {
+        try expect(out[i] == exp[i]);
+    }
+}
+
+test "deserializes an Optional" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    var out: ?u32 = undefined;
+    const exp: ?u32 = 10;
+    try serialize(?u32, exp, &list, std.testing.allocator);
+    try deserialize(?u32, list.items, &out, null);
+    try expect(out.? == exp.?);
+
+    var list2: ArrayList(u8) = .empty;
+    defer list2.deinit(std.testing.allocator);
+
+    try serialize(?u32, null, &list2, std.testing.allocator);
+    try deserialize(?u32, list2.items, &out, null);
+    try expect(out == null);
+}
+
+test "deserializes a string" {
+    const exp = "croissants";
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([]const u8, exp, &list, std.testing.allocator);
+
+    var got: []const u8 = undefined;
+
+    // Deserialize without allocator. The variable
+    // must be of type const.
+    try deserialize([]const u8, list.items, &got, null);
+    try expect(std.mem.eql(u8, exp, got));
+
+    // deserialize with allocator
+    var got_var: []u8 = undefined;
+    try deserialize([]u8, list.items, &got_var, std.testing.allocator);
+    defer std.testing.allocator.free(got_var);
+    try expect(std.mem.eql(u8, exp, got));
+}
+
+const Pastry = struct {
+    name: []const u8,
+    weight: u16,
+};
+
+const pastries = [_]Pastry{
+    Pastry{
+        .name = "croissant",
+        .weight = 20,
+    },
+    Pastry{
+        .name = "Herrentorte",
+        .weight = 500,
+    },
+};
+
+test "deserializes a structure" {
+    var out = Pastry{ .name = "", .weight = 0 };
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    try serialize(Pastry, pastries[0], &list, std.testing.allocator);
+    try deserialize(Pastry, list.items, &out, null);
+
+    try expect(pastries[0].weight == out.weight);
+    try expect(std.mem.eql(u8, pastries[0].name, out.name));
+}
+
+test "deserializes a Vector[N]" {
+    var out: [2]Pastry = undefined;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    try serialize([2]Pastry, pastries, &list, std.testing.allocator);
+    try deserialize(@TypeOf(pastries), list.items, &out, null);
+    comptime var i = 0;
+    inline while (i < pastries.len) : (i += 1) {
+        try expect(out[i].weight == pastries[i].weight);
+        try expect(std.mem.eql(u8, pastries[i].name, out[i].name));
+    }
+}
+
+test "deserializes an invalid Vector[N] payload" {
+    var out: [2]Pastry = undefined;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    try serialize([2]Pastry, pastries, &list, std.testing.allocator);
+    try std.testing.expectError(error.OffsetExceedsSize, deserialize(@TypeOf(pastries), list.items[0 .. list.items.len / 2], &out, null));
+}
+
+test "deserializes an union" {
+    const Payload = union {
+        int: u32,
+        boolean: bool,
+    };
+
+    var p: Payload = undefined;
+    try deserialize(Payload, ([_]u8{ 1, 1 })[0..], &p, null);
+    try expect(p.boolean == true);
+
+    try deserialize(Payload, ([_]u8{ 1, 0 })[0..], &p, null);
+    try expect(p.boolean == false);
+
+    try deserialize(Payload, ([_]u8{ 0, 1, 2, 3, 4 })[0..], &p, null);
+    try expect(p.int == 0x04030201);
+}
+
+test "serialize/deserialize a u256" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    const data = [_]u8{0xAA} ** 32;
+    var output: [32]u8 = undefined;
+
+    try serialize([32]u8, data, &list, std.testing.allocator);
+    try deserialize([32]u8, list.items, &output, null);
+
+    try expect(std.mem.eql(u8, data[0..], output[0..]));
+}
+
+test "(de)serialize a .One pointer in a struct" {
+    var a: u32 = 1;
+    const b = .{
+        .a = &a,
+    };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(b), b, &list, std.testing.allocator);
+    var c_val: u32 = undefined;
+    var c: @TypeOf(b) = .{ .a = &c_val };
+    try deserialize(@TypeOf(b), list.items, &c, std.testing.allocator);
+    std.testing.allocator.destroy(c.a);
+}
+
+test "(de)serialize a slice of structs" {
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+
+    // force runtime evaluation of the slice using a
+    // runtime start and end.
+    var start: usize = 0;
+    var end: usize = pastries.len;
+    _ = .{ &start, &end };
+
+    try serialize([]Pastry, @constCast(pastries[start..end]), &list, std.testing.allocator);
+
+    // pre-allocated deserialization
+    var deser_const_pastries: [pastries.len]Pastry = undefined;
+    try deserialize([]Pastry, list.items, @constCast(&deser_const_pastries[start..end]), null);
+
+    // allocating deserialization
+    var deser_var_pastries: []Pastry = undefined;
+    try deserialize([]Pastry, list.items, @constCast(&deser_var_pastries), std.testing.allocator);
+    std.testing.allocator.free(deser_var_pastries);
+}
+
+test "chunk count of basic types" {
+    try expect(chunkCount(bool) == 1);
+    try expect(chunkCount(u8) == 1);
+    try expect(chunkCount(u16) == 1);
+    try expect(chunkCount(u32) == 1);
+    try expect(chunkCount(u64) == 1);
+}
+
+test "chunk count of Bitvector[N]" {
+    try expect(chunkCount([7]bool) == 1);
+    try expect(chunkCount([12]bool) == 1);
+    try expect(chunkCount([384]bool) == 2);
+}
+
+test "chunk count of Vector[B, N]" {
+    try expect(chunkCount([17]u32) == 3);
+}
+
+test "chunk count of a struct" {
+    try expect(chunkCount(Pastry) == 2);
+}
+
+test "chunk count of a Vector[C, N]" {
+    try expect(chunkCount([2]Pastry) == 2);
+}
+
+// used at comptime to generate a bitvector from a byte vector
+fn bytesToBits(comptime N: usize, src: [N]u8) [N * 8]bool {
+    var bitvector: [N * 8]bool = undefined;
+    for (src, 0..) |byte, idx| {
+        var i = 0;
+        while (i < 8) : (i += 1) {
+            bitvector[i + idx * 8] = ((byte >> (7 - i)) & 1) == 1;
+        }
+    }
+    return bitvector;
+}
+
+const a_bytes = [_]u8{0xaa} ** 16;
+const b_bytes = [_]u8{0xbb} ** 16;
+const c_bytes = [_]u8{0xcc} ** 16;
+const d_bytes = [_]u8{0xdd} ** 16;
+const e_bytes = [_]u8{0xee} ** 16;
+const empty_bytes = [_]u8{0} ** 16;
+
+const a_bits = bytesToBits(16, a_bytes);
+const b_bits = bytesToBits(16, b_bytes);
+const c_bits = bytesToBits(16, c_bytes);
+const d_bits = bytesToBits(16, d_bytes);
+const e_bits = bytesToBits(16, e_bytes);
+
+test "calculate the root hash of a boolean" {
+    var expected = [_]u8{1} ++ [_]u8{0} ** 31;
+    var hashed: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, bool, true, &hashed, std.testing.allocator);
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+
+    expected = hashes_of_zero[0];
+    try hashTreeRoot(Sha256, bool, false, &hashed, std.testing.allocator);
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+test "calculate root hash of an array of two Bitvector[128]" {
+    const deserialized: [2][128]bool = [2][128]bool{ a_bits, b_bits };
+    var hashed: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, @TypeOf(deserialized), deserialized, &hashed, std.testing.allocator);
+
+    var expected: [32]u8 = undefined;
+    const expected_preimage = a_bytes ++ empty_bytes ++ b_bytes ++ empty_bytes;
+    Sha256.hash(expected_preimage[0..], &expected, Sha256.Options{});
+
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+test "calculate the root hash of an array of integers" {
+    var expected = [_]u8{ 0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xfe, 0xca } ++ [_]u8{0} ** 24;
+    var hashed: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, [2]u32, [_]u32{ 0xdeadbeef, 0xcafecafe }, &hashed, std.testing.allocator);
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+test "calculate root hash of an array of three Bitvector[128]" {
+    const deserialized: [3][128]bool = [3][128]bool{ a_bits, b_bits, c_bits };
+    var hashed: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, @TypeOf(deserialized), deserialized, &hashed, std.testing.allocator);
+
+    var left: [32]u8 = undefined;
+    var expected: [32]u8 = undefined;
+    const preimg1 = a_bytes ++ empty_bytes ++ b_bytes ++ empty_bytes;
+    const preimg2 = c_bytes ++ empty_bytes ** 3;
+    Sha256.hash(preimg1[0..], &left, Sha256.Options{});
+    Sha256.hash(preimg2[0..], &expected, Sha256.Options{});
+    var digest = Sha256.init(Sha256.Options{});
+    digest.update(left[0..]);
+    digest.update(expected[0..]);
+    digest.final(&expected);
+
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+test "calculate the root hash of an array of five Bitvector[128]" {
+    const deserialized = [5][128]bool{ a_bits, b_bits, c_bits, d_bits, e_bits };
+    var hashed: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, @TypeOf(deserialized), deserialized, &hashed, std.testing.allocator);
+
+    var internal_nodes: [64]u8 = undefined;
+    var left: [32]u8 = undefined;
+    var expected: [32]u8 = undefined;
+    const preimg1 = a_bytes ++ empty_bytes ++ b_bytes ++ empty_bytes;
+    const preimg2 = c_bytes ++ empty_bytes ++ d_bytes ++ empty_bytes;
+    const preimg3 = e_bytes ++ empty_bytes ** 3;
+    const preimg4 = empty_bytes ** 4;
+
+    Sha256.hash(preimg1[0..], &left, Sha256.Options{});
+    Sha256.hash(preimg2[0..], internal_nodes[0..32], Sha256.Options{});
+    var digest = Sha256.init(Sha256.Options{});
+    digest.update(left[0..]);
+    digest.update(internal_nodes[0..32]);
+    digest.final(internal_nodes[0..32]);
+
+    Sha256.hash(preimg3[0..], &left, Sha256.Options{});
+    Sha256.hash(preimg4[0..], internal_nodes[32..], Sha256.Options{});
+    digest = Sha256.init(Sha256.Options{});
+    digest.update(left[0..]);
+    digest.update(internal_nodes[32..]);
+    digest.final(internal_nodes[32..]);
+
+    Sha256.hash(internal_nodes[0..], &expected, Sha256.Options{});
+
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+const Fork = struct {
+    previous_version: [4]u8,
+    current_version: [4]u8,
+    epoch: u64,
+};
+
+test "calculate the root hash of a structure" {
+    var hashed: [32]u8 = undefined;
+    const fork = Fork{
+        .previous_version = [_]u8{ 0x9c, 0xe2, 0x5d, 0x26 },
+        .current_version = [_]u8{ 0x36, 0x90, 0x55, 0x93 },
+        .epoch = 3,
+    };
+    var expected: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(expected[0..], "58316a908701d3660123f0b8cb7839abdd961f71d92993d34e4f480fbec687d9");
+    try hashTreeRoot(Sha256, Fork, fork, &hashed, std.testing.allocator);
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+test "calculate the root hash of an Optional" {
+    var hashed: [32]u8 = undefined;
+    var payload: [64]u8 = undefined;
+    const v: ?u32 = null;
+    const u: ?u32 = 0xdeadbeef;
+    var expected: [32]u8 = undefined;
+
+    _ = try std.fmt.hexToBytes(payload[0..], "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    Sha256.hash(payload[0..], expected[0..], Sha256.Options{});
+    try hashTreeRoot(Sha256, ?u32, v, &hashed, std.testing.allocator);
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+
+    _ = try std.fmt.hexToBytes(payload[0..], "efbeadde000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000");
+    Sha256.hash(payload[0..], expected[0..], Sha256.Options{});
+    try hashTreeRoot(Sha256, ?u32, u, &hashed, std.testing.allocator);
+    try expect(std.mem.eql(u8, hashed[0..], expected[0..]));
+}
+
+test "calculate the root hash of an union" {
+    const Payload = union(enum) {
+        int: u64,
+        boolean: bool,
+    };
+    var out: [32]u8 = undefined;
+    var payload: [64]u8 = undefined;
+    _ = try std.fmt.hexToBytes(payload[0..], "d2040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+    var exp1: [32]u8 = undefined;
+    Sha256.hash(payload[0..], exp1[0..], Sha256.Options{});
+    try hashTreeRoot(Sha256, Payload, Payload{ .int = 1234 }, &out, std.testing.allocator);
+    try expect(std.mem.eql(u8, out[0..], exp1[0..]));
+
+    var exp2: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(payload[0..], "01000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000");
+    Sha256.hash(payload[0..], exp2[0..], Sha256.Options{});
+    try hashTreeRoot(Sha256, Payload, Payload{ .boolean = true }, &out, std.testing.allocator);
+    try expect(std.mem.eql(u8, out[0..], exp2[0..]));
+}
+
+test "(de)serialize List[N] of fixed-length objects" {
+    const MAX_VALIDATORS_PER_COMMITTEE: usize = 2048;
+    const ListValidatorIndex = utils.List(u64, MAX_VALIDATORS_PER_COMMITTEE);
+    var attesting_indices = try ListValidatorIndex.init(std.testing.allocator);
+    defer attesting_indices.deinit();
+    for (0..10) |i| {
+        try attesting_indices.append(i * 100);
+    }
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(ListValidatorIndex, attesting_indices, &list, std.testing.allocator);
+    var attesting_indices_deser = try ListValidatorIndex.init(std.testing.allocator);
+    defer attesting_indices_deser.deinit();
+    try deserialize(ListValidatorIndex, list.items, &attesting_indices_deser, std.testing.allocator);
+    try expect(attesting_indices.eql(&attesting_indices_deser));
+}
+
+test "(de)serialize List[N] of variable-length objects" {
+    const ListOfStrings = utils.List([]const u8, 16);
+    var string_list = try ListOfStrings.init(std.testing.allocator);
+    defer string_list.deinit();
+    for (0..10) |i| {
+        try string_list.append(try std.fmt.allocPrint(std.testing.allocator, "count={}", .{i}));
+    }
+    defer for (0..string_list.len()) |i| {
+        std.testing.allocator.free(string_list.get(i) catch unreachable);
+    };
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(ListOfStrings, string_list, &list, std.testing.allocator);
+    var string_list_deser = try ListOfStrings.init(std.testing.allocator);
+    defer string_list_deser.deinit();
+    try deserialize(ListOfStrings, list.items, &string_list_deser, std.testing.allocator);
+    try expect(string_list.len() == string_list_deser.len());
+    for (0..string_list.len()) |i| {
+        try expect(std.mem.eql(u8, try string_list.get(i), try string_list_deser.get(i)));
+    }
+}
+
+test "List[N].fromSlice of structs" {
+    const PastryList = utils.List(Pastry, 100);
+    var start: usize = 0;
+    var end: usize = pastries.len;
+    _ = .{ &start, &end };
+    var pastry_list = try PastryList.fromSlice(std.testing.allocator, pastries[start..end]);
+    defer pastry_list.deinit();
+    for (pastries, 0..) |pastry, i| {
+        try expect(std.mem.eql(u8, (try pastry_list.get(i)).name, pastry.name));
+        try expect((try pastry_list.get(i)).weight == pastry.weight);
+    }
+}
+
+test "(de)serialization of Bitlist[N]" {
+    var bitlist = try utils.Bitlist(10).init(std.testing.allocator);
+    defer bitlist.deinit();
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+    try expect(try bitlist.get(1) == false);
+    try expect(try bitlist.get(2) == true);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(bitlist), bitlist, &list, std.testing.allocator);
+    var bitlist_deser: @TypeOf(bitlist) = undefined;
+    try deserialize(@TypeOf(bitlist), list.items, &bitlist_deser, std.testing.allocator);
+    defer bitlist_deser.deinit();
+}
+
+test "(de)serialization of Bitlist[N] when N % 8 != 0" {
+    var bitlist = try utils.Bitlist(3).init(std.testing.allocator);
+    defer bitlist.deinit();
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+    try expect(try bitlist.get(1) == false);
+    try expect(try bitlist.get(2) == true);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(bitlist), bitlist, &list, std.testing.allocator);
+    var bitlist_deser: @TypeOf(bitlist) = undefined;
+    try deserialize(@TypeOf(bitlist), list.items, &bitlist_deser, std.testing.allocator);
+    defer bitlist_deser.deinit();
+    try expect(bitlist.len() == bitlist_deser.len());
+    try expect(bitlist.eql(&bitlist_deser));
+}
+
+test "(de)serialization of empty Bitlist[N]" {
+    var bitlist = try utils.Bitlist(8).init(std.testing.allocator);
+    defer bitlist.deinit();
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(bitlist), bitlist, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, &[_]u8{0x01}));
+    var bitlist_deser: @TypeOf(bitlist) = undefined;
+    try deserialize(@TypeOf(bitlist), list.items, &bitlist_deser, std.testing.allocator);
+    defer bitlist_deser.deinit();
+    try expect(bitlist.len() == bitlist_deser.len());
+    try expect(bitlist.eql(&bitlist_deser));
+}
+
+test "(de)serialization of Bitlist[0]" {
+    var bitlist = try utils.Bitlist(0).init(std.testing.allocator);
+    defer bitlist.deinit();
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(bitlist), bitlist, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, &[_]u8{0x01}));
+    var bitlist_deser: @TypeOf(bitlist) = undefined;
+    try deserialize(@TypeOf(bitlist), list.items, &bitlist_deser, std.testing.allocator);
+    defer bitlist_deser.deinit();
+    try expect(bitlist.len() == bitlist_deser.len());
+    try expect(bitlist.eql(&bitlist_deser));
+}
+
+test "(de)serialization of full Bitlist[N] when N % 8 == 0" {
+    var bitlist = try utils.Bitlist(8).init(std.testing.allocator);
+    defer bitlist.deinit();
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(false);
+    try bitlist.append(false);
+    try bitlist.append(false);
+    try bitlist.append(false);
+    try expect(try bitlist.get(1) == false);
+    try expect(try bitlist.get(2) == true);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(@TypeOf(bitlist), bitlist, &list, std.testing.allocator);
+
+    // should serialize to 0501
+    try expect(std.mem.eql(u8, list.items, &[_]u8{ 0x05, 0x01 }));
+    var bitlist_deser: @TypeOf(bitlist) = undefined;
+    try deserialize(@TypeOf(bitlist), list.items, &bitlist_deser, std.testing.allocator);
+    defer bitlist_deser.deinit();
+    try expect(bitlist.len() == bitlist_deser.len());
+    try expect(bitlist.eql(&bitlist_deser));
+}
+
+test "structs with nested fixed/variable size u8 array" {
+    const Bytes32 = [32]u8;
+    var isFixedSizeType = try isFixedSizeObject(Bytes32);
+    try expect(isFixedSizeType == true);
+
+    const BytesVar = []u8;
+    isFixedSizeType = try isFixedSizeObject(BytesVar);
+    try expect(isFixedSizeType == false);
+
+    // 1.1 test for nested but fixed structures
+    const FixedBlockBody = struct {
+        slot: u64,
+        data: [4]u8,
+    };
+    const FixedBlock = struct {
+        slot: u64,
+        proposer_index: u64,
+        parent_root: Bytes32,
+        state_root: Bytes32,
+        body: FixedBlockBody,
+    };
+    const FixedSignedBlock = struct {
+        message: FixedBlock,
+        signature: [48]u8,
+    };
+    isFixedSizeType = try isFixedSizeObject(FixedSignedBlock);
+    try expect(isFixedSizeType == true);
+    const fixed_signed_block = FixedSignedBlock{
+        .message = .{
+            .slot = 9,
+            .proposer_index = 3,
+            .parent_root = [_]u8{ 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60 },
+            .state_root = [_]u8{ 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231 },
+            .body = .{ .slot = 9, .data = [_]u8{ 1, 2, 3, 4 } },
+        },
+        .signature = [_]u8{2} ** 48,
+    };
+    var serialized_fixed_block: ArrayList(u8) = .empty;
+    defer serialized_fixed_block.deinit(std.testing.allocator);
+    try serialize(FixedSignedBlock, fixed_signed_block, &serialized_fixed_block, std.testing.allocator);
+    // 1.2 verified on an equivalent nodejs container implementation
+    const expected_serialized_fixed_block = [_]u8{ 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 9, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+    try expect(std.mem.eql(u8, serialized_fixed_block.items, expected_serialized_fixed_block[0..]));
+
+    var deserialized_fixed_block: FixedSignedBlock = undefined;
+    try deserialize(FixedSignedBlock, serialized_fixed_block.items[0..], &deserialized_fixed_block, std.testing.allocator);
+
+    // 1.3 match the individual fields
+    try expect(std.mem.eql(u8, fixed_signed_block.signature[0..], deserialized_fixed_block.signature[0..]));
+    try expect(fixed_signed_block.message.slot == deserialized_fixed_block.message.slot);
+    try expect(fixed_signed_block.message.proposer_index == deserialized_fixed_block.message.proposer_index);
+    try expect(std.mem.eql(u8, fixed_signed_block.message.parent_root[0..], deserialized_fixed_block.message.parent_root[0..]));
+    try expect(std.mem.eql(u8, fixed_signed_block.message.state_root[0..], deserialized_fixed_block.message.state_root[0..]));
+    try expect(fixed_signed_block.message.body.slot == deserialized_fixed_block.message.body.slot);
+    try expect(std.mem.eql(u8, fixed_signed_block.message.body.data[0..], deserialized_fixed_block.message.body.data[0..]));
+
+    // 2.1 test for nested variable structures
+    const VarBlockBody = struct {
+        slot: u64,
+        data: []u8,
+    };
+    const VarBlock = struct {
+        slot: u64,
+        proposer_index: u64,
+        parent_root: Bytes32,
+        state_root: Bytes32,
+        body: VarBlockBody,
+    };
+    const VarSignedBlock = struct {
+        message: VarBlock,
+        signature: [48]u8,
+    };
+    isFixedSizeType = try isFixedSizeObject(VarSignedBlock);
+    try expect(isFixedSizeType == false);
+
+    var varData = [_]u8{ 1, 2, 3, 4 };
+    const var_signed_block = VarSignedBlock{
+        .message = .{
+            .slot = 9,
+            .proposer_index = 3,
+            .parent_root = [_]u8{ 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60 },
+            .state_root = [_]u8{ 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231 },
+            .body = .{ .slot = 9, .data = &varData },
+        },
+        .signature = [_]u8{2} ** 48,
+    };
+
+    var serialized_var_block: ArrayList(u8) = .empty;
+    defer serialized_var_block.deinit(std.testing.allocator);
+    try serialize(VarSignedBlock, var_signed_block, &serialized_var_block, std.testing.allocator);
+    // 2.2 verified on an equivalent nodejs container implementation
+    const expected_serialized_var_block = [_]u8{ 52, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60, 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231, 84, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 1, 2, 3, 4 };
+    try expect(std.mem.eql(u8, serialized_var_block.items, expected_serialized_var_block[0..]));
+
+    var deserialized_var_block: VarSignedBlock = undefined;
+    try deserialize(VarSignedBlock, serialized_var_block.items[0..], &deserialized_var_block, std.testing.allocator);
+    // how should the things to be de-inited accumulated?
+    defer std.testing.allocator.free(deserialized_var_block.message.body.data);
+
+    // 2.3 match the individual fields
+    try expect(std.mem.eql(u8, var_signed_block.signature[0..], deserialized_var_block.signature[0..]));
+    try expect(var_signed_block.message.slot == deserialized_var_block.message.slot);
+    try expect(var_signed_block.message.proposer_index == deserialized_var_block.message.proposer_index);
+    try expect(std.mem.eql(u8, var_signed_block.message.parent_root[0..], deserialized_var_block.message.parent_root[0..]));
+    try expect(std.mem.eql(u8, var_signed_block.message.state_root[0..], deserialized_var_block.message.state_root[0..]));
+    try expect(var_signed_block.message.body.slot == deserialized_var_block.message.body.slot);
+    try expect(std.mem.eql(u8, var_signed_block.message.body.data[0..], deserialized_var_block.message.body.data[0..]));
+}
+
+test "slice hashtree root composite type" {
+    const Root = [32]u8;
+    const RootsList = []Root;
+    const test_root = [_]u8{23} ** 32;
+    // merkelizes as List[Root,1] as dynamic data length is mixed in as bounded type
+    var roots_list = [_]Root{test_root};
+
+    var hash_root: [32]u8 = undefined;
+    try hashTreeRoot(
+        Sha256,
+        RootsList,
+        &roots_list,
+        &hash_root,
+        std.testing.allocator,
+    );
+    // computed from nodejs ssz lib for List[Root,1] type
+    const expected_hash_root = [_]u8{ 201, 4, 170, 72, 175, 156, 205, 129, 106, 122, 167, 33, 61, 252, 122, 166, 229, 206, 174, 229, 187, 84, 208, 210, 207, 170, 189, 80, 70, 9, 184, 82 };
+    try expect(std.mem.eql(u8, &expected_hash_root, &hash_root));
+}
+
+test "slice hashtree root simple type" {
+    const DynamicRoot = []u8;
+    // merkelizes as List[u8,33] as dynamic data length is mixed in as bounded type
+    var test_root = [_]u8{23} ** 33;
+
+    var hash_root: [32]u8 = undefined;
+    try hashTreeRoot(
+        Sha256,
+        DynamicRoot,
+        &test_root,
+        &hash_root,
+        std.testing.allocator,
+    );
+    // computed from nodejs ssz lib for List[u8,33]
+    const expected_hash_root = [_]u8{ 229, 104, 130, 10, 13, 251, 109, 221, 13, 70, 107, 87, 182, 228, 3, 211, 49, 235, 199, 224, 42, 133, 57, 250, 72, 21, 166, 87, 206, 112, 35, 203 };
+    try expect(std.mem.eql(u8, &expected_hash_root, &hash_root));
+}
+
+test "List tree root calculation" {
+    const ListU64 = utils.List(u64, 1024);
+
+    var empty_list = try ListU64.init(std.testing.allocator);
+    defer empty_list.deinit();
+    var list_with_items = try ListU64.init(std.testing.allocator);
+    defer list_with_items.deinit();
+    try list_with_items.append(42);
+    try list_with_items.append(123);
+    try list_with_items.append(456);
+    const list_with_items_expected = [_]u8{ 0x2e, 0xe6, 0xa2, 0x1f, 0xa8, 0x67, 0x42, 0xfc, 0xef, 0x87, 0x55, 0x7d, 0x48, 0xfe, 0x37, 0x11, 0x9f, 0x94, 0x56, 0xe1, 0xcc, 0x14, 0x37, 0x76, 0x0f, 0x4e, 0x9d, 0x6d, 0xba, 0x84, 0xbe, 0x01 };
+
+    var empty_hash: [32]u8 = undefined;
+    var filled_hash: [32]u8 = undefined;
+
+    try hashTreeRoot(Sha256, ListU64, empty_list, &empty_hash, std.testing.allocator);
+    try hashTreeRoot(Sha256, ListU64, list_with_items, &filled_hash, std.testing.allocator);
+    try expect(std.mem.eql(u8, &filled_hash, &list_with_items_expected));
+
+    try expect(!std.mem.eql(u8, &empty_hash, &filled_hash));
+
+    var same_content_list = try ListU64.init(std.testing.allocator);
+    defer same_content_list.deinit();
+    try same_content_list.append(42);
+    try same_content_list.append(123);
+    try same_content_list.append(456);
+
+    var same_content_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU64, same_content_list, &same_content_hash, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &filled_hash, &same_content_hash));
+}
+
+test "Bitlist tree root calculation" {
+    const TestBitlist = utils.Bitlist(256);
+
+    var empty_bitlist = try TestBitlist.init(std.testing.allocator);
+    defer empty_bitlist.deinit();
+    var filled_bitlist = try TestBitlist.init(std.testing.allocator);
+    defer filled_bitlist.deinit();
+    try filled_bitlist.append(true);
+    try filled_bitlist.append(false);
+    try filled_bitlist.append(true);
+    try filled_bitlist.append(true);
+
+    var empty_hash: [32]u8 = undefined;
+    var filled_hash: [32]u8 = undefined;
+
+    try hashTreeRoot(Sha256, TestBitlist, empty_bitlist, &empty_hash, std.testing.allocator);
+    try hashTreeRoot(Sha256, TestBitlist, filled_bitlist, &filled_hash, std.testing.allocator);
+
+    try expect(!std.mem.eql(u8, &empty_hash, &filled_hash));
+
+    var same_content_bitlist = try TestBitlist.init(std.testing.allocator);
+    defer same_content_bitlist.deinit();
+    try same_content_bitlist.append(true);
+    try same_content_bitlist.append(false);
+    try same_content_bitlist.append(true);
+    try same_content_bitlist.append(true);
+
+    var same_content_hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, same_content_bitlist, &same_content_hash, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &filled_hash, &same_content_hash));
+}
+
+test "List of composite types tree root" {
+    const ListOfPastry = utils.List(Pastry, 100);
+
+    var pastry_list = try ListOfPastry.init(std.testing.allocator);
+    defer pastry_list.deinit();
+    try pastry_list.append(Pastry{ .name = "croissant", .weight = 20 });
+    try pastry_list.append(Pastry{ .name = "muffin", .weight = 30 });
+
+    var hash1: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListOfPastry, pastry_list, &hash1, std.testing.allocator);
+
+    var pastry_list2 = try ListOfPastry.init(std.testing.allocator);
+    defer pastry_list2.deinit();
+    try pastry_list2.append(Pastry{ .name = "croissant", .weight = 20 });
+    try pastry_list2.append(Pastry{ .name = "muffin", .weight = 30 });
+
+    var hash2: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListOfPastry, pastry_list2, &hash2, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, &hash1, &hash2));
+
+    try pastry_list2.append(Pastry{ .name = "bagel", .weight = 25 });
+    var hash3: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListOfPastry, pastry_list2, &hash3, std.testing.allocator);
+
+    try expect(!std.mem.eql(u8, &hash1, &hash3));
+}
+
+test "serializedSize correctly calculates List/Bitlist sizes" {
+    // Test List size calculation
+    const ListType = utils.List(u64, 100);
+    var list = try ListType.init(std.testing.allocator);
+    defer list.deinit();
+    try list.append(123);
+    try list.append(456);
+
+    // Verify serializedSize matches actual serialization
+    var serialized: ArrayList(u8) = .empty;
+    defer serialized.deinit(std.testing.allocator);
+    try serialize(ListType, list, &serialized, std.testing.allocator);
+
+    const calculated_size = try serializedSize(ListType, list);
+    try expect(calculated_size == serialized.items.len);
+
+    // Test Bitlist size calculation
+    const BitlistType = utils.Bitlist(256);
+    var bitlist = try BitlistType.init(std.testing.allocator);
+    defer bitlist.deinit();
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+
+    var bitlist_serialized: ArrayList(u8) = .empty;
+    defer bitlist_serialized.deinit(std.testing.allocator);
+    try serialize(BitlistType, bitlist, &bitlist_serialized, std.testing.allocator);
+
+    const bitlist_calculated_size = try serializedSize(BitlistType, bitlist);
+    try expect(bitlist_calculated_size == bitlist_serialized.items.len);
+
+    // Test struct containing List/Bitlist
+    const StructWithContainers = struct {
+        id: u64,
+        votes: ListType,
+        flags: BitlistType,
+    };
+
+    const test_struct = StructWithContainers{
+        .id = 42,
+        .votes = list,
+        .flags = bitlist,
+    };
+
+    var struct_serialized: ArrayList(u8) = .empty;
+    defer struct_serialized.deinit(std.testing.allocator);
+    try serialize(StructWithContainers, test_struct, &struct_serialized, std.testing.allocator);
+
+    const struct_calculated_size = try serializedSize(StructWithContainers, test_struct);
+    try expect(struct_calculated_size == struct_serialized.items.len);
+}
+
+test "isFixedSizeObject correctly identifies List/Bitlist as variable-size" {
+    const ListType = utils.List(u64, 100);
+    const BitlistType = utils.Bitlist(100);
+
+    // List and Bitlist should be identified as variable-size per SSZ spec
+    try expect(!try isFixedSizeObject(ListType));
+    try expect(!try isFixedSizeObject(BitlistType));
+
+    // Struct containing List/Bitlist should also be variable-size
+    const StructWithList = struct {
+        id: u64,
+        votes: ListType,
+    };
+
+    try expect(!try isFixedSizeObject(StructWithList));
+}
+
+test "maxInLength for fixed and variable types" {
+    try expect(try libssz.maxInLength(u8) == 1);
+    try expect(try libssz.maxInLength(u64) == 8);
+    try expect(try libssz.maxInLength(bool) == 1);
+    try expect(try libssz.maxInLength([4]u8) == 4);
+    try expect(try libssz.maxInLength([10]bool) == (10 + 7) / 8);
+
+    const ListU64 = utils.List(u64, 16);
+    try expect(try ListU64.maxInLength() == 16 * 8);
+
+    const Bitlist32 = utils.Bitlist(32);
+    try expect(Bitlist32.maxInLength() == (32 + 7 + 1) / 8);
+
+    const ListList = utils.List(utils.List(u8, 4), 2);
+    try expect(try ListList.maxInLength() == 2 * 4 + 2 * (4 * 1));
+
+    const S = struct {
+        a: u32,
+        b: [2]u8,
+    };
+    try expect(try libssz.maxInLength(S) == 4 + 2);
+}
+
+test "minInLength for fixed and variable types" {
+    try expect(try libssz.minInLength(u8) == 1);
+    try expect(try libssz.minInLength(u64) == 8);
+    try expect(try libssz.minInLength(bool) == 1);
+    try expect(try libssz.minInLength([4]u8) == 4);
+    try expect(try libssz.minInLength([10]bool) == (10 + 7) / 8);
+
+    const ListU64 = utils.List(u64, 16);
+    try expect(ListU64.minInLength() == 0);
+
+    const Bitlist32 = utils.Bitlist(32);
+    try expect(Bitlist32.minInLength() == 1);
+
+    const S = struct {
+        a: u32,
+        b: [2]u8,
+    };
+    try expect(try libssz.minInLength(S) == 4 + 2);
+
+    const VarS = struct {
+        a: u32,
+        b: []const u8,
+    };
+    _ = libssz.minInLength(VarS) catch |e| try expect(e == error.NoMinInLengthAvailable);
+}
+
+test "deserialize rejects payload shorter than minInLength" {
+    var out_u32: u32 = undefined;
+    try expectError(error.PayloadTooSmall, deserialize(u32, &[_]u8{ 0x01, 0x02 }, &out_u32, null));
+
+    var out_bool: bool = undefined;
+    try expectError(error.PayloadTooSmall, deserialize(bool, &[_]u8{}, &out_bool, null));
+
+    var out_fixed: [4]u8 = undefined;
+    try expectError(error.PayloadTooSmall, deserialize([4]u8, &[_]u8{ 0x01, 0x02 }, &out_fixed, null));
+}
+
+test "minInLength/maxInLength for struct with List field" {
+    const S = struct {
+        id: u32,
+        data: utils.List(u8, 8),
+    };
+    // min: 4 (u32) + 4 (offset for variable field) + 0 (empty list) = 8
+    try expect(try libssz.minInLength(S) == 4 + 4 + 0);
+    // max: 4 (u32) + 4 (offset for variable field) + 8*1 (full list) = 16
+    try expect(try libssz.maxInLength(S) == 4 + 4 + 8 * 1);
+}
+
+test "deserialize rejects payload longer than maxInLength" {
+    var out_u32: u32 = undefined;
+    try expectError(error.PayloadTooLarge, deserialize(u32, &[_]u8{ 0x01, 0x02, 0x03, 0x04, 0x05 }, &out_u32, null));
+
+    var out_bool: bool = undefined;
+    try expectError(error.PayloadTooLarge, deserialize(bool, &[_]u8{ 0x00, 0x01 }, &out_bool, null));
+
+    var out_fixed: [2]u8 = undefined;
+    try expectError(error.PayloadTooLarge, deserialize([2]u8, &[_]u8{ 0x01, 0x02, 0x03 }, &out_fixed, null));
+}
+
+test "zeam stf input" {
+    const Bytes32 = [32]u8;
+    const Bytes48 = [48]u8;
+    const ExecutionPayloadHeader = struct {
+        timestamp: u64,
+    };
+    const Mini3SFCheckpoint = struct {
+        root: Bytes32,
+        slot: u64,
+    };
+    const Mini3SFVote = struct {
+        validator_id: u64,
+        slot: u64,
+        head: Mini3SFCheckpoint,
+        target: Mini3SFCheckpoint,
+        source: Mini3SFCheckpoint,
+    };
+    const BeamBlockBody = struct {
+        // some form of APS
+        execution_payload_header: ExecutionPayloadHeader,
+        // mini 3sf simplified votes
+        votes: []Mini3SFVote,
+    };
+    const BeamBlock = struct {
+        slot: u64,
+        proposer_index: u64,
+        parent_root: Bytes32,
+        state_root: Bytes32,
+        body: BeamBlockBody,
+    };
+
+    const SignedBeamBlock = struct {
+        message: BeamBlock,
+        // winternitz signature might be of different size depending on num chunks and chunk size
+        signature: Bytes48,
+    };
+
+    const BeamStateConfig = struct {
+        num_validators: u64,
+    };
+    const BeamBlockHeader = struct {
+        slot: u64,
+        proposer_index: u64,
+        parent_root: Bytes32,
+        state_root: Bytes32,
+        body_root: Bytes32,
+    };
+    const BeamState = struct {
+        config: BeamStateConfig,
+        genesis_time: u64,
+        slot: u64,
+        latest_block_header: BeamBlockHeader,
+        latest_justified: Mini3SFCheckpoint,
+        lastest_finalized: Mini3SFCheckpoint,
+        historical_block_hashes: []Bytes32,
+        justified_slots: []u8,
+
+        // a flat representation of the justifications map
+        justifications_roots: []Bytes32,
+        justifications_validators: []u8,
+    };
+    const BeamSTFProverInput = struct {
+        block: SignedBeamBlock,
+        state: BeamState,
+    };
+
+    const config = BeamStateConfig{ .num_validators = 4 };
+    const genesis_root = [_]u8{9} ** 32;
+    var justifications_roots = [_]Bytes32{genesis_root};
+    var justifications_validators = [_]u8{ 0, 1, 1, 1 };
+
+    const state = BeamState{
+        .config = config,
+        .genesis_time = 93,
+        .slot = 99,
+        .latest_block_header = .{
+            .slot = 0,
+            .proposer_index = 0,
+            .parent_root = [_]u8{1} ** 32,
+            .state_root = [_]u8{2} ** 32,
+            .body_root = [_]u8{3} ** 32,
+        },
+        // mini3sf
+        .latest_justified = .{ .root = [_]u8{5} ** 32, .slot = 0 },
+        .lastest_finalized = .{ .root = [_]u8{4} ** 32, .slot = 0 },
+        .historical_block_hashes = &[_]Bytes32{},
+        .justified_slots = &[_]u8{},
+        .justifications_roots = &justifications_roots,
+        .justifications_validators = &justifications_validators,
+    };
+
+    const block = SignedBeamBlock{
+        .message = .{
+            .slot = 9,
+            .proposer_index = 3,
+            .parent_root = [_]u8{ 199, 128, 9, 253, 240, 127, 197, 106, 17, 241, 34, 55, 6, 88, 163, 83, 170, 165, 66, 237, 99, 228, 76, 75, 193, 95, 244, 205, 16, 90, 179, 60 },
+            .state_root = [_]u8{ 81, 12, 244, 147, 45, 160, 28, 192, 208, 78, 159, 151, 165, 43, 244, 44, 103, 197, 231, 128, 122, 15, 182, 90, 109, 10, 229, 68, 229, 60, 50, 231 },
+            .body = .{ .execution_payload_header = ExecutionPayloadHeader{ .timestamp = 23 }, .votes = &[_]Mini3SFVote{} },
+        },
+        .signature = [_]u8{2} ** 48,
+    };
+
+    const prover_input = BeamSTFProverInput{
+        .state = state,
+        .block = block,
+    };
+
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+
+    var serialized: ArrayList(u8) = .empty;
+    defer serialized.deinit(arena_allocator.allocator());
+    try serialize(BeamSTFProverInput, prover_input, &serialized, arena_allocator.allocator());
+
+    var prover_input_deserialized: BeamSTFProverInput = undefined;
+    try deserialize(BeamSTFProverInput, serialized.items[0..], &prover_input_deserialized, arena_allocator.allocator());
+    try expect(std.mem.eql(u8, &prover_input.block.message.parent_root, &prover_input_deserialized.block.message.parent_root));
+    try expect(std.mem.eql(u8, &prover_input.state.lastest_finalized.root, &prover_input_deserialized.state.lastest_finalized.root));
+    try expect(std.mem.eql(u8, prover_input.state.justifications_validators, prover_input_deserialized.state.justifications_validators));
+}
+
+// Test uint64 serialization and deserialization
+test "serializes uint64" {
+    const data: u64 = 0x1122334455667788;
+    const serialized_data = [_]u8{ 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(u64, data, &list, std.testing.allocator);
+    try expect(std.mem.eql(u8, list.items, serialized_data[0..]));
+}
+
+test "deserializes uint64" {
+    const data = [_]u8{ 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 };
+    var result: u64 = undefined;
+    try deserialize(u64, data[0..], &result, std.testing.allocator);
+    try expect(result == 0x1122334455667788);
+}
+
+// Test edge cases for integers
+test "serialize max/min integer values" {
+    // Max u64
+    const max_u64: u64 = std.math.maxInt(u64);
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(u64, max_u64, &list, std.testing.allocator);
+    try expect(list.items.len == 8);
+    try expect(std.mem.eql(u8, list.items, &[_]u8{0xFF} ** 8));
+
+    // Min i64 (most negative)
+    const min_i64: i64 = std.math.minInt(i64);
+    var list2: ArrayList(u8) = .empty;
+    defer list2.deinit(std.testing.allocator);
+    try serialize(i64, min_i64, &list2, std.testing.allocator);
+    try expect(list2.items.len == 8);
+}
+
+test "Empty List hash tree root" {
+    const ListU32 = utils.List(u32, 100);
+    var empty_list = try ListU32.init(std.testing.allocator);
+    defer empty_list.deinit();
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU32, empty_list, &hash, std.testing.allocator);
+
+    // Updated to correct SSZ-compliant hash that uses max capacity for merkleization
+    const zig_expected = [_]u8{
+        0x79, 0x29, 0x30, 0xBB, 0xD5, 0xBA, 0xAC, 0x43,
+        0xBC, 0xC7, 0x98, 0xEE, 0x49, 0xAA, 0x81, 0x85,
+        0xEF, 0x76, 0xBB, 0x3B, 0x44, 0xBA, 0x62, 0xB9,
+        0x1D, 0x86, 0xAE, 0x56, 0x9E, 0x4B, 0xB5, 0x35,
+    };
+    try expect(std.mem.eql(u8, &hash, &zig_expected));
+}
+
+test "Empty BitList(<=256) hash tree root" {
+    const BitListLen100 = utils.Bitlist(100);
+    var empty_list = try BitListLen100.init(std.testing.allocator);
+    defer empty_list.deinit();
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BitListLen100, empty_list, &hash, std.testing.allocator);
+
+    const zig_expected = [_]u8{
+        0xf5, 0xa5, 0xfd, 0x42, 0xd1, 0x6a, 0x20, 0x30,
+        0x27, 0x98, 0xef, 0x6e, 0xd3, 0x09, 0x97, 0x9b,
+        0x43, 0x00, 0x3d, 0x23, 0x20, 0xd9, 0xf0, 0xe8,
+        0xea, 0x98, 0x31, 0xa9, 0x27, 0x59, 0xfb, 0x4b,
+    };
+    try expect(std.mem.eql(u8, &hash, &zig_expected));
+}
+
+test "Empty BitList (>256) hash tree root" {
+    const BitListLen100 = utils.Bitlist(2570);
+    var empty_list = try BitListLen100.init(std.testing.allocator);
+    defer empty_list.deinit();
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, BitListLen100, empty_list, &hash, std.testing.allocator);
+
+    const zig_expected = [_]u8{
+        0x79, 0x29, 0x30, 0xbb, 0xd5, 0xba, 0xac, 0x43,
+        0xbc, 0xc7, 0x98, 0xee, 0x49, 0xaa, 0x81, 0x85,
+        0xef, 0x76, 0xbb, 0x3b, 0x44, 0xba, 0x62, 0xb9,
+        0x1d, 0x86, 0xae, 0x56, 0x9e, 0x4b, 0xb5, 0x35,
+    };
+    try expect(std.mem.eql(u8, &hash, &zig_expected));
+}
+
+test "List at maximum capacity" {
+    const ListU8 = utils.List(u8, 4);
+    var full_list = try ListU8.init(std.testing.allocator);
+    defer full_list.deinit();
+
+    // Fill to capacity
+    try full_list.append(1);
+    try full_list.append(2);
+    try full_list.append(3);
+    try full_list.append(4);
+
+    // Test bounds checking: should fail to add beyond capacity
+    try std.testing.expectError(error.Overflow, full_list.append(5));
+
+    // Test hash tree root at capacity
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU8, full_list, &hash, std.testing.allocator);
+
+    // Python reference: List[uint8, 4] with [1,2,3,4]
+    const expected = [_]u8{
+        0x95, 0xc1, 0xf6, 0x30, 0xb7, 0xa8, 0x42, 0x8b,
+        0x56, 0xd5, 0x1d, 0xa4, 0xdf, 0xae, 0xce, 0x95,
+        0x19, 0x67, 0xa7, 0x03, 0x59, 0x68, 0x22, 0x2f,
+        0xfb, 0x56, 0x0e, 0x7c, 0x78, 0xcd, 0x42, 0x35,
+    };
+    try expect(std.mem.eql(u8, &hash, &expected));
+}
+
+test "Array hash tree root" {
+    const data: [4]u32 = .{ 1, 2, 3, 4 };
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, [4]u32, data, &hash, std.testing.allocator);
+
+    // Python reference: Vector[uint32, 4] with [1,2,3,4]
+    // For basic types packed in one chunk, hash is the serialized data
+    const expected = [_]u8{
+        0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    };
+    try expect(std.mem.eql(u8, &hash, &expected));
+}
+
+test "Large Bitvector serialization and hash" {
+    const LargeBitvec = [512]bool;
+    var data: LargeBitvec = [_]bool{false} ** 512;
+
+    // Set some bits
+    data[0] = true;
+    data[255] = true;
+    data[256] = true;
+    data[511] = true;
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(LargeBitvec, data, &list, std.testing.allocator);
+
+    // Should be 512/8 = 64 bytes
+    try expect(list.items.len == 64);
+
+    // Check specific bits are set (little-endian bit ordering for serialize)
+    try expect(list.items[0] & 0x01 == 0x01); // bit 0 -> LSB of byte 0
+    try expect(list.items[31] & 0x80 == 0x80); // bit 255 -> MSB of byte 31
+    try expect(list.items[32] & 0x01 == 0x01); // bit 256 -> LSB of byte 32
+    try expect(list.items[63] & 0x80 == 0x80); // bit 511 -> MSB of byte 63
+
+    // Test hash tree root
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, LargeBitvec, data, &hash, std.testing.allocator);
+    const expected = [_]u8{
+        0x1d, 0x83, 0x09, 0x11, 0x4a, 0xfe, 0xf7, 0x14,
+        0x89, 0xbe, 0x68, 0xd4, 0x5e, 0x18, 0xc3, 0x39,
+        0x1f, 0x6e, 0x93, 0x05, 0xb4, 0x57, 0x20, 0x0d,
+        0xdc, 0x82, 0xe4, 0x3c, 0x0d, 0x78, 0x35, 0x35,
+    };
+    try expect(std.mem.eql(u8, &hash, &expected));
+}
+
+test "Bitlist edge cases" {
+    const TestBitlist = utils.Bitlist(100);
+
+    // All false
+    var all_false = try TestBitlist.init(std.testing.allocator);
+    defer all_false.deinit();
+    for (0..50) |_| {
+        try all_false.append(false);
+    }
+
+    var hash1: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, all_false, &hash1, std.testing.allocator);
+
+    const expected_false = [_]u8{
+        0x02, 0xc8, 0xc1, 0x5f, 0xed, 0x3f, 0x1b, 0x86,
+        0xb5, 0xd7, 0x88, 0x0d, 0xe1, 0xfc, 0xbf, 0x45,
+        0x12, 0x89, 0x85, 0xc4, 0xf4, 0xb5, 0x49, 0xac,
+        0x89, 0x61, 0xcc, 0x39, 0x0d, 0x51, 0x97, 0x2f,
+    };
+    try expect(std.mem.eql(u8, &hash1, &expected_false));
+
+    // All true
+    var all_true = try TestBitlist.init(std.testing.allocator);
+    defer all_true.deinit();
+    for (0..50) |_| {
+        try all_true.append(true);
+    }
+
+    var hash2: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, all_true, &hash2, std.testing.allocator);
+
+    // Python reference: Bitlist[100] with 50 true bits
+    const expected_true = [_]u8{
+        0xa9, 0x85, 0xe0, 0x62, 0x05, 0x71, 0xe7, 0x45,
+        0x15, 0xfd, 0x9e, 0xc7, 0x0b, 0x4e, 0xa5, 0x15,
+        0x66, 0x3c, 0x55, 0xe0, 0x52, 0xad, 0x24, 0x7f,
+        0xc1, 0xf6, 0xdd, 0xe5, 0xe1, 0xe7, 0x0e, 0x67,
+    };
+    try expect(std.mem.eql(u8, &hash2, &expected_true));
+}
+
+test "Bitlist trailing zeros optimization" {
+    const TestBitlist = utils.Bitlist(256);
+
+    // Test case 1: 8 false bits - should result in one 0x00 byte after pack_bits
+    var eight_false = try TestBitlist.init(std.testing.allocator);
+    defer eight_false.deinit();
+    for (0..8) |_| {
+        try eight_false.append(false);
+    }
+
+    var hash1: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, eight_false, &hash1, std.testing.allocator);
+
+    // Expected hash for 8 false bits in Bitlist[256]
+    // This should keep one zero byte and not remove all then add back a chunk
+    const expected_eight_false = [_]u8{
+        0x5a, 0xc7, 0x8d, 0x95, 0x32, 0x11, 0xaa, 0x82,
+        0x2c, 0x3a, 0xe6, 0xe9, 0xb0, 0x05, 0x8e, 0x42,
+        0x39, 0x4d, 0xd3, 0x2e, 0x59, 0x92, 0xf2, 0x9f,
+        0x9c, 0x12, 0xda, 0x36, 0x81, 0x98, 0x51, 0x30,
+    };
+    try expect(std.mem.eql(u8, &hash1, &expected_eight_false));
+
+    // Test case 2: Pattern with trailing zeros but non-zero first byte
+    var pattern = try TestBitlist.init(std.testing.allocator);
+    defer pattern.deinit();
+    try pattern.append(true);
+    try pattern.append(false);
+    try pattern.append(true);
+    // Add 13 false bits to get 16 total
+    for (0..13) |_| {
+        try pattern.append(false);
+    }
+
+    var hash2: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, TestBitlist, pattern, &hash2, std.testing.allocator);
+
+    // Expected hash for [T,F,T,F...F] (16 bits total)
+    // First byte is 0x05, second byte is 0x00
+    // Should remove only the second zero byte
+    const expected_pattern = [_]u8{
+        0x94, 0x30, 0xdb, 0x52, 0x07, 0x85, 0xa6, 0x68,
+        0x94, 0xde, 0xd7, 0x55, 0x2e, 0x5e, 0x86, 0x2e,
+        0xde, 0x23, 0x18, 0x92, 0xaa, 0x19, 0xb3, 0x0e,
+        0x4a, 0xb4, 0xbd, 0xae, 0x9b, 0x7d, 0x02, 0xec,
+    };
+    try expect(std.mem.eql(u8, &hash2, &expected_pattern));
+}
+
+test "uint256 hash tree root" {
+    const data: u256 = 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF;
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, u256, data, &hash, std.testing.allocator);
+    const expected = [_]u8{
+        0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+        0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+        0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+        0xEF, 0xCD, 0xAB, 0x89, 0x67, 0x45, 0x23, 0x01,
+    };
+    try expect(std.mem.eql(u8, &hash, &expected));
+}
+
+test "Single element List" {
+    const ListU64 = utils.List(u64, 10);
+    var single = try ListU64.init(std.testing.allocator);
+    defer single.deinit();
+    try single.append(42);
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, ListU64, single, &hash, std.testing.allocator);
+
+    const expected = [_]u8{
+        0x54, 0xd7, 0x76, 0x7c, 0xc1, 0xdd, 0xd2, 0xf6,
+        0x66, 0x8d, 0xcd, 0x00, 0x0c, 0x78, 0xb9, 0xfe,
+        0x37, 0xf9, 0x9d, 0x66, 0x2c, 0xfc, 0x5a, 0xc2,
+        0x9c, 0x30, 0xfb, 0x0b, 0xb1, 0x28, 0xb1, 0xbc,
+    };
+    try expect(std.mem.eql(u8, &hash, &expected));
+}
+
+test "Nested structure hash tree root" {
+    const Inner = struct {
+        a: u32,
+        b: u64,
+    };
+
+    const Outer = struct {
+        x: Inner,
+        y: u16,
+        z: Inner,
+    };
+
+    const data = Outer{
+        .x = Inner{ .a = 1, .b = 2 },
+        .y = 3,
+        .z = Inner{ .a = 4, .b = 5 },
+    };
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, Outer, data, &hash, std.testing.allocator);
+
+    const expected = [_]u8{
+        0x4e, 0xbe, 0x9c, 0x7f, 0x41, 0x63, 0xd9, 0x34,
+        0xc1, 0x7a, 0x88, 0xa1, 0x38, 0x31, 0x10, 0xce,
+        0xac, 0x60, 0x50, 0x5b, 0x84, 0xea, 0xf5, 0x1f,
+        0x81, 0xcb, 0xce, 0x0c, 0xe1, 0x9f, 0xc0, 0x43,
+    };
+    try expect(std.mem.eql(u8, &hash, &expected));
+}
+
+test "serialize negative i8 and i16" {
+    const val_i8: i8 = -42;
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(i8, val_i8, &list, std.testing.allocator);
+    try expect(list.items.len == 1);
+    try expect(list.items[0] == 0xD6); // Two's complement of -42
+
+    const val_i16: i16 = -1000;
+    var list2: ArrayList(u8) = .empty;
+    defer list2.deinit(std.testing.allocator);
+    try serialize(i16, val_i16, &list2, std.testing.allocator);
+    try expect(list2.items.len == 2);
+    // -1000 in two's complement is 0xFC18
+    try expect(list2.items[0] == 0x18);
+    try expect(list2.items[1] == 0xFC);
+}
+
+test "Zero-length array" {
+    const empty: [0]u32 = .{};
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([0]u32, empty, &list, std.testing.allocator);
+    try expect(list.items.len == 0);
+
+    var hash: [32]u8 = undefined;
+    try hashTreeRoot(Sha256, [0]u32, empty, &hash, std.testing.allocator);
+    // Should be the zero chunk
+    try expect(std.mem.eql(u8, &hash, &([_]u8{0} ** 32)));
+}
+
+// SSZ Validation Tests
+test "validateBitlist - comprehensive validation" {
+    // Test empty bitlist
+    {
+        const empty_buf = [_]u8{};
+        try std.testing.expectError(error.InvalidBitlistEncoding, utils.Bitlist(10).validateBitlist(&empty_buf));
+    }
+
+    // Test bitlist with trailing zero byte
+    {
+        const zero_trailing = [_]u8{ 0xFF, 0x00 };
+        try std.testing.expectError(error.BitlistTrailingByteZero, utils.Bitlist(16).validateBitlist(&zero_trailing));
+    }
+
+    // Test bitlist exceeding bit limit
+    {
+        const too_many_bits = [_]u8{ 0xFF, 0xFF, 0xFF }; // 23 bits (exceeds limit of 16)
+        try std.testing.expectError(error.BitlistTooManyBits, utils.Bitlist(16).validateBitlist(&too_many_bits));
+    }
+
+    // Test bitlist exceeding byte limit
+    {
+        const too_many_bytes = [_]u8{ 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+        try std.testing.expectError(error.BitlistTooManyBytes, utils.Bitlist(16).validateBitlist(&too_many_bytes));
+    }
+
+    // Test valid bitlist
+    {
+        const valid_bitlist = [_]u8{ 0xFF, 0x01 }; // 8 + 0 = 8 bits (delimiter at position 0 of second byte)
+        try utils.Bitlist(16).validateBitlist(&valid_bitlist); // Should not error
+    }
+}
+
+test "decodeDynamicLength - comprehensive validation" {
+    // Test empty buffer
+    {
+        const empty_buf = [_]u8{};
+        const length = try utils.List(u32, 100).decodeDynamicLength(&empty_buf);
+        try expect(length == 0);
+    }
+
+    // Test buffer too short
+    {
+        const short_buf = [_]u8{ 0x01, 0x02 };
+        try std.testing.expectError(error.DynamicLengthTooShort, utils.List(u32, 100).decodeDynamicLength(&short_buf));
+    }
+
+    // Test invalid offset (not multiple of 4)
+    {
+        const invalid_offset = [_]u8{ 0x03, 0x00, 0x00, 0x00 }; // offset = 3, not multiple of 4
+        try std.testing.expectError(error.DynamicLengthNotOffsetSized, utils.List(u32, 1000).decodeDynamicLength(&invalid_offset));
+    }
+
+    // Test zero offset
+    {
+        const zero_offset = [_]u8{ 0x00, 0x00, 0x00, 0x00 };
+        try std.testing.expectError(error.DynamicLengthNotOffsetSized, utils.List(u32, 100).decodeDynamicLength(&zero_offset));
+    }
+
+    // Test length exceeds max
+    {
+        const big_length = [_]u8{ 0x00, 0x02, 0x00, 0x00 }; // offset = 512, length = 128
+        try std.testing.expectError(error.DynamicLengthExceedsMax, utils.List(u32, 100).decodeDynamicLength(&big_length));
+    }
+
+    // Test valid length
+    {
+        const valid_length = [_]u8{ 0x10, 0x00, 0x00, 0x00 }; // offset = 16, length = 4
+        const length = try utils.List(u32, 100).decodeDynamicLength(&valid_length);
+        try expect(length == 4);
+    }
+}
+
+test "List validation - size limits enforced" {
+    var list = try utils.List(u32, 3).init(std.testing.allocator);
+    defer list.deinit();
+
+    // Test oversized fixed-size list
+    {
+        // Create serialized data representing 5 u32s (exceeds max of 3)
+        var oversized_data = [_]u8{
+            0x01, 0x00, 0x00, 0x00, // u32 = 1
+            0x02, 0x00, 0x00, 0x00, // u32 = 2
+            0x03, 0x00, 0x00, 0x00, // u32 = 3
+            0x04, 0x00, 0x00, 0x00, // u32 = 4
+            0x05, 0x00, 0x00, 0x00, // u32 = 5
+        };
+
+        try std.testing.expectError(error.PayloadTooLarge, deserialize(utils.List(u32, 3), &oversized_data, &list, std.testing.allocator));
+    }
+}
+
+test "Bitlist validation - comprehensive style" {
+    var bitlist = try utils.Bitlist(8).init(std.testing.allocator);
+    defer bitlist.deinit();
+
+    // Test bitlist with missing delimiter
+    {
+        const no_delimiter = [_]u8{0x00};
+        try std.testing.expectError(error.BitlistTrailingByteZero, deserialize(utils.Bitlist(8), &no_delimiter, &bitlist, std.testing.allocator));
+    }
+
+    // Test bitlist exceeding size limit
+    {
+        const too_large = [_]u8{ 0xFF, 0xFF }; // 16 bits, but limit is 8
+        try std.testing.expectError(error.BitlistTooManyBits, deserialize(utils.Bitlist(8), &too_large, &bitlist, std.testing.allocator));
+    }
+
+    // Test valid bitlist
+    {
+        const valid = [_]u8{0x07}; // 2 data bits: 11, delimiter at position 2
+        try deserialize(utils.Bitlist(8), &valid, &bitlist, std.testing.allocator);
+        try expect(bitlist.length == 2); // Should have 2 actual data bits
+    }
+}
+
+test "Bitlist.init creates empty list (ArrayList migration fix)" {
+    // ArrayList init should create empty list, populate with append()
+
+    const TestBitlist = utils.Bitlist(10);
+    var bitlist = try TestBitlist.init(std.testing.allocator);
+    defer bitlist.deinit();
+
+    // After init, bitlist should be empty (length=0), not pre-sized
+    try expect(bitlist.len() == 0);
+    try expect(bitlist.inner.items.len == 0);
+
+    // Populate with append
+    try bitlist.append(true);
+    try bitlist.append(false);
+
+    try expect(bitlist.len() == 2);
+    try expect(try bitlist.get(0) == true);
+    try expect(try bitlist.get(1) == false);
+}
+
+test "Bitlist init consistency with List" {
+    // Both List and Bitlist should have consistent init behavior
+    const TestList = utils.List(u32, 10);
+    const TestBitlist = utils.Bitlist(10);
+
+    var list = try TestList.init(std.testing.allocator);
+    defer list.deinit();
+    var bitlist = try TestBitlist.init(std.testing.allocator);
+    defer bitlist.deinit();
+
+    // Both should start empty after init
+    try expect(list.len() == 0);
+    try expect(bitlist.len() == 0);
+
+    // Both should have reserved capacity but no actual elements
+    try expect(list.inner.items.len == 0);
+    try expect(bitlist.inner.items.len == 0);
+}
+
+test "Bitlist bounds checking during ArrayList migration" {
+    // Test that proper bounds checking prevents the inconsistent state
+    const TestBitlist = utils.Bitlist(3);
+    var bitlist = try TestBitlist.init(std.testing.allocator); // capacity > N
+    defer bitlist.deinit();
+
+    // Should start empty
+    try expect(bitlist.len() == 0);
+
+    // Fill to capacity
+    try bitlist.append(true);
+    try bitlist.append(false);
+    try bitlist.append(true);
+
+    // Should hit the limit now
+    try expect(bitlist.len() == 3);
+
+    // Test bounds checking: should fail to add beyond capacity
+    try std.testing.expectError(error.Overflow, bitlist.append(true));
+}
+
+test "Simulate BoundedArray behavior vs ArrayList behavior" {
+    // This test demonstrates the difference between old BoundedArray and new ArrayList
+    const TestBitlist = utils.Bitlist(8);
+
+    // NEW BEHAVIOR (ArrayList-based): Start empty, populate with append
+    var new_bitlist = try TestBitlist.init(std.testing.allocator);
+    defer new_bitlist.deinit();
+
+    try expect(new_bitlist.len() == 0); // Starts empty
+
+    // Populate step by step
+    try new_bitlist.append(true);
+    try new_bitlist.append(false);
+    try new_bitlist.append(true);
+    try new_bitlist.append(false);
+
+    try expect(new_bitlist.len() == 4);
+    try expect(try new_bitlist.get(0) == true);
+    try expect(try new_bitlist.get(1) == false);
+    try expect(try new_bitlist.get(2) == true);
+    try expect(try new_bitlist.get(3) == false);
+
+    // Test serialization works correctly
+    var serialized: ArrayList(u8) = .empty;
+    defer serialized.deinit(std.testing.allocator);
+    try new_bitlist.sszEncode(&serialized, std.testing.allocator);
+
+    // This test validates ArrayList migration works
+    // We know serialization produces output - exact bytes tested elsewhere
+    try expect(serialized.items.len >= 1); // At least produces some output
+    try expect(new_bitlist.len() == 4); // Proper length tracking
+}
+
+test "Bitlist memory safety after init fix" {
+    // Ensures no out-of-bounds access after fixing the init issue
+    const TestBitlist = utils.Bitlist(16);
+    var bitlist = try TestBitlist.init(std.testing.allocator);
+    defer bitlist.deinit();
+
+    // These operations should not crash
+    try expect(bitlist.len() == 0);
+
+    // Add one element safely
+    try bitlist.append(true);
+    try expect(bitlist.len() == 1);
+    try expect(try bitlist.get(0) == true);
+
+    // Now this supposed to panic
+    // bitlist.get(1);
+}
+
+test "SSZ compliance: Bitlist starts empty per spec" {
+    // Our init should create empty bitlist, then populate with append
+    const TestBitlist = utils.Bitlist(100);
+
+    // Test 1: Empty bitlist serialization
+    var empty_bitlist = try TestBitlist.init(std.testing.allocator);
+    defer empty_bitlist.deinit();
+
+    var empty_serialized: ArrayList(u8) = .empty;
+    defer empty_serialized.deinit(std.testing.allocator);
+    try empty_bitlist.sszEncode(&empty_serialized, std.testing.allocator);
+
+    // Empty bitlist should serialize to single byte with delimiter bit
+    try expect(empty_serialized.items.len == 1);
+    try expect(empty_serialized.items[0] == 0x01); // Just the delimiter bit
+
+    // Test 2: Round-trip empty bitlist
+    var decoded_empty = try TestBitlist.init(std.testing.allocator);
+    defer decoded_empty.deinit();
+    try TestBitlist.sszDecode(empty_serialized.items, &decoded_empty, std.testing.allocator);
+    try expect(decoded_empty.len() == 0);
+
+    // Test 3: Populated bitlist starts from empty state
+    var populated = try TestBitlist.init(std.testing.allocator);
+    defer populated.deinit();
+
+    // Add bits one by one (proper SSZ usage pattern)
+    try populated.append(true);
+    try populated.append(false);
+    try populated.append(true);
+
+    var populated_serialized: ArrayList(u8) = .empty;
+    defer populated_serialized.deinit(std.testing.allocator);
+    try populated.sszEncode(&populated_serialized, std.testing.allocator);
+
+    // SSZ spec: [true, false, true] + delimiter at index 3
+    // Bits: 0=1, 1=0, 2=1, delimiter=1 at bit 3
+    // Binary: 0b00001101 = 0x0D (our implementation is correct!)
+    try expect(populated_serialized.items.len == 1);
+    try expect(populated_serialized.items[0] == 0x0D);
+}
+
+test "SSZ external reference vectors" {
+    const TestBitlist = utils.Bitlist(16);
+
+    // Reference test 1: Decode known valid SSZ bitlist from spec
+    const ssz_empty_bitlist = [_]u8{0x01}; // Empty bitlist per SSZ spec
+    var decoded_empty = try TestBitlist.init(std.testing.allocator);
+    defer decoded_empty.deinit();
+
+    try TestBitlist.sszDecode(&ssz_empty_bitlist, &decoded_empty, std.testing.allocator);
+    try expect(decoded_empty.len() == 0);
+
+    // Reference test 2: Decode [true, false, true] from SSZ spec
+    const ssz_pattern = [_]u8{0x0D}; // Per SSZ spec: 0b00001101
+    var decoded_pattern = try TestBitlist.init(std.testing.allocator);
+    defer decoded_pattern.deinit();
+
+    try TestBitlist.sszDecode(&ssz_pattern, &decoded_pattern, std.testing.allocator);
+
+    try expect(decoded_pattern.len() == 3);
+    try expect(try decoded_pattern.get(0) == true);
+    try expect(try decoded_pattern.get(1) == false);
+    try expect(try decoded_pattern.get(2) == true);
+
+    // Reference test 3: Round-trip should produce same bytes as spec
+    var reencoded: ArrayList(u8) = .empty;
+    defer reencoded.deinit(std.testing.allocator);
+    try decoded_pattern.sszEncode(&reencoded, std.testing.allocator);
+
+    try expect(reencoded.items.len == 1);
+    try expect(reencoded.items[0] == 0x0D);
+}
+
+test "List fromSlice overflow rejection" {
+    const TestList = utils.List(u32, 2);
+    const oversized_slice = [_]u32{ 1, 2, 3, 4 };
+    const result = TestList.fromSlice(std.testing.allocator, &oversized_slice);
+    try expectError(error.Overflow, result);
+}
+
+test "List fromSlice at exact capacity" {
+    const TestList = utils.List(u32, 3);
+    const exact_slice = [_]u32{ 10, 20, 30 };
+    var list = try TestList.fromSlice(std.testing.allocator, &exact_slice);
+    defer list.deinit();
+    try expect(list.len() == 3);
+}
+
+test "Zero capacity List" {
+    const TestList = utils.List(u32, 0);
+    var list = try TestList.init(std.testing.allocator);
+    defer list.deinit();
+    try expect(list.len() == 0);
+    try expectError(error.Overflow, list.append(1));
+}
+
+test "Zero capacity Bitlist" {
+    const TestBitlist = utils.Bitlist(0);
+    var bitlist = try TestBitlist.init(std.testing.allocator);
+    defer bitlist.deinit();
+    try expect(bitlist.len() == 0);
+    try expectError(error.Overflow, bitlist.append(true));
+}
+
+test "Large capacity List overflow" {
+    const TestList = utils.List(u8, 1000);
+    var list = try TestList.init(std.testing.allocator);
+    defer list.deinit();
+
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        try list.append(@truncate(i));
+    }
+    try expect(list.len() == 1000);
+    try expectError(error.Overflow, list.append(255));
+}
+
+test "Large capacity Bitlist overflow" {
+    const TestBitlist = utils.Bitlist(1000);
+    var bitlist = try TestBitlist.init(std.testing.allocator);
+    defer bitlist.deinit();
+
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        try bitlist.append(i % 2 == 0);
+    }
+    try expect(bitlist.len() == 1000);
+    try expectError(error.Overflow, bitlist.append(true));
+}
+
+test "empty slice of dynamic items has zero serializedSize" {
+    const DynamicItem = []const u8;
+    const empty_slice: []const DynamicItem = &[_]DynamicItem{};
+
+    const size = try serializedSize([]const DynamicItem, empty_slice);
+    try expect(size == 0);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([]const DynamicItem, empty_slice, &list, std.testing.allocator);
+    try expect(list.items.len == 0);
+
+    try expect(size == list.items.len);
+}
+
+test "non-empty slice of dynamic items has correct serializedSize" {
+    const item1: []const u8 = "hello";
+    const item2: []const u8 = "world";
+    const items = [_][]const u8{ item1, item2 };
+    const slice: []const []const u8 = &items;
+
+    const size = try serializedSize([]const []const u8, slice);
+    try expect(size == 18);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([]const []const u8, slice, &list, std.testing.allocator);
+    try expect(list.items.len == 18);
+
+    try expect(size == list.items.len);
+}
+
+test "struct with empty dynamic list has correct serializedSize" {
+    const Inner = []const u8;
+    const TestStruct = struct {
+        fixed_field: u32,
+        dynamic_list: []const Inner,
+    };
+
+    const empty_list: []const Inner = &[_]Inner{};
+    const data = TestStruct{
+        .fixed_field = 42,
+        .dynamic_list = empty_list,
+    };
+
+    const size = try serializedSize(TestStruct, data);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize(TestStruct, data, &list, std.testing.allocator);
+
+    try expect(size == list.items.len);
+}
+
+test "array of dynamic items has correct serializedSize with offsets" {
+    // Each dynamic element in an array needs a 4-byte offset in the serialization
+    const item1: []const u8 = "ab"; // 2 bytes
+    const item2: []const u8 = "cde"; // 3 bytes
+
+    const arr = [2][]const u8{ item1, item2 };
+
+    // Expected size: 2 offsets (4 bytes each) + 2 bytes + 3 bytes = 8 + 5 = 13
+    const size = try serializedSize([2][]const u8, arr);
+    try expect(size == 13);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([2][]const u8, arr, &list, std.testing.allocator);
+    try expect(list.items.len == 13);
+
+    // Verify serializedSize matches actual serialization length
+    try expect(size == list.items.len);
+}
+
+test "empty array of dynamic items has zero serializedSize" {
+    const arr: [0][]const u8 = .{};
+
+    const size = try serializedSize([0][]const u8, arr);
+    try expect(size == 0);
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([0][]const u8, arr, &list, std.testing.allocator);
+    try expect(list.items.len == 0);
+
+    try expect(size == list.items.len);
+}
+
+test "nested dynamic list uses relative offsets" {
+    const InnerList = utils.List([]const u8, 10);
+    const OuterStruct = struct {
+        fixed_field: [32]u8, // 32 bytes
+        dynamic_list: InnerList, // variable
+    };
+
+    var inner_list = try InnerList.init(std.testing.allocator);
+    defer inner_list.deinit();
+
+    const item1: []const u8 = "hello";
+    const item2: []const u8 = "world";
+    try inner_list.append(item1);
+    try inner_list.append(item2);
+
+    const outer = OuterStruct{
+        .fixed_field = [_]u8{0xAB} ** 32,
+        .dynamic_list = inner_list,
+    };
+
+    var encoded: ArrayList(u8) = .empty;
+    defer encoded.deinit(std.testing.allocator);
+    try serialize(OuterStruct, outer, &encoded, std.testing.allocator);
+
+    const list_offset = std.mem.readInt(u32, encoded.items[32..36], .little);
+    try expect(list_offset == 36); // offset to dynamic_list from struct start
+
+    const first_item_offset = std.mem.readInt(u32, encoded.items[36..40], .little);
+    try expect(first_item_offset == 8); // 2 items * 4 bytes offset each
+
+    var decoded: OuterStruct = undefined;
+    try deserialize(OuterStruct, encoded.items, &decoded, std.testing.allocator);
+    defer decoded.dynamic_list.deinit();
+
+    try expect(decoded.dynamic_list.len() == 2);
+    const decoded_item1 = try decoded.dynamic_list.get(0);
+    const decoded_item2 = try decoded.dynamic_list.get(1);
+    try expect(std.mem.eql(u8, decoded_item1, "hello"));
+    try expect(std.mem.eql(u8, decoded_item2, "world"));
+}
+
+test "nested dynamic array uses relative offsets" {
+    const OuterStruct = struct {
+        fixed_field: [16]u8, // 16 bytes
+        dynamic_array: [2][]const u8, // variable
+    };
+
+    const item1: []const u8 = "foo";
+    const item2: []const u8 = "barbaz";
+
+    const outer = OuterStruct{
+        .fixed_field = [_]u8{0xCD} ** 16,
+        .dynamic_array = .{ item1, item2 },
+    };
+
+    var encoded: ArrayList(u8) = .empty;
+    defer encoded.deinit(std.testing.allocator);
+    try serialize(OuterStruct, outer, &encoded, std.testing.allocator);
+
+    const array_offset = std.mem.readInt(u32, encoded.items[16..20], .little);
+    try expect(array_offset == 20);
+
+    const first_item_offset = std.mem.readInt(u32, encoded.items[20..24], .little);
+    try expect(first_item_offset == 8); // 2 items * 4 bytes offset each
+
+    var decoded: OuterStruct = undefined;
+    try deserialize(OuterStruct, encoded.items, &decoded, std.testing.allocator);
+
+    try expect(std.mem.eql(u8, decoded.dynamic_array[0], "foo"));
+    try expect(std.mem.eql(u8, decoded.dynamic_array[1], "barbaz"));
+}
+
+test "deeply nested dynamic structures use relative offsets" {
+    const InnerList = utils.List([]const u8, 5);
+    const OuterList = utils.List(InnerList, 5);
+    const Container = struct {
+        prefix: [8]u8,
+        nested_lists: OuterList,
+    };
+
+    var inner1 = try InnerList.init(std.testing.allocator);
+    defer inner1.deinit();
+    try inner1.append("a");
+    try inner1.append("bb");
+
+    var inner2 = try InnerList.init(std.testing.allocator);
+    defer inner2.deinit();
+    try inner2.append("ccc");
+
+    var outer_list = try OuterList.init(std.testing.allocator);
+    defer outer_list.deinit();
+    try outer_list.append(inner1);
+    try outer_list.append(inner2);
+
+    const container = Container{
+        .prefix = [_]u8{0xFF} ** 8,
+        .nested_lists = outer_list,
+    };
+
+    var encoded: ArrayList(u8) = .empty;
+    defer encoded.deinit(std.testing.allocator);
+    try serialize(Container, container, &encoded, std.testing.allocator);
+
+    var decoded: Container = undefined;
+    try deserialize(Container, encoded.items, &decoded, std.testing.allocator);
+    defer {
+        for (decoded.nested_lists.constSlice()) |inner| {
+            var inner_copy = inner;
+            inner_copy.deinit();
+        }
+        decoded.nested_lists.deinit();
+    }
+
+    try expect(decoded.nested_lists.len() == 2);
+
+    const decoded_inner1 = try decoded.nested_lists.get(0);
+    try expect(decoded_inner1.len() == 2);
+    try expect(std.mem.eql(u8, try decoded_inner1.get(0), "a"));
+    try expect(std.mem.eql(u8, try decoded_inner1.get(1), "bb"));
+
+    const decoded_inner2 = try decoded.nested_lists.get(1);
+    try expect(decoded_inner2.len() == 1);
+    try expect(std.mem.eql(u8, try decoded_inner2.get(0), "ccc"));
+}
+
+// Regression: deserialize for fixed-size [N]T where @sizeOf(T) > 1 wrote
+// only out[0], out[pitch], out[2*pitch] ... because the loop variable was
+// used as both the element index (out[i], i < out.len) and the byte step
+// (i += pitch). For [N]u8 (pitch=1) this accidentally worked; for any
+// wider element the interior elements were never written.
+test "roundtrip: [3]u16 preserves middle element" {
+    const data: [3]u16 = .{ 100, 200, 65535 };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([3]u16, data, &list, std.testing.allocator);
+    try expect(list.items.len == 6);
+
+    var out: [3]u16 = .{ 0, 0, 0 };
+    try deserialize([3]u16, list.items, &out, null);
+    try expect(out[0] == 100);
+    try expect(out[1] == 200);
+    try expect(out[2] == 65535);
+}
+
+test "roundtrip: [4]u64 preserves all elements" {
+    const data: [4]u64 = .{ 0, 1, 0xdeadbeef, std.math.maxInt(u64) };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([4]u64, data, &list, std.testing.allocator);
+    try expect(list.items.len == 32);
+
+    var out: [4]u64 = .{ 0, 0, 0, 0 };
+    try deserialize([4]u64, list.items, &out, null);
+    try expect(out[0] == 0);
+    try expect(out[1] == 1);
+    try expect(out[2] == 0xdeadbeef);
+    try expect(out[3] == std.math.maxInt(u64));
+}
+
+test "roundtrip: [2][4]u32 (nested fixed array) preserves inner elements" {
+    const data: [2][4]u32 = .{
+        .{ 1, 2, 3, 4 },
+        .{ 5, 6, 7, 8 },
+    };
+
+    var list: ArrayList(u8) = .empty;
+    defer list.deinit(std.testing.allocator);
+    try serialize([2][4]u32, data, &list, std.testing.allocator);
+    try expect(list.items.len == 32);
+
+    var out: [2][4]u32 = undefined;
+    try deserialize([2][4]u32, list.items, &out, null);
+    try expect(std.mem.eql(u32, &out[0], &.{ 1, 2, 3, 4 }));
+    try expect(std.mem.eql(u32, &out[1], &.{ 5, 6, 7, 8 }));
+}
+
+test {
+    _ = @import("beacon_tests.zig");
+}

--- a/pkgs/third_party/ssz/src/utils.zig
+++ b/pkgs/third_party/ssz/src/utils.zig
@@ -1,0 +1,415 @@
+const std = @import("std");
+const lib = @import("./lib.zig");
+
+// Zig compiler configuration
+const serialize = lib.serialize;
+const deserialize = lib.deserialize;
+const isFixedSizeObject = lib.isFixedSizeObject;
+const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
+const hashes_of_zero = @import("./zeros.zig").hashes_of_zero;
+
+// SSZ specification constants
+const BYTES_PER_CHUNK = 32;
+const chunk = [BYTES_PER_CHUNK]u8;
+const zero_chunk: chunk = [_]u8{0} ** BYTES_PER_CHUNK;
+
+/// Implements the SSZ `List[N]` container.
+pub fn List(T: type, comptime N: usize) type {
+    // Compile-time check: List[bool, N] is not allowed, use Bitlist[N] instead
+    if (T == bool) {
+        @compileError("List[bool, N] is not supported. Use Bitlist(" ++ std.fmt.comptimePrint("{}", .{N}) ++ ") instead for boolean lists.");
+    }
+
+    return struct {
+        const Self = @This();
+        const Item = T;
+        const Inner = std.ArrayList(T);
+
+        const OFFSET_SIZE = 4;
+
+        inner: Inner,
+        allocator: Allocator,
+
+        pub fn sszEncode(self: *const Self, l: *ArrayList(u8), allocator: Allocator) !void {
+            try serialize([]const Item, self.constSlice(), l, allocator);
+        }
+
+        pub fn isFixedSizeObject() bool {
+            return false;
+        }
+
+        /// Maximum serialized byte length for List(T, N) with at most N elements.
+        pub fn maxInLength() !usize {
+            if (try lib.isFixedSizeObject(Item)) {
+                return N * try lib.serializedFixedSize(Item);
+            }
+            return N * @sizeOf(u32) + N * try lib.maxInLength(Item);
+        }
+
+        /// Minimum serialized byte length for List(T, N) (empty list).
+        pub fn minInLength() usize {
+            return 0;
+        }
+
+        pub fn sszDecode(serialized: []const u8, out: *Self, allocator: ?Allocator) !void {
+            // BitList[N] or regular List[N]?
+            const alloc = allocator orelse return error.AllocatorRequired;
+            out.* = try init(alloc);
+
+            // FastSSZ-style capacity optimization: pre-allocate based on input size
+            // TODO: replace this with the definite value, taken from the list
+            if (serialized.len > 0) {
+                const estimated_capacity = if (try lib.isFixedSizeObject(Self.Item))
+                    serialized.len / (try lib.serializedFixedSize(Self.Item))
+                else
+                    serialized.len / 8; // Conservative estimate for dynamic types
+                try out.inner.ensureTotalCapacity(alloc, estimated_capacity);
+            }
+
+            if (Self.Item == bool) {
+                @panic("Use the optimized utils.Bitlist(N) instead of utils.List(bool, N)");
+            } else if (try lib.isFixedSizeObject(Self.Item)) {
+                const pitch = try lib.serializedFixedSize(Self.Item);
+                if (serialized.len % pitch != 0) return error.OffsetOrdering;
+                const n_items = serialized.len / pitch;
+                if (n_items > N) return error.OffsetExceedsSize;
+
+                for (0..n_items) |i| {
+                    var item: Self.Item = undefined;
+                    try deserialize(Self.Item, serialized[i * pitch .. (i + 1) * pitch], &item, allocator);
+                    try out.append(item);
+                }
+            } else {
+                // Validate and decode dynamic list length
+                const size = try Self.decodeDynamicLength(serialized);
+                const prefix_len = @as(usize, size) * 4;
+                if (prefix_len > serialized.len) return error.OffsetExceedsSize;
+
+                const indices = std.mem.bytesAsSlice(u32, serialized[0..prefix_len]);
+                var i = @as(usize, 0);
+                while (i < size) : (i += 1) {
+                    const end = if (i < size - 1) indices[i + 1] else serialized.len;
+                    const start = indices[i];
+                    if (start > serialized.len or end > serialized.len) {
+                        return error.OffsetExceedsSize;
+                    }
+                    if (start > end) return error.OffsetOrdering;
+                    if (i > 0 and start < indices[i - 1]) {
+                        return error.OffsetOrdering;
+                    }
+                    const item = try out.inner.addOne(alloc);
+                    try deserialize(Self.Item, serialized[start..end], item, allocator);
+                }
+            }
+        }
+
+        pub fn init(allocator: Allocator) !Self {
+            return .{ .inner = .empty, .allocator = allocator };
+        }
+
+        pub fn eql(self: *const Self, other: *const Self) bool {
+            if (self.len() != other.len()) return false;
+
+            const self_slice = self.constSlice();
+            const other_slice = other.constSlice();
+
+            // For struct/array types, use std.meta.eql for proper deep comparison
+            if (@typeInfo(Self.Item) == .@"struct" or @typeInfo(Self.Item) == .array) {
+                return std.meta.eql(self_slice, other_slice);
+            } else {
+                // For a slice of primitive types, it's faster to do a memory
+                // comparison.
+                return std.mem.eql(Self.Item, self_slice, other_slice);
+            }
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.inner.deinit(self.allocator);
+        }
+
+        pub fn append(self: *Self, item: Self.Item) error{ Overflow, OutOfMemory }!void {
+            if (self.inner.items.len >= N) return error.Overflow;
+            return self.inner.append(self.allocator, item);
+        }
+
+        pub fn slice(self: *Self) []T {
+            return self.inner.items;
+        }
+
+        pub fn constSlice(self: *const Self) []const T {
+            return self.inner.items;
+        }
+
+        pub fn fromSlice(allocator: Allocator, m: []const T) !Self {
+            if (m.len > N) return error.Overflow;
+            var inner: Inner = .empty;
+            try inner.appendSlice(allocator, m);
+            return .{ .inner = inner, .allocator = allocator };
+        }
+
+        pub fn get(self: Self, i: usize) error{IndexOutOfBounds}!T {
+            if (i >= self.inner.items.len) return error.IndexOutOfBounds;
+            return self.inner.items[i];
+        }
+
+        pub fn set(self: *Self, i: usize, item: T) error{IndexOutOfBounds}!void {
+            if (i >= self.inner.items.len) return error.IndexOutOfBounds;
+            self.inner.items[i] = item;
+        }
+
+        pub fn len(self: *const Self) usize {
+            return self.inner.items.len;
+        }
+
+        pub fn serializedSize(self: *const Self) !usize {
+            const inner_slice = self.constSlice();
+            return lib.serializedSize(@TypeOf(inner_slice), inner_slice);
+        }
+
+        pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
+            const items = self.constSlice();
+
+            switch (@typeInfo(Item)) {
+                .int => {
+                    var list: ArrayList(u8) = .empty;
+                    defer list.deinit(allocator);
+                    const chunks = try lib.pack([]const Item, items, &list, allocator);
+
+                    const bytes_per_item = @sizeOf(Item);
+                    const items_per_chunk = BYTES_PER_CHUNK / bytes_per_item;
+                    const chunks_for_max_capacity = (N + items_per_chunk - 1) / items_per_chunk;
+                    var tmp: chunk = undefined;
+                    try lib.merkleize(Hasher, chunks, chunks_for_max_capacity, &tmp);
+                    lib.mixInLength2(Hasher, tmp, items.len, out);
+                },
+                else => {
+                    var chunks: ArrayList(chunk) = .empty;
+                    defer chunks.deinit(allocator);
+                    var tmp: chunk = undefined;
+                    for (items) |item| {
+                        try lib.hashTreeRoot(Hasher, Item, item, &tmp, allocator);
+                        try chunks.append(allocator, tmp);
+                    }
+                    // Always use N (max capacity) for merkleization, even when empty
+                    // This ensures proper tree depth according to SSZ specification
+                    try lib.merkleize(Hasher, chunks.items, N, &tmp);
+                    lib.mixInLength2(Hasher, tmp, items.len, out);
+                },
+            }
+        }
+
+        /// Decodes and validates the length from dynamic input
+        pub fn decodeDynamicLength(buf: []const u8) !u32 {
+            if (buf.len == 0) {
+                return 0;
+            }
+            if (buf.len < 4) {
+                return error.DynamicLengthTooShort;
+            }
+
+            const offset = std.mem.readInt(u32, buf[0..4], std.builtin.Endian.little);
+            if (offset % OFFSET_SIZE != 0 or offset == 0) {
+                return error.DynamicLengthNotOffsetSized;
+            }
+
+            const length = offset / OFFSET_SIZE;
+            if (length > N) {
+                return error.DynamicLengthExceedsMax;
+            }
+
+            return length;
+        }
+    };
+}
+
+/// Implements the SSZ `Bitlist[N]` container
+pub fn Bitlist(comptime N: usize) type {
+    return struct {
+        const Self = @This();
+        // stores list without sentinel
+        const Inner = std.ArrayList(u8);
+
+        inner: Inner,
+        allocator: Allocator,
+        length: usize,
+
+        pub fn sszEncode(self: *const Self, l: *ArrayList(u8), allocator: Allocator) !void {
+            if (self.length == 0) {
+                try l.append(allocator, @as(u8, 1));
+                return;
+            }
+
+            // slice has at least one byte, appends all
+            // non-terminal bytes.
+            const sl = self.inner.items;
+            try l.appendSlice(allocator, sl[0 .. sl.len - 1]);
+
+            if (self.length % 8 == 0) {
+                // sentinel is extra byte
+                try l.append(allocator, sl[sl.len - 1]);
+                try l.append(allocator, 1);
+            } else {
+                try l.append(allocator, sl[sl.len - 1] | @shlExact(@as(u8, 1), @truncate(self.length % 8)));
+            }
+        }
+
+        pub fn sszDecode(serialized: []const u8, out: *Self, allocator: ?std.mem.Allocator) !void {
+            const alloc = allocator orelse return error.AllocatorRequired;
+            out.* = try init(alloc);
+
+            // Comprehensive validation (handles empty, trailing zero, size limits)
+            try Self.validateBitlist(serialized);
+
+            // FastSSZ-style capacity optimization: pre-allocate based on input size
+            const byte_capacity = serialized.len;
+            if (byte_capacity > 0) {
+                try out.inner.ensureTotalCapacity(alloc, byte_capacity);
+            }
+
+            // Find sentinel bit position using @clz (count leading zeros)
+            const last_byte = serialized[serialized.len - 1];
+            const msb_pos = @as(usize, 8) - @clz(last_byte);
+            const bit_length = 8 * (serialized.len - 1) + (msb_pos - 1);
+
+            // Calculate how many full bytes we need (excluding sentinel)
+            const full_bytes = bit_length / 8;
+            const remaining_bits = bit_length % 8;
+
+            // Copy all full bytes
+            if (full_bytes > 0) {
+                try out.*.inner.appendSlice(alloc, serialized[0..full_bytes]);
+            }
+
+            // Handle remaining bits in the last byte (if any)
+            if (remaining_bits > 0) {
+                // The last byte contains both data bits and the sentinel bit
+                // We need to mask out the sentinel bit and any bits after it
+                const mask = (@as(u8, 1) << @truncate(remaining_bits)) - 1;
+                try out.*.inner.append(alloc, serialized[full_bytes] & mask);
+            }
+
+            out.*.length = bit_length;
+        }
+
+        pub fn isFixedSizeObject() bool {
+            return false;
+        }
+
+        /// Maximum serialized byte length for Bitlist(N) (N bits + sentinel).
+        pub fn maxInLength() usize {
+            return (N + 7 + 1) / 8;
+        }
+
+        /// Minimum serialized byte length for Bitlist(N) (empty bitlist: one byte with sentinel).
+        pub fn minInLength() usize {
+            return 1;
+        }
+
+        pub fn init(allocator: Allocator) !Self {
+            return .{ .inner = .empty, .allocator = allocator, .length = 0 };
+        }
+
+        pub fn get(self: Self, i: usize) error{IndexOutOfBounds}!bool {
+            if (i >= self.length) return error.IndexOutOfBounds;
+            return self.inner.items[i / 8] & @shlExact(@as(u8, 1), @truncate(i % 8)) != 0;
+        }
+
+        pub fn set(self: *Self, i: usize, bit: bool) error{IndexOutOfBounds}!void {
+            if (i >= self.length) return error.IndexOutOfBounds;
+            const mask = ~@shlExact(@as(u8, 1), @truncate(i % 8));
+            const b = if (bit) @shlExact(@as(u8, 1), @truncate(i % 8)) else 0;
+            self.inner.items[i / 8] = @truncate((self.inner.items[i / 8] & mask) | b);
+        }
+
+        pub fn append(self: *Self, item: bool) error{ Overflow, OutOfMemory, IndexOutOfBounds }!void {
+            if (self.length >= N) return error.Overflow;
+            if (self.length % 8 == 0) {
+                try self.inner.append(self.allocator, 0);
+            }
+            self.length += 1;
+            try self.set(self.length - 1, item);
+        }
+
+        pub fn len(self: *const Self) usize {
+            return self.length;
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.inner.deinit(self.allocator);
+        }
+
+        pub fn eql(self: *const Self, other: *const Self) bool {
+            return (self.length == other.length) and std.mem.eql(u8, self.inner.items, other.inner.items);
+        }
+
+        pub fn serializedSize(self: *const Self) usize {
+            // Size is number of bytes needed plus one bit for the sentinel
+            return (self.length + 7 + 1) / 8;
+        }
+
+        pub fn hashTreeRoot(self: *const Self, Hasher: type, out: *[32]u8, allocator: Allocator) !void {
+            const bit_length = self.length;
+
+            var bitfield_bytes: ArrayList(u8) = .empty;
+            defer bitfield_bytes.deinit(allocator);
+
+            if (bit_length > 0) {
+                // Get the internal bit data since we don't store delimiter
+                const sl = self.inner.items;
+                try bitfield_bytes.appendSlice(allocator, sl[0..sl.len]);
+
+                // Remove trailing zeros but keep at least one byte
+                // This avoids the wasteful pattern of removing all zeros then adding back a chunk
+                while (bitfield_bytes.items.len > 1 and bitfield_bytes.items[bitfield_bytes.items.len - 1] == 0) {
+                    _ = bitfield_bytes.pop();
+                }
+            }
+
+            // Pack bits into chunks (pad to chunk boundary)
+            const padding_size = (BYTES_PER_CHUNK - bitfield_bytes.items.len % BYTES_PER_CHUNK) % BYTES_PER_CHUNK;
+            _ = try bitfield_bytes.appendSlice(allocator, zero_chunk[0..padding_size]);
+
+            const chunks = std.mem.bytesAsSlice(chunk, bitfield_bytes.items);
+            var tmp: chunk = undefined;
+
+            // Use chunk_count limit as per SSZ specification
+            const chunk_count_limit = (N + 255) / 256;
+            try lib.merkleize(Hasher, chunks, chunk_count_limit, &tmp);
+            lib.mixInLength2(Hasher, tmp, bit_length, out);
+        }
+
+        /// Validates that the bitlist is correctly formed
+        pub fn validateBitlist(buf: []const u8) !void {
+            const byte_len = buf.len;
+
+            // Empty buffer is invalid, at least sentinel bit should exist
+            if (byte_len == 0) return error.InvalidBitlistEncoding;
+
+            // Maximum possible bytes in a bitlist with provided bitlimit.
+            const max_bytes = ((N + 7 + 1) >> 3);
+            if (byte_len > max_bytes) {
+                return error.BitlistTooManyBytes;
+            }
+
+            // The most significant bit is present in the last byte in the array.
+            const last = buf[byte_len - 1];
+            if (last == 0) {
+                return error.BitlistTrailingByteZero;
+            }
+
+            // Determine the position of the most significant bit.
+            // Find most significant bit position
+            const msb_pos = if (last == 0) 0 else 8 - @clz(last);
+
+            // The absolute position of the most significant bit will be the number of
+            // bits in the preceding bytes plus the position of the most significant
+            // bit. Subtract this value by 1 to determine the length of the bitlist.
+            const num_of_bits: u64 = @intCast(8 * (byte_len - 1) + msb_pos - 1);
+
+            if (num_of_bits > N) {
+                return error.BitlistTooManyBits;
+            }
+        }
+    };
+}

--- a/pkgs/third_party/ssz/src/zeros.zig
+++ b/pkgs/third_party/ssz/src/zeros.zig
@@ -1,0 +1,29 @@
+// List of root hashes of zero-subtrees, up to depth 255.
+const std = @import("std");
+
+/// Generic function to build zero hashes for any hash function
+/// HashType should be a hash type like std.crypto.hash.sha2.Sha256
+/// digest_length is the output size of the hash in bytes
+pub fn buildHashesOfZero(comptime HashType: type, comptime digest_length: usize, comptime depth: usize) [depth][digest_length]u8 {
+    @setEvalBranchQuota(10000000);
+    var ret: [depth][digest_length]u8 = undefined;
+
+    var current = [_]u8{0} ** digest_length;
+
+    ret[0] = current;
+
+    var i: usize = 1;
+    while (i < depth) : (i += 1) {
+        // Hash the current level twice (left and right child are the same)
+        var hasher = HashType.init(.{});
+        hasher.update(&current);
+        hasher.update(&current);
+        current = hasher.finalResult();
+        ret[i] = current;
+    }
+
+    return ret;
+}
+
+// SHA256 zero hashes (the default for SSZ)
+pub const hashes_of_zero = buildHashesOfZero(std.crypto.hash.sha2.Sha256, 32, 256);


### PR DESCRIPTION
## Summary
Fixes [#843](https://github.com/blockblaz/zeam/issues/843): vendored `ssz.zig` could **panic** on malformed peer-supplied offsets (struct second pass, variable `[]T`, union slice, List decode). Deserialization now returns `error.OffsetExceedsSize` / `error.OffsetOrdering` (and related list errors) instead of slicing out of bounds.

## Zeam integration
- `build.zig.zon`: `ssz` dependency is `.path = "pkgs/third_party/ssz"` so the fix ships with zeam until **blockblaz/ssz.zig** publishes an equivalent commit (then we can switch back to `git+` + hash per issue notes).
- `ReqRespRequest.deserialize` for `blocks_by_root`: any non-`OutOfMemory` decode error maps to `error.MalformedReqRespRequest` (Hive `malformed_request` regression); `zig build test` / `simtest` were run locally.

## Also included
Regression test hardening from the malformed BlocksByRoot branch (exact Hive-style bytes and extra cases) is preserved in this branch history.

Closes #843.