### PR TITLE
metrics: xev clock until_done drain observability (#863)

### DIFF
--- a/pkgs/metrics/README.md
+++ b/pkgs/metrics/README.md
@@ -72,6 +72,28 @@ All metrics are defined in the `Metrics` struct in `pkgs/metrics/src/lib.zig`. T
 - **Labels**: None
 - **Sample Collection Event**: On every block processed by the chain
 
+### Event loop health (issues #863, #867)
+
+These series help correlate **long `[clock]` `slot_interval` gaps** with wall time spent inside **`xev.Loop.run(.until_done)`** in `Clock.run` (completion backlog: gossip, reqresp, rust-bridge, etc.). They do **not** replace `zeam_chain_onblock_duration_seconds` for attributing slow **`onBlock`** — use both on the same timeline.
+
+#### `zeam_xev_clock_until_done_drain_seconds` (Histogram)
+- **Description**: Wall time for one `run(.until_done)` drain in the clock driver.
+- **Type**: Histogram
+- **Unit**: Seconds
+- **Buckets**: 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60
+- **Labels**: None
+- **Sample Collection Event**: After each clock-loop `run(.until_done)` completes
+
+#### `zeam_xev_clock_until_done_slow_ge_500ms_total` (Counter)
+- **Description**: Number of clock-loop drains taking ≥0.5s wall time.
+- **Type**: Counter
+- **Sample Collection Event**: When a drain completes at ≥0.5s
+
+#### `zeam_xev_clock_until_done_slow_ge_1s_total` (Counter)
+- **Description**: Number of clock-loop drains taking ≥1s wall time (same path also emits a `[clock]` **warn** log).
+- **Type**: Counter
+- **Sample Collection Event**: When a drain completes at ≥1s
+
 ### Fork Choice Metrics
 
 #### `lean_head_slot` (Gauge)

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -116,6 +116,13 @@ const Metrics = struct {
     zeam_compact_attestations_output_total: CompactAttestationsOutputCounter,
     // Tick interval duration: actual elapsed time between clock ticks (nominal 0.8s)
     lean_tick_interval_duration_seconds: TickIntervalDurationHistogram,
+    /// Wall time for one `xev.Loop.run(.until_done)` in `Clock.run` (issues #863, #867).
+    /// Large values imply completion backlog (gossip / reqresp / bridge) before the next tick.
+    zeam_xev_clock_until_done_drain_seconds: XevClockUntilDoneDrainHistogram,
+    /// Count of clock-loop `run(.until_done)` drains taking ≥500ms wall time.
+    zeam_xev_clock_until_done_slow_ge_500ms_total: ZeamXevClockUntilDoneSlowGe500msCounter,
+    /// Count of clock-loop `run(.until_done)` drains taking ≥1s wall time.
+    zeam_xev_clock_until_done_slow_ge_1s_total: ZeamXevClockUntilDoneSlowGe1sCounter,
     // Fork-choice tick interval duration: actual elapsed time between forkchoice tickIntervalUnlocked calls
     zeam_fork_choice_tick_interval_duration_seconds: ForkChoiceTickIntervalDurationHistogram,
     /// Wall time for the per-slot aggregation tick (interval 2): `maybeAggregateOnInterval`
@@ -304,6 +311,12 @@ const Metrics = struct {
     // compactAttestations metric types
     const CompactAttestationsTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5 });
     const TickIntervalDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6 });
+    /// Buckets from sub-ms through multi-second xev drains observed on loaded devnets (#863).
+    const XevClockUntilDoneDrainHistogram = metrics_lib.Histogram(f32, &[_]f32{
+        0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60,
+    });
+    const ZeamXevClockUntilDoneSlowGe500msCounter = metrics_lib.Counter(u64);
+    const ZeamXevClockUntilDoneSlowGe1sCounter = metrics_lib.Counter(u64);
     const ForkChoiceTickIntervalDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6 });
     /// Aggregation tick (interval-in-slot 2): spans sub-ms through multi-second stalls.
     const AggregationIntervalTickHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0 });
@@ -502,6 +515,12 @@ fn observeTickIntervalDuration(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeXevClockUntilDoneDrain(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.XevClockUntilDoneDrainHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeForkChoiceTickIntervalDuration(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return;
     const histogram: *Metrics.ForkChoiceTickIntervalDurationHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -608,6 +627,10 @@ pub var lean_tick_interval_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeTickIntervalDuration,
 };
+pub var zeam_xev_clock_until_done_drain_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeXevClockUntilDoneDrain,
+};
 pub var zeam_fork_choice_tick_interval_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeForkChoiceTickIntervalDuration,
@@ -707,6 +730,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_compact_attestations_input_total = Metrics.CompactAttestationsInputCounter.init("zeam_compact_attestations_input_total", .{ .help = "Total number of attestations input to compactAttestations" }, .{}),
         .zeam_compact_attestations_output_total = Metrics.CompactAttestationsOutputCounter.init("zeam_compact_attestations_output_total", .{ .help = "Total number of attestations output from compactAttestations after compaction" }, .{}),
         .lean_tick_interval_duration_seconds = Metrics.TickIntervalDurationHistogram.init("lean_tick_interval_duration_seconds", .{ .help = "Elapsed time between clock ticks in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
+        .zeam_xev_clock_until_done_drain_seconds = Metrics.XevClockUntilDoneDrainHistogram.init("zeam_xev_clock_until_done_drain_seconds", .{ .help = "Wall time in seconds for one xev run(.until_done) in the clock driver (issues #863, #867). Captures completion backlog before the next tickInterval()." }, .{}),
+        .zeam_xev_clock_until_done_slow_ge_500ms_total = Metrics.ZeamXevClockUntilDoneSlowGe500msCounter.init("zeam_xev_clock_until_done_slow_ge_500ms_total", .{ .help = "Clock-loop xev run(.until_done) drains with wall time >= 0.5s (#863)." }, .{}),
+        .zeam_xev_clock_until_done_slow_ge_1s_total = Metrics.ZeamXevClockUntilDoneSlowGe1sCounter.init("zeam_xev_clock_until_done_slow_ge_1s_total", .{ .help = "Clock-loop xev run(.until_done) drains with wall time >= 1s (#863)." }, .{}),
         .zeam_fork_choice_tick_interval_duration_seconds = Metrics.ForkChoiceTickIntervalDurationHistogram.init("zeam_fork_choice_tick_interval_duration_seconds", .{ .help = "Elapsed time between forkchoice tick calls in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
         .zeam_node_aggregation_interval_tick_seconds = Metrics.AggregationIntervalTickHistogram.init("zeam_node_aggregation_interval_tick_seconds", .{ .help = "Wall time for BeamNode at per-slot interval 2: maybeAggregateOnInterval plus publishProducedAggregations (includes null/skip/error paths)." }, .{}),
         // BeamNode mutex contention metrics (issue #786)
@@ -767,6 +793,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     lean_attestations_production_time_seconds.context = @ptrCast(&metrics.lean_attestations_production_time_seconds);
     zeam_compact_attestations_time_seconds.context = @ptrCast(&metrics.zeam_compact_attestations_time_seconds);
     lean_tick_interval_duration_seconds.context = @ptrCast(&metrics.lean_tick_interval_duration_seconds);
+    zeam_xev_clock_until_done_drain_seconds.context = @ptrCast(&metrics.zeam_xev_clock_until_done_drain_seconds);
     zeam_fork_choice_tick_interval_duration_seconds.context = @ptrCast(&metrics.zeam_fork_choice_tick_interval_duration_seconds);
     zeam_node_aggregation_interval_tick_seconds.context = @ptrCast(&metrics.zeam_node_aggregation_interval_tick_seconds);
     lean_pending_blocks_drain_iters.context = @ptrCast(&metrics.lean_pending_blocks_drain_iters);
@@ -1127,4 +1154,25 @@ test "slice (d)/(e) #803: fetch-dedup + root-compute-skipped counters appear in 
     for (fetch_outcomes) |lbl| {
         try testing.expect(std.mem.indexOf(u8, body, lbl) != null);
     }
+}
+
+// Issues #863 / #867: clock-loop xev drain observability must stay in the
+// Prometheus scrape output (histogram + slow-drain counters).
+test "issues #863/#867: xev until_done drain metrics appear in /metrics output" {
+    if (isZKVM()) return;
+
+    try init(std.heap.page_allocator);
+
+    zeam_xev_clock_until_done_drain_seconds.record(0.012);
+    metrics.zeam_xev_clock_until_done_slow_ge_500ms_total.incr();
+    metrics.zeam_xev_clock_until_done_slow_ge_1s_total.incr();
+
+    var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer.deinit();
+    try writeMetrics(&alloc_writer.writer);
+    const body = alloc_writer.writer.buffered();
+
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_xev_clock_until_done_drain_seconds") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_xev_clock_until_done_slow_ge_500ms_total") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_xev_clock_until_done_slow_ge_1s_total") != null);
 }

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -118,7 +118,16 @@ pub const Clock = struct {
     pub fn run(self: *Self) !void {
         while (true) {
             self.tickInterval();
+            const drain_timer = zeam_metrics.zeam_xev_clock_until_done_drain_seconds.start();
             try self.events.run(.until_done);
+            const drain_s = drain_timer.observe();
+            if (drain_s >= 0.5) {
+                zeam_metrics.metrics.zeam_xev_clock_until_done_slow_ge_500ms_total.incr();
+            }
+            if (drain_s >= 1.0) {
+                zeam_metrics.metrics.zeam_xev_clock_until_done_slow_ge_1s_total.incr();
+                self.logger.warn("xev until_done drain took {d:.3}s (slot driver backlog; see #863)", .{drain_s});
+            }
         }
     }
 


### PR DESCRIPTION
## Context

> From zeam_0 Loki logs around multiple large slot_interval spikes, the heavy xev loop looks like network / gossip / reqresp / bridge completion pressure (GossipSub-style traffic + reqresp), not something the logs attribute to onBlock in those slices. To confirm or refute slow onBlock on the hot path, you still want metrics (and optionally per-completion instrumentation) on the next live run.

This PR adds **Prometheus visibility** for wall time spent in **`xev.Loop.run(.until_done)`** on the **clock driver** (`Clock.run`), i.e. the gap between `tickInterval()` calls that is *not* explained by fork-choice logic alone. It complements existing **`lean_tick_interval_duration_seconds`** (time *since the previous* `tickInterval`) and **`zeam_chain_onblock_duration_seconds`** for **`onBlock`** attribution.

Related: **#863**, **#867**.

## What changed

- **`zeam_xev_clock_until_done_drain_seconds`** — histogram (buckets from 0.5ms through 60s) recording each drain’s wall time.
- **`zeam_xev_clock_until_done_slow_ge_500ms_total`** / **`zeam_xev_clock_until_done_slow_ge_1s_total`** — counters for slow drains.
- **`[clock]` warn** when a drain takes **≥ 1s** (Loki-friendly marker aligned with the counters).
- **`pkgs/metrics/README.md`** — documents the new series and how to read them next to **`zeam_chain_onblock_duration_seconds`**.
- **Scrape contract test** so the metric names stay in `/metrics` output.

## How to use on the next devnet

On the same timeline as **`lean_tick_interval_duration_seconds`** spikes, compare:

1. **`zeam_xev_clock_until_done_drain_seconds`** tail vs tick interval tail (both should move together if starvation is `run(.until_done)`).
2. **`zeam_chain_onblock_duration_seconds`** — if tail spikes **without** matching xev drain tail, suspect other paths; if both spike together, **`onBlock`** may still be on the hot loop.

## Follow-up (not in this PR)

Per-completion attribution inside libp2p/bridge, reqresp batching, and moving work off the xev thread remain separate changes once metrics narrow the blame.
