### PR TITLE
Track gossip chain queue depth through processing

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -171,8 +171,9 @@ const Metrics = struct {
     // Chain-worker queue + loop metrics (slice c-1 of #803).
     //   * `_dropped_total{queue="block"|"attestation"}` — producer
     //     `trySend` rejections when the queue was full.
-    //   * `_depth{queue="..."}` — instantaneous queue depth, set on
-    //     successful sends; for backlog visibility on devnet stress.
+    //   * `_depth{queue="..."}` — outstanding accepted work, incremented
+    //     on successful sends and decremented after worker processing; for
+    //     backlog visibility on devnet stress.
     //   * `lean_chain_worker_loop_iters_total` — worker-loop liveness
     //     counter; external watchdogs use the delta between scrapes
     //     to detect stalls without touching queue state.
@@ -722,7 +723,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_blocks_future_slot_dropped_total = Metrics.LeanBlocksFutureSlotDroppedCounter.init("lean_blocks_future_slot_dropped_total", .{ .help = "Total number of gossip blocks hard-rejected as FutureSlot beyond the queueable window (issue #788)." }, .{}),
         // Chain-worker queue + loop metrics (slice c-1 of #803).
         .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
-        .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Instantaneous depth of the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
+        .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed, labeled by queue (block|attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -176,7 +176,7 @@ const Metrics = struct {
     lean_pending_blocks_replayed_total: LeanPendingBlocksReplayedCounter,
     lean_blocks_future_slot_dropped_total: LeanBlocksFutureSlotDroppedCounter,
     // Chain-worker queue + loop metrics (slice c-1 of #803).
-    //   * `_dropped_total{queue="block"|"attestation"}` — producer
+    //   * `_dropped_total{queue="block"|"attestation"|"aggregated_attestation"}` — producer
     //     `trySend` rejections when the queue was full.
     //   * `_depth{queue="..."}` — outstanding accepted work, incremented
     //     on successful sends and decremented after worker processing; for
@@ -748,8 +748,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_pending_blocks_replayed_total = try Metrics.LeanPendingBlocksReplayedCounter.init(allocator, io, "lean_pending_blocks_replayed_total", .{ .help = "Total number of replays from pending_blocks, by terminal result (issue #788)." }, .{}),
         .lean_blocks_future_slot_dropped_total = Metrics.LeanBlocksFutureSlotDroppedCounter.init("lean_blocks_future_slot_dropped_total", .{ .help = "Total number of gossip blocks hard-rejected as FutureSlot beyond the queueable window (issue #788)." }, .{}),
         // Chain-worker queue + loop metrics (slice c-1 of #803).
-        .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation)." }, .{}),
-        .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed, labeled by queue (block|attestation)." }, .{}),
+        .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
+        .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed or explicitly discarded during shutdown, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -593,8 +593,8 @@ pub const BeamChain = struct {
         try w.sendAttestation(.{ .on_gossip_attestation = gossip });
     }
 
-    /// Route a gossip aggregated-attestation through the dedicated
-    /// aggregated-attestation worker queue.
+    /// Route a gossip aggregated-attestation through the worker's
+    /// aggregated-attestation queue so backlog/drop metrics stay labelable.
     pub fn submitGossipAggregatedAttestation(
         self: *Self,
         agg: types.SignedAggregatedAttestation,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -593,13 +593,14 @@ pub const BeamChain = struct {
         try w.sendAttestation(.{ .on_gossip_attestation = gossip });
     }
 
-    /// Route a gossip aggregated-attestation through the worker queue.
+    /// Route a gossip aggregated-attestation through the dedicated
+    /// aggregated-attestation worker queue.
     pub fn submitGossipAggregatedAttestation(
         self: *Self,
         agg: types.SignedAggregatedAttestation,
     ) SubmitError!void {
         const w = self.chain_worker orelse return error.ChainWorkerDisabled;
-        try w.sendAttestation(.{ .on_gossip_aggregated_attestation = agg });
+        try w.sendAggregatedAttestation(.{ .on_gossip_aggregated_attestation = agg });
     }
 
     /// Route a `processPendingBlocks` tick through the worker queue.

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -25,15 +25,14 @@
 //!     never blocks on a full queue. Two consumer APIs: blocking
 //!     `recv` (used by tests + any single-queue consumer) and
 //!     non-blocking `tryRecv` (used by the chain-worker loop, which
-//!     multiplexes two queues).
-//!   * `ChainWorker` — owns the thread, two queues (block-FIFO,
-//!     attestation-LIFO per the design doc §"Bounded queue,
-//!     backpressure, and starvation"), stop flag, and a shared
+//!     multiplexes the worker queues).
+//!   * `ChainWorker` — owns the thread, queues for block, raw
+//!     attestation, and aggregated-attestation work, stop flag, and a shared
 //!     `wake_cond` so the worker wakes regardless of which queue a
 //!     producer pushed into. Producers MUST send via
 //!     `sendBlock`/`sendAttestation` so the wake signal is emitted.
 //!     Shutdown is signalled out-of-band: `stop()` flips `stop_flag`,
-//!     closes both queues, and signals `wake_cond`; the loop drains
+//!     closes all queues, and signals `wake_cond`; the loop drains
 //!     remaining messages (calling `Message.deinit` so producer-
 //!     allocated heap is not leaked) and returns. There is
 //!     deliberately no `Message.shutdown` variant — the queues
@@ -205,7 +204,7 @@ pub const Message = union(enum) {
 /// tail (newest first). The design doc §"Bounded queue, backpressure"
 /// requires gossip blocks FIFO (ordering matters for safety) and gossip
 /// attestations LIFO (freshness > ordering). Slashings will be FIFO too
-/// when c-2 routes them; for c-1 we only ship the two queues we need
+/// when c-2 routes them; for c-1 we only shipped the queues we needed
 /// immediately.
 ///
 /// Shutdown semantics: `close()` sets `closed = true` and broadcasts
@@ -310,7 +309,7 @@ pub fn BoundedQueue(comptime T: type) type {
         /// Used by tests in c-1 and by any single-queue consumer.
         /// The chain-worker loop in c-1 (`ChainWorker.runLoop`) does
         /// NOT use this on the hot path because the worker draining
-        /// two queues must wake when EITHER queue has work — see
+        /// multiple queues must wake when any queue has work — see
         /// `tryRecv` + the worker's shared condvar in `ChainWorker`.
         pub fn recv(self: *Self) ?T {
             const item = self.inner.getOneUncancelable(self.io) catch |err| switch (err) {
@@ -322,7 +321,7 @@ pub fn BoundedQueue(comptime T: type) type {
 
         /// Single-consumer non-blocking recv. Returns `null` when the
         /// queue is empty (whether closed or not). Used by the
-        /// chain-worker loop, which multiplexes two queues and uses a
+        /// chain-worker loop, which multiplexes the worker queues and uses a
         /// shared condvar at the worker level for wakeup.
         pub fn tryRecv(self: *Self) ?T {
             var buf: [1]T = undefined;
@@ -339,7 +338,7 @@ pub fn BoundedQueue(comptime T: type) type {
             self.inner.close(self.io);
         }
 
-        /// Snapshot of the current depth (`sent_total - recv_total`).
+        /// Snapshot of the current pending depth (`sent_total - recv_total`).
         /// Race-free for the metric's purposes — a brief stale read
         /// is acceptable since Prometheus gauges are sampled values.
         ///
@@ -351,7 +350,7 @@ pub fn BoundedQueue(comptime T: type) type {
         /// `ChainWorker.runLoop`, this is fine: the worker re-runs
         /// its drain loop on the next iteration and will pick up any
         /// item that was in flight.
-        pub fn depth(self: *Self) usize {
+        pub fn pendingDepth(self: *Self) usize {
             const sent_n = self.sent_total.load(.monotonic);
             const recv_n = self.recv_total.load(.monotonic);
             return @intCast(sent_n -| recv_n);
@@ -366,12 +365,15 @@ pub fn BoundedQueue(comptime T: type) type {
         }
 
         /// Snapshot of messages accepted by producers that have not yet
-        /// completed worker-side handling. Unlike `depth()`, this does not
+        /// completed worker-side handling. Unlike `pendingDepth()`, this does not
         /// decrement when the worker merely pops an item; it decrements only
         /// after dispatch (or shutdown discard) finishes.
         pub fn outstandingDepth(self: *Self) usize {
             const sent_n = self.sent_total.load(.monotonic);
             const processed_n = self.processed_total.load(.monotonic);
+            // These are separate monotonic loads, so a scrape can observe a
+            // transiently newer processed count than sent count. Saturating
+            // subtraction makes that race an acceptable brief under-report.
             return @intCast(sent_n -| processed_n);
         }
     };
@@ -429,7 +431,11 @@ pub const Handlers = struct {
 
 /// Default capacities. Generous enough that a 30s gossip burst on
 /// devnet4 (~3 attestations/slot × 32 validators × 8 slots ≈ 800) does
-/// not saturate. Tuned by the slice c-2 stress harness.
+/// not saturate. Tuned by the slice c-2 stress harness. Aggregated
+/// attestations get a separate 512-message burst budget: under current
+/// devnet load they arrive below raw-attestation volume, and the worker
+/// drains one raw + one aggregated item per loop so neither class can
+/// indefinitely starve the other.
 pub const DEFAULT_BLOCK_QUEUE_CAPACITY: usize = 256;
 pub const DEFAULT_ATTESTATION_QUEUE_CAPACITY: usize = 1024;
 pub const DEFAULT_AGGREGATED_ATTESTATION_QUEUE_CAPACITY: usize = 512;
@@ -451,7 +457,7 @@ pub const ChainWorker = struct {
     const Self = @This();
 
     allocator: Allocator,
-    /// Backing storage for the two queues — allocated in `init`,
+    /// Backing storage for the worker queues — allocated in `init`,
     /// freed in `deinit`. Owned by ChainWorker; the queues hold
     /// non-owning references via `std.Io.Queue.init(buf)`.
     block_queue_buf: []Message,
@@ -477,8 +483,8 @@ pub const ChainWorker = struct {
     /// queue state.
     loop_iters: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
-    /// Shared wake mechanism. The worker drains both queues each
-    /// iteration; when both are empty it parks here. Producers signal
+    /// Shared wake mechanism. The worker drains all queues each
+    /// iteration; when all are empty it parks here. Producers signal
     /// after every successful enqueue so the worker wakes regardless
     /// of which queue received the work. The mutex is only held long
     /// enough to wait/signal.
@@ -487,17 +493,16 @@ pub const ChainWorker = struct {
     ///
     /// `wake_mutex` and the per-queue mutexes ARE composed in one
     /// place: the worker's lost-wakeup re-check in `runLoop` holds
-    /// `wake_mutex` while calling `block_queue.depth()` and
-    /// `attestation_queue.depth()` (which take their own internal
-    /// mutexes). The composition is safe under the rule
+    /// `wake_mutex` while calling each queue's `pendingDepth()` (which
+    /// takes its own internal mutex). The composition is safe under the rule
     ///
     ///   ORDER: wake_mutex → queue_mutex (never reverse)
     ///
-    /// Producers respect this trivially: `sendBlock`/`sendAttestation`
-    /// take queue_mutex (inside trySend) FIRST and release it BEFORE
-    /// taking wake_mutex (inside `wake()`). The worker is the only
+    /// Producers respect this trivially: send wrappers take queue_mutex
+    /// (inside trySend) FIRST and release it BEFORE taking wake_mutex
+    /// (inside `wake()`). The worker is the only
     /// thread that holds wake_mutex while reaching for a queue
-    /// mutex, and only via `depth()` (read-only, immediately
+    /// mutex, and only via `pendingDepth()` (read-only, immediately
     /// released).
     ///
     /// Future contributors who add new wake-mutex-protected paths
@@ -592,8 +597,7 @@ pub const ChainWorker = struct {
     /// queue without blocking. Producers must use these wrappers
     /// rather than calling `block_queue.trySend` directly so the
     /// worker's shared wake-condvar is signalled — otherwise the
-    /// worker can park on an empty block queue while attestations
-    /// pile up (and vice versa).
+    /// worker can park while queued work piles up.
     pub fn sendBlock(self: *Self, msg: Message) BlockQueue.TrySendError!void {
         self.block_queue.trySend(msg) catch |err| {
             if (err == error.QueueFull) {
@@ -656,7 +660,7 @@ pub const ChainWorker = struct {
 
     /// Wake the worker if it's parked. Safe to call from any
     /// producer; idempotent under spurious wakeups (the loop
-    /// re-checks both queues each iteration).
+    /// re-checks all queues each iteration).
     pub fn wake(self: *Self) void {
         const io = self.io;
         self.wake_mutex.lockUncancelable(io);
@@ -682,7 +686,7 @@ pub const ChainWorker = struct {
     ///      and both reached `t.join()` (UB on the second).
     ///   2. Set `stop_flag` so the loop's drain-then-park guard
     ///      observes it.
-    ///   3. Close both queues so any blocked standalone `recv`
+    ///   3. Close all queues so any blocked standalone `recv`
     ///      returns null. The worker loop itself is woken via
     ///      the shared `wake_cond` in step 4; the queues' own
     ///      condvars are not what it parks on.
@@ -715,14 +719,16 @@ pub const ChainWorker = struct {
         self.thread = null;
     }
 
-    /// Worker thread main loop. Each iteration drains the block queue
-    /// first (FIFO, safety-ordered) then the attestation queue (LIFO,
-    /// freshness-ordered) per the design doc. When BOTH queues are
-    /// empty, the worker parks on the shared `wake_cond`, which any
-    /// producer signals via `sendBlock` / `sendAttestation`, and `stop`
-    /// signals after closing the queues.
+    /// Worker thread main loop. Each iteration attempts one block, one
+    /// raw-attestation, and one aggregated-attestation dispatch before
+    /// parking. That keeps block work highest priority while preventing a
+    /// hot raw-attestation queue from indefinitely starving aggregated
+    /// attestations. When all queues are empty, the worker parks on the
+    /// shared `wake_cond`, which any producer signals via `sendBlock` /
+    /// `sendAttestation` / `sendAggregatedAttestation`, and `stop` signals
+    /// after closing the queues.
     ///
-    /// Exit condition: `stop_flag == true` AND both queues are
+    /// Exit condition: `stop_flag == true` AND all queues are
     /// drained. On exit, any messages still in the queues are popped
     /// and freed via `Message.deinit` so producer-allocated heap is
     /// not leaked when shutdown races a partial enqueue burst.
@@ -733,30 +739,36 @@ pub const ChainWorker = struct {
             _ = self.loop_iters.fetchAdd(1, .monotonic);
             zeam_metrics.metrics.lean_chain_worker_loop_iters_total.incr();
 
-            // Drain block queue first (highest priority). `tryRecv`
-            // never blocks; we keep draining until empty.
+            var dispatched_any = false;
+
+            // Block queue stays first (highest priority), but each loop also
+            // gives raw and aggregated attestations one dispatch opportunity.
             if (self.block_queue.tryRecv()) |msg| {
                 self.dispatch(msg);
                 self.block_queue.markProcessed();
                 self.recordBlockQueueDepth();
-                continue;
+                dispatched_any = true;
             }
 
-            // Then attestation queue.
+            // Raw attestations and aggregated attestations are intentionally
+            // separate metrics labels/queues. The consensus path does not
+            // require FIFO ordering between these gossip topics, and handling
+            // one of each per loop avoids starvation under sustained load.
             if (self.attestation_queue.tryRecv()) |msg| {
                 self.dispatch(msg);
                 self.attestation_queue.markProcessed();
                 self.recordAttestationQueueDepth();
-                continue;
+                dispatched_any = true;
             }
 
-            // Then aggregated attestation queue.
             if (self.aggregated_attestation_queue.tryRecv()) |msg| {
                 self.dispatch(msg);
                 self.aggregated_attestation_queue.markProcessed();
                 self.recordAggregatedAttestationQueueDepth();
-                continue;
+                dispatched_any = true;
             }
+
+            if (dispatched_any) continue;
 
             // All queues empty this round. Check stop condition
             // BEFORE parking: if stop was requested while we were
@@ -767,9 +779,8 @@ pub const ChainWorker = struct {
                 break;
             }
 
-            // Park on the shared wake-cond. Any producer that calls
-            // sendBlock / sendAttestation will signal it, as will
-            // `stop()`. We re-check both queues + the stop flag on
+            // Park on the shared wake-cond. Any producer send wrapper will
+            // signal it, as will `stop()`. We re-check all queues + the stop flag on
             // wake so a spurious wakeup is harmless.
             self.wake_mutex.lockUncancelable(io);
             // Re-check under the wake mutex to avoid the lost-wakeup
@@ -777,9 +788,9 @@ pub const ChainWorker = struct {
             // last drain and our park here would have signalled an
             // unparked worker; without this re-check we'd sleep
             // forever even though there is work pending.
-            if (self.block_queue.depth() == 0 and
-                self.attestation_queue.depth() == 0 and
-                self.aggregated_attestation_queue.depth() == 0 and
+            if (self.block_queue.pendingDepth() == 0 and
+                self.attestation_queue.pendingDepth() == 0 and
+                self.aggregated_attestation_queue.pendingDepth() == 0 and
                 !self.stop_flag.load(.acquire))
             {
                 self.wake_cond.waitUncancelable(io, &self.wake_mutex);
@@ -789,7 +800,7 @@ pub const ChainWorker = struct {
         self.logger.info("chain-worker: loop stopped", .{});
     }
 
-    /// Pop and free every remaining message in both queues without
+    /// Pop and free every remaining message in all queues without
     /// running their handler logic. Called from `runLoop` once the
     /// stop flag is observed; ensures producer-allocated heap is not
     /// leaked when stop races a partial enqueue burst.
@@ -902,7 +913,7 @@ test "BoundedQueue: trySend / recv preserves FIFO order" {
     try q.trySend(.{ .process_pending_blocks = .{ .current_slot = 2 } });
     try q.trySend(.{ .process_pending_blocks = .{ .current_slot = 3 } });
 
-    try testing.expectEqual(@as(usize, 3), q.depth());
+    try testing.expectEqual(@as(usize, 3), q.pendingDepth());
 
     const m1 = q.recv() orelse return error.UnexpectedNull;
     try testing.expectEqual(@as(types.Slot, 1), m1.process_pending_blocks.current_slot);
@@ -911,12 +922,12 @@ test "BoundedQueue: trySend / recv preserves FIFO order" {
     const m3 = q.recv() orelse return error.UnexpectedNull;
     try testing.expectEqual(@as(types.Slot, 3), m3.process_pending_blocks.current_slot);
 
-    try testing.expectEqual(@as(usize, 0), q.depth());
+    try testing.expectEqual(@as(usize, 0), q.pendingDepth());
     q.close();
     try testing.expect(q.recv() == null);
 }
 
-// Note: c-1 dropped LIFO mode — both queues are FIFO until c-2
+// Note: c-1 dropped LIFO mode — worker queues are FIFO until c-2
 // swaps the attestation queue for a 1024cores intrusive MPSC node
 // queue (per @GrapeBaBa's review). The previous LIFO test is
 // removed; the FIFO test above covers the only ordering surface
@@ -1025,17 +1036,17 @@ test "BoundedQueue: ring wraparound — head walks past capacity-1 with items li
     var round: usize = 0;
     while (round < 16) : (round += 1) {
         // Fill to capacity.
-        while (q.depth() < cap) {
+        while (q.pendingDepth() < cap) {
             try q.trySend(.{ .process_pending_blocks = .{ .current_slot = @intCast(next_send) } });
             next_send += 1;
         }
-        try testing.expectEqual(cap, q.depth());
+        try testing.expectEqual(cap, q.pendingDepth());
 
         // Drain all-but-one. The remaining item sits at
         // (head + len - 1) % cap which, as head walks the ring,
         // exercises every slot of `items[]`.
         var keep: usize = 0;
-        while (q.depth() > 1) {
+        while (q.pendingDepth() > 1) {
             const m = q.recv() orelse return error.UnexpectedNull;
             try testing.expectEqual(
                 @as(types.Slot, @intCast(next_recv)),
@@ -1044,14 +1055,14 @@ test "BoundedQueue: ring wraparound — head walks past capacity-1 with items li
             next_recv += 1;
             keep += 1;
         }
-        try testing.expectEqual(@as(usize, 1), q.depth());
+        try testing.expectEqual(@as(usize, 1), q.pendingDepth());
         try testing.expect(keep == cap - 1);
     }
 
     // Final drain. Every value popped must still match the FIFO
     // sequence — if any wraparound mishandling silently re-ordered
     // the ring, this assertion fires.
-    while (q.depth() > 0) {
+    while (q.pendingDepth() > 0) {
         const m = q.recv() orelse return error.UnexpectedNull;
         try testing.expectEqual(
             @as(types.Slot, @intCast(next_recv)),
@@ -1109,7 +1120,7 @@ test "BoundedQueue: multi-producer trySend race — counters are exact" {
                 _ = queue.recv() orelse return;
             }
             // Final drain.
-            while (queue.depth() > 0) {
+            while (queue.pendingDepth() > 0) {
                 _ = queue.recv();
             }
         }
@@ -1166,7 +1177,7 @@ test "ChainWorker: start, send a message, stop() drains and joins cleanly" {
 
 test "ChainWorker: start without explicit Shutdown — stop() unblocks recv()" {
     // Verifies the close()-path of stop(): the worker is parked on
-    // `recv()` inside `runLoop`; `stop()` closes both queues, recv
+    // `recv()` inside `runLoop`; `stop()` closes all queues, recv
     // returns null, the loop exits, the join completes.
     var logger_config = zeam_utils.getTestLoggerConfig();
     var w = try ChainWorker.init(testing.allocator, .{
@@ -1471,6 +1482,7 @@ test "ChainWorker: metrics — sendBlock/sendAttestation/runLoop bump lean_chain
         // hit QueueFull and bump lean_chain_queue_dropped_total.
         .block_queue_capacity = 1,
         .attestation_queue_capacity = 1,
+        .aggregated_attestation_queue_capacity = 1,
     });
     defer w.deinit();
 
@@ -1492,7 +1504,14 @@ test "ChainWorker: metrics — sendBlock/sendAttestation/runLoop bump lean_chain
         w.sendAttestation(.{ .process_pending_blocks = .{ .current_slot = 4 } }),
     );
 
-    // 4) Start the worker briefly so runLoop runs at least once and
+    // 4) Same shape on the aggregated-attestation queue.
+    try w.sendAggregatedAttestation(.{ .process_pending_blocks = .{ .current_slot = 5 } });
+    try testing.expectError(
+        error.QueueFull,
+        w.sendAggregatedAttestation(.{ .process_pending_blocks = .{ .current_slot = 6 } }),
+    );
+
+    // 5) Start the worker briefly so runLoop runs at least once and
     //    bumps lean_chain_worker_loop_iters_total.
     try w.start();
     while (w.loop_iters.load(.monotonic) < 1) {
@@ -1500,7 +1519,7 @@ test "ChainWorker: metrics — sendBlock/sendAttestation/runLoop bump lean_chain
     }
     w.stop();
 
-    // 5) Scrape /metrics via writeMetrics and assert each metric +
+    // 6) Scrape /metrics via writeMetrics and assert each metric +
     //    label is in the rendered body.
     var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
     defer alloc_writer.deinit();
@@ -1513,6 +1532,7 @@ test "ChainWorker: metrics — sendBlock/sendAttestation/runLoop bump lean_chain
 
     try testing.expect(std.mem.indexOf(u8, body, "queue=\"block\"") != null);
     try testing.expect(std.mem.indexOf(u8, body, "queue=\"attestation\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "queue=\"aggregated_attestation\"") != null);
 }
 
 test "ChainWorker.stop: idempotent under concurrent callers (no double-join UB)" {

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -261,6 +261,7 @@ pub fn BoundedQueue(comptime T: type) type {
         dropped_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
         sent_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
         recv_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+        processed_total: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
         pub const TrySendError = error{ QueueFull, QueueClosed };
 
@@ -354,6 +355,24 @@ pub fn BoundedQueue(comptime T: type) type {
             const sent_n = self.sent_total.load(.monotonic);
             const recv_n = self.recv_total.load(.monotonic);
             return @intCast(sent_n -| recv_n);
+        }
+
+        /// Mark one popped message as fully processed (or explicitly
+        /// discarded during shutdown). Used for the Prometheus queue-depth
+        /// gauge, whose operator-facing meaning is "accepted by a producer
+        /// but not yet finished by the worker".
+        pub fn markProcessed(self: *Self) void {
+            _ = self.processed_total.fetchAdd(1, .monotonic);
+        }
+
+        /// Snapshot of messages accepted by producers that have not yet
+        /// completed worker-side handling. Unlike `depth()`, this does not
+        /// decrement when the worker merely pops an item; it decrements only
+        /// after dispatch (or shutdown discard) finishes.
+        pub fn outstandingDepth(self: *Self) usize {
+            const sent_n = self.sent_total.load(.monotonic);
+            const processed_n = self.processed_total.load(.monotonic);
+            return @intCast(sent_n -| processed_n);
         }
     };
 }
@@ -571,10 +590,7 @@ pub const ChainWorker = struct {
             }
             return err;
         };
-        zeam_metrics.metrics.lean_chain_queue_depth.set(
-            .{ .queue = "block" },
-            self.block_queue.depth(),
-        ) catch {};
+        self.recordBlockQueueDepth();
         self.wake();
     }
 
@@ -588,11 +604,22 @@ pub const ChainWorker = struct {
             }
             return err;
         };
+        self.recordAttestationQueueDepth();
+        self.wake();
+    }
+
+    fn recordBlockQueueDepth(self: *Self) void {
+        zeam_metrics.metrics.lean_chain_queue_depth.set(
+            .{ .queue = "block" },
+            self.block_queue.outstandingDepth(),
+        ) catch {};
+    }
+
+    fn recordAttestationQueueDepth(self: *Self) void {
         zeam_metrics.metrics.lean_chain_queue_depth.set(
             .{ .queue = "attestation" },
-            self.attestation_queue.depth(),
+            self.attestation_queue.outstandingDepth(),
         ) catch {};
-        self.wake();
     }
 
     /// Wake the worker if it's parked. Safe to call from any
@@ -677,12 +704,16 @@ pub const ChainWorker = struct {
             // never blocks; we keep draining until empty.
             if (self.block_queue.tryRecv()) |msg| {
                 self.dispatch(msg);
+                self.block_queue.markProcessed();
+                self.recordBlockQueueDepth();
                 continue;
             }
 
             // Then attestation queue.
             if (self.attestation_queue.tryRecv()) |msg| {
                 self.dispatch(msg);
+                self.attestation_queue.markProcessed();
+                self.recordAttestationQueueDepth();
                 continue;
             }
 
@@ -725,11 +756,15 @@ pub const ChainWorker = struct {
         while (self.block_queue.tryRecv()) |popped| {
             var m = popped;
             m.deinit();
+            self.block_queue.markProcessed();
+            self.recordBlockQueueDepth();
             freed += 1;
         }
         while (self.attestation_queue.tryRecv()) |popped| {
             var m = popped;
             m.deinit();
+            self.attestation_queue.markProcessed();
+            self.recordAttestationQueueDepth();
             freed += 1;
         }
         if (freed > 0) {

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -379,6 +379,7 @@ pub fn BoundedQueue(comptime T: type) type {
 
 pub const BlockQueue = BoundedQueue(Message);
 pub const AttestationQueue = BoundedQueue(Message);
+pub const AggregatedAttestationQueue = BoundedQueue(Message);
 
 /// Per-variant dispatch vtable.
 ///
@@ -431,6 +432,7 @@ pub const Handlers = struct {
 /// not saturate. Tuned by the slice c-2 stress harness.
 pub const DEFAULT_BLOCK_QUEUE_CAPACITY: usize = 256;
 pub const DEFAULT_ATTESTATION_QUEUE_CAPACITY: usize = 1024;
+pub const DEFAULT_AGGREGATED_ATTESTATION_QUEUE_CAPACITY: usize = 512;
 
 /// Owns the chain-worker thread, the bounded queues, and a stop flag.
 ///
@@ -454,8 +456,10 @@ pub const ChainWorker = struct {
     /// non-owning references via `std.Io.Queue.init(buf)`.
     block_queue_buf: []Message,
     attestation_queue_buf: []Message,
+    aggregated_attestation_queue_buf: []Message,
     block_queue: BlockQueue,
     attestation_queue: AttestationQueue,
+    aggregated_attestation_queue: AggregatedAttestationQueue,
     stop_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     /// Single-shot guard so concurrent `stop()` callers don't both
     /// reach `t.join()` (which is UB on the second caller — the
@@ -526,6 +530,7 @@ pub const ChainWorker = struct {
     pub const InitOpts = struct {
         block_queue_capacity: usize = DEFAULT_BLOCK_QUEUE_CAPACITY,
         attestation_queue_capacity: usize = DEFAULT_ATTESTATION_QUEUE_CAPACITY,
+        aggregated_attestation_queue_capacity: usize = DEFAULT_AGGREGATED_ATTESTATION_QUEUE_CAPACITY,
         logger: zeam_utils.ModuleLogger,
         /// Optional dispatch vtable; see `ChainWorker.handlers`.
         handlers: ?Handlers = null,
@@ -547,6 +552,8 @@ pub const ChainWorker = struct {
         errdefer allocator.free(block_buf);
         const att_buf = try allocator.alloc(Message, opts.attestation_queue_capacity);
         errdefer allocator.free(att_buf);
+        const agg_att_buf = try allocator.alloc(Message, opts.aggregated_attestation_queue_capacity);
+        errdefer allocator.free(agg_att_buf);
 
         return .{
             .allocator = allocator,
@@ -554,8 +561,10 @@ pub const ChainWorker = struct {
             .io = io,
             .block_queue_buf = block_buf,
             .attestation_queue_buf = att_buf,
+            .aggregated_attestation_queue_buf = agg_att_buf,
             .block_queue = BlockQueue.init(block_buf, io),
             .attestation_queue = AttestationQueue.init(att_buf, io),
+            .aggregated_attestation_queue = AggregatedAttestationQueue.init(agg_att_buf, io),
             .logger = opts.logger,
             .handlers = opts.handlers,
         };
@@ -570,8 +579,10 @@ pub const ChainWorker = struct {
         }
         self.block_queue.deinit();
         self.attestation_queue.deinit();
+        self.aggregated_attestation_queue.deinit();
         self.allocator.free(self.block_queue_buf);
         self.allocator.free(self.attestation_queue_buf);
+        self.allocator.free(self.aggregated_attestation_queue_buf);
         self.threaded.deinit();
         self.allocator.destroy(self.threaded);
     }
@@ -619,6 +630,27 @@ pub const ChainWorker = struct {
         zeam_metrics.metrics.lean_chain_queue_depth.set(
             .{ .queue = "attestation" },
             self.attestation_queue.outstandingDepth(),
+        ) catch {};
+    }
+
+    /// Send an aggregated-attestation-flavored message and wake the worker.
+    /// Same wakeup contract as `sendBlock`. Bumps the metrics family
+    /// with `queue="aggregated_attestation"`.
+    pub fn sendAggregatedAttestation(self: *Self, msg: Message) AggregatedAttestationQueue.TrySendError!void {
+        self.aggregated_attestation_queue.trySend(msg) catch |err| {
+            if (err == error.QueueFull) {
+                zeam_metrics.metrics.lean_chain_queue_dropped_total.incr(.{ .queue = "aggregated_attestation" }) catch {};
+            }
+            return err;
+        };
+        self.recordAggregatedAttestationQueueDepth();
+        self.wake();
+    }
+
+    fn recordAggregatedAttestationQueueDepth(self: *Self) void {
+        zeam_metrics.metrics.lean_chain_queue_depth.set(
+            .{ .queue = "aggregated_attestation" },
+            self.aggregated_attestation_queue.outstandingDepth(),
         ) catch {};
     }
 
@@ -675,6 +707,7 @@ pub const ChainWorker = struct {
         self.stop_flag.store(true, .release);
         self.block_queue.close();
         self.attestation_queue.close();
+        self.aggregated_attestation_queue.close();
         self.wake();
         if (self.thread) |t| {
             t.join();
@@ -717,7 +750,15 @@ pub const ChainWorker = struct {
                 continue;
             }
 
-            // Both queues empty this round. Check stop condition
+            // Then aggregated attestation queue.
+            if (self.aggregated_attestation_queue.tryRecv()) |msg| {
+                self.dispatch(msg);
+                self.aggregated_attestation_queue.markProcessed();
+                self.recordAggregatedAttestationQueueDepth();
+                continue;
+            }
+
+            // All queues empty this round. Check stop condition
             // BEFORE parking: if stop was requested while we were
             // draining, drain anything that arrived after the last
             // probe and exit.
@@ -738,6 +779,7 @@ pub const ChainWorker = struct {
             // forever even though there is work pending.
             if (self.block_queue.depth() == 0 and
                 self.attestation_queue.depth() == 0 and
+                self.aggregated_attestation_queue.depth() == 0 and
                 !self.stop_flag.load(.acquire))
             {
                 self.wake_cond.waitUncancelable(io, &self.wake_mutex);
@@ -765,6 +807,13 @@ pub const ChainWorker = struct {
             m.deinit();
             self.attestation_queue.markProcessed();
             self.recordAttestationQueueDepth();
+            freed += 1;
+        }
+        while (self.aggregated_attestation_queue.tryRecv()) |popped| {
+            var m = popped;
+            m.deinit();
+            self.aggregated_attestation_queue.markProcessed();
+            self.recordAggregatedAttestationQueueDepth();
             freed += 1;
         }
         if (freed > 0) {


### PR DESCRIPTION
## Summary
- make `lean_chain_queue_depth{queue="block|attestation|aggregated_attestation"}` track outstanding chain-worker work until the worker finishes processing it or explicitly discards it during shutdown
- route gossip aggregated attestations through a dedicated `aggregated_attestation` worker queue so backlog/drop metrics stay labelable by work class
- update the worker dispatch loop to give block, raw-attestation, and aggregated-attestation queues one dispatch opportunity per loop, preventing hot raw-attestation traffic from indefinitely starving aggregated attestations
- document the aggregated queue capacity rationale, queue ordering semantics, shutdown discard accounting, and the approximate atomic-snapshot behavior of outstanding-depth gauges
- clarify metric help/comment text so dashboards know about the new `aggregated_attestation` queue label

## Validation
- `zig fmt pkgs/node/src/chain_worker.zig pkgs/node/src/chain.zig pkgs/metrics/src/lib.zig`
- `zig build` (EXIT:0)
- `zig build test --summary all` (EXIT:0)
