### PR TITLE
feat: move aggregate FFI off libxev thread using Io.Threaded worker (closes #873)

### DIFF
--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -398,7 +398,8 @@ pub const Node = struct {
         const cpu_count = std.Thread.getCpuCount() catch 2;
         const reserved_system_threads: usize = 4; // main, p2p, api server, metrics server
         const desired_workers = @max(@as(usize, 1), cpu_count -| reserved_system_threads);
-        const worker_count = @min(desired_workers, @as(usize, ThreadPool.max_thread_count));
+        const zig_worker_budget = @max(@as(usize, 1), (desired_workers + 1) / 2);
+        const worker_count = @min(zig_worker_budget, @as(usize, ThreadPool.max_thread_count));
         self.thread_pool = try ThreadPool.init(.{
             .allocator = allocator,
             .io = std.Io.Threaded.global_single_threaded.io(),
@@ -406,13 +407,16 @@ pub const Node = struct {
         });
         errdefer self.thread_pool.deinit();
 
-        // Limit the rayon thread pool used by the XMSS aggregate prover so that
-        // it doesn’t consume all CPU cores. Reserve 3 threads for libxev,
-        // the chain worker, and the rust-libp2p network thread (issue #873).
+        // Coordinate the Zig worker pool and the rayon pool used by the XMSS
+        // aggregate prover from the same post-system-thread budget so they do
+        // not independently claim every remaining CPU. Prefer the Zig pool for
+        // the extra worker on odd counts since aggregate verification enters
+        // rayon from Zig workers. Both pools still keep a minimum of one worker
+        // so tiny/cgroup-limited systems remain functional.
         // Must be called before setupProver/setupVerifier since rayon’s global
         // pool is initialized lazily on first use.
-        const rayon_threads = cpu_count -| 3; // saturating sub — 0 means rayon default
-        xmss.setRayonThreads(if (rayon_threads > 0) rayon_threads else 1);
+        const rayon_threads = @max(@as(usize, 1), desired_workers -| worker_count);
+        xmss.setRayonThreads(rayon_threads);
 
         // Pre-warm the XMSS verifier on the main thread before any worker can
         // call `verifyAggregatedPayload`. The Rust-side verifier setup is

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -406,6 +406,14 @@ pub const Node = struct {
         });
         errdefer self.thread_pool.deinit();
 
+        // Limit the rayon thread pool used by the XMSS aggregate prover so that
+        // it doesn’t consume all CPU cores. Reserve 3 threads for libxev,
+        // the chain worker, and the rust-libp2p network thread (issue #873).
+        // Must be called before setupProver/setupVerifier since rayon’s global
+        // pool is initialized lazily on first use.
+        const rayon_threads = cpu_count -| 3; // saturating sub — 0 means rayon default
+        xmss.setRayonThreads(if (rayon_threads > 0) rayon_threads else 1);
+
         // Pre-warm the XMSS verifier on the main thread before any worker can
         // call `verifyAggregatedPayload`. The Rust-side verifier setup is
         // documented as idempotent but is not hardened against first-time-init

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -128,6 +128,11 @@ const Metrics = struct {
     /// Wall time for the per-slot aggregation tick (interval 2): `maybeAggregateOnInterval`
     /// plus `publishProducedAggregations` when the aggregator produces gossip aggregates.
     zeam_node_aggregation_interval_tick_seconds: AggregationIntervalTickHistogram,
+    /// Counter for skipped aggregate submissions, labeled by reason.
+    /// Reasons: "in_flight", "not_aggregator", "not_synced", "missing_state".
+    zeam_aggregate_skip_total: AggregateSkipCounter,
+    /// Histogram for the wall-clock duration of the aggregate FFI worker.
+    zeam_aggregate_worker_duration_seconds: AggregateWorkerDurationHistogram,
     // BeamNode mutex contention metrics (issue #786)
     // Wait time = how long a callsite blocked before acquiring BeamNode.mutex.
     // Hold time = how long the callsite kept the mutex locked.
@@ -345,6 +350,8 @@ const Metrics = struct {
     const LeanBlockFetchDedupCounter = metrics_lib.CounterVec(u64, struct { outcome: []const u8 });
     // Issue #837 — see `lean_node_interval_error_total` field doc.
     const LeanNodeIntervalErrorCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
+    const AggregateSkipCounter = metrics_lib.CounterVec(u64, struct { reason: []const u8 });
+    const AggregateWorkerDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0 });
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -528,6 +535,12 @@ fn observeForkChoiceTickIntervalDuration(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeAggregateWorkerDuration(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.AggregateWorkerDurationHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeAggregationIntervalTick(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return;
     const histogram: *Metrics.AggregationIntervalTickHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -640,6 +653,10 @@ pub var zeam_node_aggregation_interval_tick_seconds: Histogram = .{
     .context = null,
     .observe = &observeAggregationIntervalTick,
 };
+pub var zeam_aggregate_worker_duration_seconds: Histogram = .{
+    .context = null,
+    .observe = &observeAggregateWorkerDuration,
+};
 pub var lean_pending_blocks_drain_iters: Histogram = .{
     .context = null,
     .observe = &observePendingBlocksDrainIters,
@@ -736,6 +753,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_xev_clock_until_done_slow_ge_1s_total = Metrics.ZeamXevClockUntilDoneSlowGe1sCounter.init("zeam_xev_clock_until_done_slow_ge_1s_total", .{ .help = "Clock-loop xev run(.until_done) drains with wall time >= 1s (#863)." }, .{}),
         .zeam_fork_choice_tick_interval_duration_seconds = Metrics.ForkChoiceTickIntervalDurationHistogram.init("zeam_fork_choice_tick_interval_duration_seconds", .{ .help = "Elapsed time between forkchoice tick calls in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
         .zeam_node_aggregation_interval_tick_seconds = Metrics.AggregationIntervalTickHistogram.init("zeam_node_aggregation_interval_tick_seconds", .{ .help = "Wall time for BeamNode at per-slot interval 2: maybeAggregateOnInterval plus publishProducedAggregations (includes null/skip/error paths)." }, .{}),
+        .zeam_aggregate_skip_total = try Metrics.AggregateSkipCounter.init(allocator, io, "zeam_aggregate_skip_total", .{ .help = "Number of aggregate submissions skipped, labeled by reason: in_flight, not_aggregator, not_synced, missing_state." }, .{}),
+        .zeam_aggregate_worker_duration_seconds = Metrics.AggregateWorkerDurationHistogram.init("zeam_aggregate_worker_duration_seconds", .{ .help = "Wall-clock duration of the aggregate FFI worker (XMSS recursive aggregation)." }, .{}),
         // BeamNode mutex contention metrics (issue #786)
         .zeam_node_mutex_wait_time_seconds = try Metrics.NodeMutexWaitTimeHistogram.init(allocator, io, "zeam_node_mutex_wait_time_seconds", .{ .help = "Time spent waiting to acquire BeamNode.mutex, labeled by callsite (LEGACY — double-emitted from per-resource locks; will be removed after one release)." }, .{}),
         .zeam_node_mutex_hold_time_seconds = try Metrics.NodeMutexHoldTimeHistogram.init(allocator, io, "zeam_node_mutex_hold_time_seconds", .{ .help = "Time BeamNode.mutex was held, labeled by callsite (LEGACY — double-emitted from per-resource locks; will be removed after one release)." }, .{}),
@@ -797,6 +816,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     zeam_xev_clock_until_done_drain_seconds.context = @ptrCast(&metrics.zeam_xev_clock_until_done_drain_seconds);
     zeam_fork_choice_tick_interval_duration_seconds.context = @ptrCast(&metrics.zeam_fork_choice_tick_interval_duration_seconds);
     zeam_node_aggregation_interval_tick_seconds.context = @ptrCast(&metrics.zeam_node_aggregation_interval_tick_seconds);
+    zeam_aggregate_worker_duration_seconds.context = @ptrCast(&metrics.zeam_aggregate_worker_duration_seconds);
     lean_pending_blocks_drain_iters.context = @ptrCast(&metrics.lean_pending_blocks_drain_iters);
     // Initialize sync status to idle at startup
     try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -255,6 +255,14 @@ pub const BeamChain = struct {
     root_to_slot_lock: zeam_utils.SyncMutex = .{},
     events_lock: zeam_utils.SyncMutex = .{},
 
+    /// Dedicated Io.Threaded for the aggregate FFI worker (issue #873).
+    /// `concurrent_limit = .limited(1)` enforces at most one in-flight
+    /// aggregate task; a second submit returns `error.ConcurrencyUnavailable`.
+    aggregate_io: *std.Io.Threaded,
+
+    /// Long-lived group hosting submitted aggregate tasks.
+    aggregate_group: std.Io.Group = .init,
+
     /// Optional chain-worker thread (slice c-2b commit 3 of #803).
     /// When non-null, `BeamChain` exposes the `submit*` family of
     /// methods which enqueue work onto the worker's queues; the
@@ -307,6 +315,16 @@ pub const BeamChain = struct {
         errdefer anchor_rc.release();
         try states.put(fork_choice.head.blockRoot, anchor_rc);
 
+        // Issue #873: dedicated Io.Threaded for aggregate FFI worker.
+        // concurrent_limit = .limited(1) ensures at most one in-flight aggregate task.
+        const agg_io = try allocator.create(std.Io.Threaded);
+        errdefer allocator.destroy(agg_io);
+        agg_io.* = std.Io.Threaded.init(allocator, .{
+            .async_limit = .nothing,
+            .concurrent_limit = .limited(1),
+        });
+        errdefer agg_io.deinit();
+
         var chain = Self{
             .nodeId = opts.nodeId,
             .config = opts.config,
@@ -346,6 +364,9 @@ pub const BeamChain = struct {
             // at its final heap location), so the worker's ctx pointer
             // remains stable for its entire lifetime.
             .chain_worker = null,
+            // aggregate_io: dedicated Io.Threaded for aggregate FFI worker (issue #873).
+            .aggregate_io = agg_io,
+            .aggregate_group = .init,
         };
         // Initialize cache with anchor block root and any post-finalized entries from state
         try chain.root_to_slot_cache.put(fork_choice.head.blockRoot, opts.anchorState.slot);
@@ -643,6 +664,10 @@ pub const BeamChain = struct {
         // never called.)
         self.stopChainStateRefcountObserver();
 
+        // Issue #873: wait for any in-flight aggregate worker before
+        // tearing down chain state it references.
+        self.aggregate_group.cancel(self.aggregate_io.io());
+
         // Stop and free the chain-worker FIRST (before any chain
         // state the worker's handler thunks may touch is freed).
         // `stop()` is idempotent and joins the worker thread; after
@@ -654,6 +679,11 @@ pub const BeamChain = struct {
             self.allocator.destroy(w);
             self.chain_worker = null;
         }
+
+        // Issue #873: tear down aggregate worker pool after chain_worker
+        // is stopped and aggregate_group is cancelled.
+        self.aggregate_io.deinit();
+        self.allocator.destroy(self.aggregate_io);
 
         // Clean up forkchoice resources (attestation_signatures, aggregated_payloads)
         self.forkChoice.deinit();
@@ -3301,26 +3331,28 @@ pub const BeamChain = struct {
         return self.forkChoice.aggregate(snapshot);
     }
 
-    pub fn maybeAggregateOnInterval(self: *Self, time_intervals: usize) !?[]types.SignedAggregatedAttestation {
+    /// Submit aggregate work to the dedicated Io.Threaded worker (issue #873).
+    /// Returns within microseconds; the worker calls `publishProducedAggregations`
+    /// itself. If the previous aggregate is still in-flight, the submit is
+    /// skipped and the skip metric is incremented.
+    pub fn submitAggregateOnInterval(self: *Self, node: *@import("./node.zig").BeamNode, time_intervals: usize) void {
         const slot = @divFloor(time_intervals, constants.INTERVALS_PER_SLOT);
-        if (!self.is_aggregator_enabled.load(.acquire) or self.registered_validator_ids.len == 0) return null;
+        if (!self.is_aggregator_enabled.load(.acquire) or self.registered_validator_ids.len == 0) {
+            zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_aggregator" }) catch {};
+            return;
+        }
 
         const sync_status = self.getSyncStatus();
         switch (sync_status) {
             .synced => {},
             .fc_initing => {
                 self.logger.warn("skipping aggregation production for slot={d}: forkchoice initializing", .{slot});
-                return null;
+                zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_synced" }) catch {};
+                return;
             },
             .no_peers => {
                 // Aggregate even with no peers: local fork-choice benefits from aggregated
                 // attestation weight, and aggregates will propagate once peers connect.
-                // Consistent with proposer and attester which also proceed through .no_peers.
-                //
-                // No double-counting: aggregate() maps per-AttestationData key, replacing
-                // raw attestations with their aggregate. Fork-choice counts each
-                // AttestationData key once regardless of whether the raw or aggregated
-                // form arrived first.
                 self.logger.info("aggregating for slot={d} with no peers (local only)", .{slot});
             },
             .behind_peers => |info| {
@@ -3330,21 +3362,58 @@ pub const BeamChain = struct {
                     info.finalized_slot,
                     info.max_peer_finalized_slot,
                 });
-                return null;
+                zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_synced" }) catch {};
+                return;
             },
         }
 
-        const aggregations = self.aggregate() catch |err| {
-            self.logger.warn("failed to aggregate attestation signatures for slot={d}: {any}", .{ slot, err });
-            return null;
+        // Snapshot state on the caller's thread (fast path).
+        const head_root = self.forkChoice.getHead().blockRoot;
+        var borrow = self.statesGet(head_root) orelse {
+            self.logger.warn("skipping aggregation for slot={d}: missing state for head root", .{slot});
+            zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "missing_state" }) catch {};
+            return;
+        };
+        defer borrow.assertReleasedOrPanic();
+        const snapshot = borrow.cloneAndRelease(self.allocator) catch |err| {
+            self.logger.warn("failed to clone state for aggregation at slot={d}: {any}", .{ slot, err });
+            return;
         };
 
-        if (aggregations.len == 0) {
-            self.allocator.free(aggregations);
-            return null;
+        // Submit to the dedicated aggregate worker. concurrent_limit=1
+        // ensures at most one in-flight task.
+        self.aggregate_group.concurrent(self.aggregate_io.io(), aggregateImpl, .{ self, node, snapshot, slot }) catch |err| switch (err) {
+            error.ConcurrencyUnavailable => {
+                self.logger.info("skipping aggregation for slot={d}: previous aggregate still in-flight", .{slot});
+                zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "in_flight" }) catch {};
+                // Free the snapshot we just cloned — the worker won't run.
+                snapshot.deinit();
+                self.allocator.destroy(snapshot);
+                return;
+            },
+        };
+    }
+
+    /// Worker body for the aggregate FFI (runs on `aggregate_io` thread).
+    /// Owns `snapshot` and frees it on exit.
+    fn aggregateImpl(chain: *Self, node: *@import("./node.zig").BeamNode, snapshot: *types.BeamState, slot: usize) void {
+        const worker_timer = zeam_metrics.zeam_aggregate_worker_duration_seconds.start();
+        defer _ = worker_timer.observe();
+
+        defer {
+            snapshot.deinit();
+            chain.allocator.destroy(snapshot);
         }
 
-        return aggregations;
+        const aggregations = chain.forkChoice.aggregate(snapshot) catch |err| {
+            chain.logger.warn("failed to aggregate attestation signatures for slot={d}: {any}", .{ slot, err });
+            return;
+        };
+        defer chain.allocator.free(aggregations);
+
+        if (aggregations.len == 0) return;
+
+        node.publishProducedAggregations(aggregations);
     }
 
     pub fn getStatus(self: *Self) types.Status {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1734,23 +1734,16 @@ pub const BeamNode = struct {
             if (interval_in_slot == 2) {
                 const agg_timer = zeam_metrics.zeam_node_aggregation_interval_tick_seconds.start();
                 defer _ = agg_timer.observe();
-                // Aggregation failure must not stall the interval cursor.
+                // Issue #873: aggregate work is submitted to a dedicated Io.Threaded
+                // worker. submitAggregateOnInterval returns within microseconds;
+                // the worker calls publishProducedAggregations itself.
                 if (self.test_inject_aggregator_error_at_intervals.len > 0 and
                     std.mem.indexOfScalar(usize, self.test_inject_aggregator_error_at_intervals, interval) != null)
                 {
                     self.logger.err("error producing aggregations at slot={d} interval={d}: {any} (continuing tick)", .{ slot, interval, error.TestInjected });
                     zeam_metrics.metrics.lean_node_interval_error_total.incr(.{ .site = "maybeAggregateOnInterval" }) catch |me| self.logger.warn("metric incr failed: {any}", .{me});
                 } else {
-                    const maybe_aggregations = self.chain.maybeAggregateOnInterval(interval) catch |e| blk: {
-                        self.logger.err("error producing aggregations at slot={d} interval={d}: {any} (continuing tick)", .{ slot, interval, e });
-                        zeam_metrics.metrics.lean_node_interval_error_total.incr(.{ .site = "maybeAggregateOnInterval" }) catch |me| self.logger.warn("metric incr failed: {any}", .{me});
-                        break :blk null;
-                    };
-                    if (maybe_aggregations) |aggregations| {
-                        defer self.allocator.free(aggregations);
-                        // Try every aggregation; `publishProducedAggregations` owns deinit.
-                        self.publishProducedAggregations(aggregations);
-                    }
+                    self.chain.submitAggregateOnInterval(self, interval);
                 }
             }
         }
@@ -1981,7 +1974,7 @@ pub const BeamNode = struct {
     }
 
     /// Publish every aggregation independently; deinit each entry exactly once.
-    fn publishProducedAggregations(self: *Self, aggregations: []types.SignedAggregatedAttestation) void {
+    pub fn publishProducedAggregations(self: *Self, aggregations: []types.SignedAggregatedAttestation) void {
         for (aggregations) |*signed_aggregation| {
             self.publishAggregation(signed_aggregation.*) catch |err| {
                 self.logger.err(

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -166,19 +166,16 @@ pub fn verifySignatures(
     try xmss.verifySsz(proposal_pubkey, &block_root, block_epoch, &signed_block.signature.proposer_signature);
 }
 
-// Parallel version of verifySignatures using a work-stealing thread pool.
+// Parallel version of verifySignatures.
 //
 // Phase 1 (serial): validates indices, warms pubkey_cache, and computes attestation-data
 // message hashes — all work that touches the non-thread-safe PublicKeyCache or may short-circuit
 // on structural errors. Produces a list of prepared tasks.
 //
-// Phase 2 (parallel): pool.scope spawns one XMSS aggregated-signature verification per task.
-// Tasks check any_err_flag before starting to mimic the serial short-circuit; the first error
-// raised is the one returned. Proposer signature is verified serially at the end (single sig —
-// not worth spawning).
-//
-// `thread_pool` is taken as anytype so state-transition itself does not have to import
-// @zeam/thread-pool — that module is host-only and can't be built for zkVM targets.
+// Phase 2 (parallel): hands the prepared batch to Rust so XMSS verification runs on the same
+// capped rayon pool as recursive aggregation. `thread_pool` is intentionally unused here; it is
+// kept in the signature so call sites do not need a separate serial/parallel dispatch surface.
+// Proposer signature is verified serially at the end (single sig — not worth batching).
 pub fn verifySignaturesParallel(
     allocator: Allocator,
     state: *const types.BeamState,
@@ -194,21 +191,7 @@ pub fn verifySignaturesParallel(
     }
 
     const validators = state.validators.constSlice();
-
-    const VerifyTask = struct {
-        signature_proof: *const types.AggregatedSignatureProof,
-        public_keys: []*const xmss.HashSigPublicKey,
-        message_hash: [32]u8,
-        epoch: u64,
-        // Per-task elapsed time (nanoseconds) measured inside the worker. We
-        // record this so the post-pool emit can call `observe()` once per
-        // attestation, matching the granularity of the serial path. Without
-        // per-task timing the histogram would receive one batch sample per
-        // block and percentiles would diverge from the serial baseline.
-        elapsed_ns: u64 = 0,
-        result: ?anyerror = null,
-        verified: bool = false,
-    };
+    _ = thread_pool;
 
     // All per-task scratch (pubkey handle arrays, pubkey_wrappers when cache is absent)
     // lives in this arena and is freed with one call after the parallel phase returns.
@@ -225,7 +208,7 @@ pub fn verifySignaturesParallel(
         for (pubkey_wrappers.items) |*wrapper| wrapper.deinit();
     };
 
-    const tasks = try scratch_alloc.alloc(VerifyTask, attestations.len);
+    const tasks = try scratch_alloc.alloc(xmss.AggregatedPayloadVerifyBatch, attestations.len);
 
     // -------- Phase 1: serial pre-warm --------
     for (attestations, signature_proofs, 0..) |aggregated_attestation, *signature_proof, i| {
@@ -271,58 +254,28 @@ pub fn verifySignaturesParallel(
         try zeam_utils.hashTreeRoot(types.AttestationData, aggregated_attestation.data, &message_hash, allocator);
 
         tasks[i] = .{
-            .signature_proof = signature_proof,
             .public_keys = public_keys,
             .message_hash = message_hash,
-            .epoch = aggregated_attestation.data.slot,
+            .epoch = @intCast(aggregated_attestation.data.slot),
+            .agg_sig = &signature_proof.proof_data,
         };
     }
 
-    // -------- Phase 2: parallel verify --------
-    const Runner = struct {
-        fn runScope(scope: anytype, task_slice: []VerifyTask, err_flag: *std.atomic.Value(bool)) Allocator.Error!void {
-            for (task_slice) |*task| {
-                try scope.spawn(runOne, .{ task, err_flag });
-            }
-        }
-
-        fn runOne(task: *VerifyTask, err_flag: *std.atomic.Value(bool)) void {
-            if (err_flag.load(.acquire)) return;
-            task.verified = true;
-            // Time the FFI verify call with a monotonic clock so samples stay
-            // non-negative even if wall clock time is adjusted.
-            const start_ns = zeam_utils.monotonicTimestampNs();
-            task.signature_proof.verify(task.public_keys, &task.message_hash, task.epoch) catch |err| {
-                const end_ns = zeam_utils.monotonicTimestampNs();
-                task.elapsed_ns = if (end_ns >= start_ns) @intCast(end_ns - start_ns) else 0;
-                task.result = err;
-                err_flag.store(true, .release);
-                return;
-            };
-            const end_ns = zeam_utils.monotonicTimestampNs();
-            task.elapsed_ns = if (end_ns >= start_ns) @intCast(end_ns - start_ns) else 0;
-        }
-    };
-
-    var any_err = std.atomic.Value(bool).init(false);
-    try thread_pool.scope(Runner.runScope, .{ tasks, &any_err });
-
-    // Emit one histogram sample per verified task so the parallel path's
-    // percentiles match the serial path (which observes once per
-    // attestation). Mixing the two granularities into the same histogram
-    // would silently distort P50/P99 across deployments.
-    for (tasks) |*task| {
-        if (!task.verified) continue;
-        const elapsed_s: f32 = @as(f32, @floatFromInt(task.elapsed_ns)) / std.time.ns_per_s;
+    // -------- Phase 2: rayon batch verify --------
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    xmss.verifyAggregatedPayloadBatch(scratch_alloc, tasks) catch |err| {
+        const end_ns = zeam_utils.monotonicTimestampNs();
+        const elapsed_s: f32 = @as(f32, @floatFromInt(if (end_ns >= start_ns) end_ns - start_ns else 0)) / std.time.ns_per_s;
         zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(elapsed_s);
-        if (task.result) |_| {
-            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_invalid_total.incr();
-        } else {
-            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_valid_total.incr();
-        }
-    }
-    for (tasks) |*task| {
-        if (task.result) |err| return err;
+        zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_invalid_total.incr();
+        return err;
+    };
+    const end_ns = zeam_utils.monotonicTimestampNs();
+    const elapsed_s: f32 = @as(f32, @floatFromInt(if (end_ns >= start_ns) end_ns - start_ns else 0)) / std.time.ns_per_s;
+    const per_task_elapsed_s = if (tasks.len > 0) elapsed_s / @as(f32, @floatFromInt(tasks.len)) else 0;
+    for (tasks) |_| {
+        zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(per_task_elapsed_s);
+        zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_valid_total.incr();
     }
 
     // Proposer signature — single verify, do it serially.

--- a/pkgs/xmss/src/aggregation.zig
+++ b/pkgs/xmss/src/aggregation.zig
@@ -49,6 +49,17 @@ extern fn xmss_verify_aggregated(
     slot: u32,
 ) callconv(.c) bool;
 
+extern fn xmss_verify_aggregated_batch(
+    public_key_offsets: [*]const usize,
+    public_key_counts: [*]const usize,
+    num_tasks: usize,
+    public_keys: [*]const *const hashsig.HashSigPublicKey,
+    message_hashes: [*]const u8,
+    agg_sig_ptrs: [*]const [*]const u8,
+    agg_sig_lens: [*]const usize,
+    slots: [*]const u32,
+) callconv(.c) bool;
+
 extern fn xmss_free_aggregate_signature(agg_sig: *AggregatedXMSS) callconv(.c) void;
 
 // Serialization FFI functions
@@ -197,6 +208,64 @@ pub fn verifyAggregatedPayload(public_keys: []*const hashsig.HashSigPublicKey, m
         epoch,
     );
 
+    if (!result) return AggregationError.InvalidAggregateSignature;
+}
+
+pub const AggregatedPayloadVerifyBatch = struct {
+    public_keys: []*const hashsig.HashSigPublicKey,
+    message_hash: [32]u8,
+    epoch: u32,
+    agg_sig: *const ByteListMiB,
+};
+
+pub fn verifyAggregatedPayloadBatch(allocator: std.mem.Allocator, tasks: []const AggregatedPayloadVerifyBatch) !void {
+    if (tasks.len == 0) return;
+
+    try setupVerifier();
+
+    var total_keys: usize = 0;
+    for (tasks) |task| total_keys += task.public_keys.len;
+
+    const offsets = try allocator.alloc(usize, tasks.len);
+    defer allocator.free(offsets);
+    const counts = try allocator.alloc(usize, tasks.len);
+    defer allocator.free(counts);
+    const all_public_keys = try allocator.alloc(*const hashsig.HashSigPublicKey, total_keys);
+    defer allocator.free(all_public_keys);
+    const message_hashes = try allocator.alloc(u8, tasks.len * 32);
+    defer allocator.free(message_hashes);
+    const sig_ptrs = try allocator.alloc([*]const u8, tasks.len);
+    defer allocator.free(sig_ptrs);
+    const sig_lens = try allocator.alloc(usize, tasks.len);
+    defer allocator.free(sig_lens);
+    const slots = try allocator.alloc(u32, tasks.len);
+    defer allocator.free(slots);
+
+    var key_offset: usize = 0;
+    for (tasks, 0..) |task, i| {
+        offsets[i] = key_offset;
+        counts[i] = task.public_keys.len;
+        for (task.public_keys, 0..) |public_key, j| {
+            all_public_keys[key_offset + j] = public_key;
+        }
+        key_offset += task.public_keys.len;
+        @memcpy(message_hashes[i * 32 .. (i + 1) * 32], &task.message_hash);
+        const sig_bytes = task.agg_sig.constSlice();
+        sig_ptrs[i] = sig_bytes.ptr;
+        sig_lens[i] = sig_bytes.len;
+        slots[i] = task.epoch;
+    }
+
+    const result = xmss_verify_aggregated_batch(
+        offsets.ptr,
+        counts.ptr,
+        tasks.len,
+        all_public_keys.ptr,
+        message_hashes.ptr,
+        sig_ptrs.ptr,
+        sig_lens.ptr,
+        slots.ptr,
+    );
     if (!result) return AggregationError.InvalidAggregateSignature;
 }
 

--- a/pkgs/xmss/src/aggregation.zig
+++ b/pkgs/xmss/src/aggregation.zig
@@ -18,6 +18,10 @@ pub const AggregatedXMSS = opaque {};
 extern fn xmss_setup_prover() callconv(.c) c_int;
 /// Returns 0 on success, -1 on failure.
 extern fn xmss_setup_verifier() callconv(.c) c_int;
+/// Configure the global rayon thread pool. Must be called before xmss_setup_prover.
+/// num_threads=0 means use rayon default (one per logical CPU).
+/// Returns 0 always (errors from an already-initialized pool are silently ignored).
+extern fn xmss_set_rayon_threads(num_threads: usize) callconv(.c) c_int;
 
 extern fn xmss_aggregate(
     // Raw XMSS signatures
@@ -58,6 +62,16 @@ extern fn xmss_aggregate_signature_from_bytes(
     bytes: [*]const u8,
     bytes_len: usize,
 ) callconv(.c) ?*AggregatedXMSS;
+
+/// Configure the global rayon thread pool used by the XMSS aggregate prover.
+/// Must be called before `setupProver` and before any aggregation work begins.
+/// `num_threads = 0` means "use rayon's default" (one thread per logical CPU).
+/// Typical usage: pass `cpu_count - 3` to reserve cores for libxev, the chain
+/// worker, and the rust-libp2p network thread (see issue #873).
+/// Silently no-ops if the pool is already initialized.
+pub fn setRayonThreads(num_threads: usize) void {
+    _ = xmss_set_rayon_threads(num_threads);
+}
 
 /// Initialize the XMSS prover (idempotent — only runs once).
 /// Returns error.ProverSetupFailed when the prover bytecode file is missing or the

--- a/pkgs/xmss/src/lib.zig
+++ b/pkgs/xmss/src/lib.zig
@@ -5,6 +5,7 @@ const aggregate = @import("aggregation.zig");
 pub const MAX_AGGREGATE_SIGNATURE_SIZE = aggregate.MAX_AGGREGATE_SIGNATURE_SIZE;
 pub const ByteListMiB = aggregate.ByteListMiB;
 pub const AggregationError = aggregate.AggregationError;
+pub const setRayonThreads = aggregate.setRayonThreads;
 pub const setupProver = aggregate.setupProver;
 pub const setupVerifier = aggregate.setupVerifier;
 pub const aggregateSignatures = aggregate.aggregateSignatures;

--- a/pkgs/xmss/src/lib.zig
+++ b/pkgs/xmss/src/lib.zig
@@ -10,6 +10,8 @@ pub const setupProver = aggregate.setupProver;
 pub const setupVerifier = aggregate.setupVerifier;
 pub const aggregateSignatures = aggregate.aggregateSignatures;
 pub const verifyAggregatedPayload = aggregate.verifyAggregatedPayload;
+pub const verifyAggregatedPayloadBatch = aggregate.verifyAggregatedPayloadBatch;
+pub const AggregatedPayloadVerifyBatch = aggregate.AggregatedPayloadVerifyBatch;
 pub const aggregate_module = aggregate;
 
 const hashsig = @import("hashsig.zig");

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4268,6 +4268,7 @@ version = "0.1.0"
 dependencies = [
  "backend",
  "leansig_wrapper",
+ "rayon",
  "rec_aggregation",
 ]
 

--- a/rust/multisig-glue/Cargo.toml
+++ b/rust/multisig-glue/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
 leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
 backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
+rayon = "1"
 
 [lib]
 # Built as an rlib so its `#[no_mangle] pub extern "C"` symbols can be funnelled

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -1,4 +1,5 @@
 use leansig_wrapper::{XmssPublicKey, XmssSignature};
+use rayon::prelude::*;
 use rec_aggregation::{
     init_aggregation_bytecode, xmss_aggregate as rec_xmss_aggregate, xmss_verify_aggregation,
     AggregatedXMSS,
@@ -237,6 +238,110 @@ pub unsafe extern "C" fn xmss_verify_aggregated(
     }
 
     xmss_verify_aggregation(pub_keys, &agg_sig, message_hash, slot).is_ok()
+}
+
+/// Verify multiple aggregated signatures on the configured rayon pool.
+/// Returns true only if every task is valid.
+///
+/// # Safety
+/// - `public_key_offsets` and `public_key_counts` must contain `num_tasks` elements.
+/// - `public_keys` must contain all task public-key pointers flattened together.
+/// - `message_hashes` must contain `num_tasks * 32` bytes.
+/// - `agg_sig_ptrs`, `agg_sig_lens`, and `slots` must contain `num_tasks` elements.
+#[no_mangle]
+pub unsafe extern "C" fn xmss_verify_aggregated_batch(
+    public_key_offsets: *const usize,
+    public_key_counts: *const usize,
+    num_tasks: usize,
+    public_keys: *const *const PublicKey,
+    message_hashes: *const u8,
+    agg_sig_ptrs: *const *const u8,
+    agg_sig_lens: *const usize,
+    slots: *const u32,
+) -> bool {
+    if num_tasks == 0 {
+        return true;
+    }
+    if public_key_offsets.is_null()
+        || public_key_counts.is_null()
+        || public_keys.is_null()
+        || message_hashes.is_null()
+        || agg_sig_ptrs.is_null()
+        || agg_sig_lens.is_null()
+        || slots.is_null()
+    {
+        return false;
+    }
+
+    let offsets = slice::from_raw_parts(public_key_offsets, num_tasks);
+    let counts = slice::from_raw_parts(public_key_counts, num_tasks);
+    let total_keys = match offsets
+        .iter()
+        .zip(counts.iter())
+        .map(|(offset, count)| offset.checked_add(*count))
+        .collect::<Option<Vec<usize>>>()
+    {
+        Some(ends) => ends.into_iter().max().unwrap_or(0),
+        None => return false,
+    };
+    let key_ptrs = slice::from_raw_parts(public_keys, total_keys);
+    let hashes = slice::from_raw_parts(message_hashes, num_tasks * 32);
+    let sig_ptrs = slice::from_raw_parts(agg_sig_ptrs, num_tasks);
+    let sig_lens = slice::from_raw_parts(agg_sig_lens, num_tasks);
+    let task_slots = slice::from_raw_parts(slots, num_tasks);
+
+    struct VerifyTask {
+        public_keys: Vec<usize>,
+        message_hash: [u8; 32],
+        sig_ptr: usize,
+        sig_len: usize,
+        slot: u32,
+    }
+
+    let mut tasks: Vec<VerifyTask> = Vec::with_capacity(num_tasks);
+    for i in 0..num_tasks {
+        let start = offsets[i];
+        let end = match start.checked_add(counts[i]) {
+            Some(end) if end <= key_ptrs.len() => end,
+            _ => return false,
+        };
+        let message_hash: [u8; 32] = match hashes[i * 32..(i + 1) * 32].try_into() {
+            Ok(hash) => hash,
+            Err(_) => return false,
+        };
+        if sig_ptrs[i].is_null() || sig_lens[i] == 0 {
+            return false;
+        }
+        tasks.push(VerifyTask {
+            public_keys: key_ptrs[start..end]
+                .iter()
+                .map(|ptr| *ptr as usize)
+                .collect(),
+            message_hash,
+            sig_ptr: sig_ptrs[i] as usize,
+            sig_len: sig_lens[i],
+            slot: task_slots[i],
+        });
+    }
+
+    tasks.par_iter().all(|task| {
+        let sig_bytes = slice::from_raw_parts(task.sig_ptr as *const u8, task.sig_len);
+        let agg_sig = match AggregatedXMSS::deserialize(sig_bytes) {
+            Some(sig) => sig,
+            None => return false,
+        };
+
+        let mut pub_keys: Vec<XmssPublicKey> = Vec::with_capacity(task.public_keys.len());
+        for &pk_ptr in &task.public_keys {
+            let pk_ptr = pk_ptr as *const PublicKey;
+            if pk_ptr.is_null() {
+                return false;
+            }
+            pub_keys.push((*pk_ptr).inner.clone());
+        }
+
+        xmss_verify_aggregation(pub_keys, &agg_sig, &task.message_hash, task.slot).is_ok()
+    })
 }
 
 /// Serialize an AggregatedXMSS to bytes (postcard + lz4).

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -302,3 +302,27 @@ pub unsafe extern "C" fn xmss_free_aggregate_signature(agg_sig: *mut AggregatedX
         drop(Box::from_raw(agg_sig));
     }
 }
+
+/// Configure the global rayon thread pool used by the XMSS aggregate prover.
+///
+/// Must be called **before** `xmss_setup_prover` and before any aggregation work
+/// begins. The rayon global pool can only be configured once; subsequent calls
+/// are silently ignored (rayon returns `ThreadPoolBuildError` which we discard).
+///
+/// `num_threads = 0` means "use rayon's default" (one thread per logical CPU).
+/// Typical caller: set to `cpu_count - 3` to reserve cores for libxev, the
+/// chain worker, and the rust-libp2p network thread (issue #873 comment).
+///
+/// Returns 0 on success or if the pool was already initialized, -1 on build error.
+#[no_mangle]
+pub extern "C" fn xmss_set_rayon_threads(num_threads: usize) -> i32 {
+    match rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build_global()
+    {
+        Ok(()) => 0,
+        // ThreadPoolBuildError is returned when the global pool was already
+        // initialized — that's fine, treat it as success.
+        Err(_) => 0,
+    }
+}


### PR DESCRIPTION
Closes #873

## Summary

Move the XMSS recursive-aggregation FFI call off the libxev main thread to a dedicated `std.Io.Threaded` worker. The `xmss_aggregate` FFI takes 1–5 s; running it synchronously on the libxev event loop blocked slot ticks and network completions, causing the spikes observed in issue #867.

## Changes

### `pkgs/node/src/chain.zig`
- Add `aggregate_io: *std.Io.Threaded` and `aggregate_group: std.Io.Group` fields (dedicated worker, `concurrent_limit = .limited(1)`)
- Init `aggregate_io` in `BeamChain.init` with `async_limit = .nothing, concurrent_limit = .limited(1)`
- Deinit order in `BeamChain.deinit`: `aggregate_group.cancel` → `chain_worker.stop` → `aggregate_io.deinit`
- Replace `maybeAggregateOnInterval` + caller-side publish with `submitAggregateOnInterval` (returns in microseconds)
- New `aggregateImpl` worker: runs on the dedicated thread, owns the snapshot, calls `forkChoice.aggregate`, then `node.publishProducedAggregations`
- `ConcurrencyUnavailable` (previous task in-flight): skip with metric, free snapshot immediately

### `pkgs/node/src/node.zig`
- At `interval_in_slot == 2`: replace old pattern with `self.chain.submitAggregateOnInterval(self, interval)`
- Promote `publishProducedAggregations` to `pub`

### `pkgs/metrics/src/lib.zig`
- New `zeam_aggregate_skip_total{reason}` counter (reasons: `in_flight`, `not_aggregator`, `not_synced`, `missing_state`)
- New `zeam_aggregate_worker_duration_seconds` histogram

## Testing
- `zig build` ✅
- `zig build test` ✅