### PR TITLE
simtest: wait for metrics port before beam sim ready

### DIFF
--- a/pkgs/cli/test/integration.zig
+++ b/pkgs/cli/test/integration.zig
@@ -71,9 +71,12 @@ fn spinBeamSimNode(allocator: std.mem.Allocator, exe_path: []const u8) !*process
 
     std.debug.print("INFO: Process spawned successfully with PID\n", .{});
 
-    // Wait for server to be ready
+    // Wait for both API (9667) and metrics (9668) listeners. Integration tests
+    // hit `/metrics` on the metrics port immediately after this returns; only
+    // probing the API port caused flaky `ConnectionRefused` on slow/loaded CI.
     const start_time = zeam_utils.unixTimestampMillis();
-    var server_ready = false;
+    var api_ready = false;
+    var metrics_ready = false;
     var retry_count: u32 = 0;
 
     while (zeam_utils.unixTimestampMillis() - start_time < constants.DEFAULT_SERVER_STARTUP_TIMEOUT_MS) {
@@ -82,34 +85,58 @@ fn spinBeamSimNode(allocator: std.mem.Allocator, exe_path: []const u8) !*process
         // Print progress every 10 retries
         if (retry_count % 10 == 0) {
             const elapsed = @divTrunc(zeam_utils.unixTimestampMillis() - start_time, 1000);
-            std.debug.print("INFO: Still waiting for server... ({} seconds, {} retries)\n", .{ elapsed, retry_count });
+            std.debug.print("INFO: Still waiting for beam sim (api={any} metrics={any})... ({}s, {} retries)\n", .{
+                api_ready,
+                metrics_ready,
+                elapsed,
+                retry_count,
+            });
         }
 
-        // Try to connect to the metrics server
-        const address = net.IpAddress.parseIp4(constants.DEFAULT_SERVER_IP, constants.DEFAULT_API_PORT) catch {
+        const port: u16 = if (!api_ready) constants.DEFAULT_API_PORT else constants.DEFAULT_METRICS_PORT;
+
+        const address = net.IpAddress.parseIp4(constants.DEFAULT_SERVER_IP, port) catch {
             zeam_utils.sleepNs(constants.DEFAULT_RETRY_INTERVAL_MS * std.time.ns_per_ms);
             continue;
         };
 
         var connection = address.connect(io, .{ .mode = .stream }) catch |err| {
-            // Only print error details on certain intervals to avoid spam
             if (retry_count % 20 == 0) {
-                std.debug.print("DEBUG: Connection attempt {} failed: {}\n", .{ retry_count, err });
+                std.debug.print("DEBUG: TCP {d} attempt {} failed: {}\n", .{ port, retry_count, err });
             }
             zeam_utils.sleepNs(constants.DEFAULT_RETRY_INTERVAL_MS * std.time.ns_per_ms);
             continue;
         };
-
-        // Test if we can actually send/receive data
         connection.close(io);
-        server_ready = true;
-        std.debug.print("SUCCESS: Server ready after {} seconds ({} retries)\n", .{ @divTrunc(zeam_utils.unixTimestampMillis() - start_time, 1000), retry_count });
+
+        if (!api_ready) {
+            api_ready = true;
+            std.debug.print("SUCCESS: API port {d} accepting after {}s ({} retries)\n", .{
+                constants.DEFAULT_API_PORT,
+                @divTrunc(zeam_utils.unixTimestampMillis() - start_time, 1000),
+                retry_count,
+            });
+            continue;
+        }
+        metrics_ready = true;
+        std.debug.print("SUCCESS: Metrics port {d} accepting after {}s ({} retries)\n", .{
+            constants.DEFAULT_METRICS_PORT,
+            @divTrunc(zeam_utils.unixTimestampMillis() - start_time, 1000),
+            retry_count,
+        });
         break;
     }
 
+    const server_ready = api_ready and metrics_ready;
+
     // If server didn't start, try to get process output for debugging
     if (!server_ready) {
-        std.debug.print("ERROR: Metrics server not ready after {} seconds ({} retries)\n", .{ @divTrunc(constants.DEFAULT_SERVER_STARTUP_TIMEOUT_MS, 1000), retry_count });
+        std.debug.print("ERROR: Beam sim not ready after {}s (api={any} metrics={any}, retries={})\n", .{
+            @divTrunc(constants.DEFAULT_SERVER_STARTUP_TIMEOUT_MS, 1000),
+            api_ready,
+            metrics_ready,
+            retry_count,
+        });
 
         // Try to read any output from the process
         if (cli_process.stdout) |stdout| {


### PR DESCRIPTION
## Problem

`zig build simtest` could fail with **`pkgs/cli/test/integration.zig`** (e.g. `14 passed; 1 failed`) while beam mock logs still looked healthy.

`spinBeamSimNode` only waited until **TCP accepted on the API port (9667)**, but the first integration check (`getMetrics`) hits **`/metrics` on 9668**. The comment even said “metrics server” while the code probed the API port.

On a loaded or slow machine, **9667 comes up before 9668**, so the test could **`ConnectionRefused`** or scrape before the metrics HTTP server was ready → flaky simtest.

## Fix

Within the same **`DEFAULT_SERVER_STARTUP_TIMEOUT_MS`** window, wait for **both**:

1. **API port** `9667` accepts TCP  
2. **Metrics port** `9668` accepts TCP  

Then return the child handle. Error logging now reports which side failed.

## Verification

`zig build simtest` — all 15 integration tests passed locally after this change.
