### PR TITLE
fix(types): clone participants bitlist when building aggregation bits

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2448,7 +2448,7 @@ pub const BeamChain = struct {
                 var participant_indices: std.ArrayList(usize) = try types.aggregationBitsToValidatorIndices(&signature_proof.participants, self.allocator);
                 defer participant_indices.deinit(self.allocator);
 
-                if (validator_indices.items.len != participant_indices.items.len) {
+                if (validator_indices.items.len != participant_indices.items.len or !std.mem.eql(usize, validator_indices.items, participant_indices.items)) {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
                     self.logger.err(
                         "attestation signature mismatch index={d} validators={d} participants={d}",

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1071,12 +1071,12 @@ pub const ForkChoice = struct {
                     try types.sszClone(self.allocator, types.AggregatedSignatureProof, best_proof.?.*, &cloned_proof);
                     errdefer cloned_proof.deinit();
 
-                    var att_bits = try types.AggregationBits.init(self.allocator);
+                    var att_bits: types.AggregationBits = undefined;
+                    try types.sszClone(self.allocator, types.AggregationBits, cloned_proof.participants, &att_bits);
                     errdefer att_bits.deinit();
 
                     for (0..cloned_proof.participants.len()) |i| {
                         if (cloned_proof.participants.get(i) catch false) {
-                            try types.aggregationBitsSet(&att_bits, i, true);
                             if (i >= covered.capacity()) {
                                 try covered.resize(i + 1, false);
                             }

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1117,13 +1117,9 @@ pub const ForkChoice = struct {
             }
 
             for (agg_attestations.constSlice()) |agg_att| {
-                var cloned_bits = try types.AggregationBits.init(self.allocator);
+                var cloned_bits: types.AggregationBits = undefined;
+                try types.sszClone(self.allocator, types.AggregationBits, agg_att.aggregation_bits, &cloned_bits);
                 errdefer cloned_bits.deinit();
-                for (0..agg_att.aggregation_bits.len()) |i| {
-                    if (agg_att.aggregation_bits.get(i) catch false) {
-                        try types.aggregationBitsSet(&cloned_bits, i, true);
-                    }
-                }
                 try candidate_atts.append(.{ .aggregation_bits = cloned_bits, .data = agg_att.data });
             }
 

--- a/pkgs/spectest/src/runner/fork_choice_runner.zig
+++ b/pkgs/spectest/src/runner/fork_choice_runner.zig
@@ -781,18 +781,16 @@ fn processBlockStep(
         };
         defer proof_template.deinit();
 
-        const bits_len = aggregated_attestation.aggregation_bits.len();
-        for (0..bits_len) |i| {
-            if (aggregated_attestation.aggregation_bits.get(i) catch false) {
-                types.aggregationBitsSet(&proof_template.participants, i, true) catch |err| {
-                    std.debug.print(
-                        "fixture {s} case {s}{f}: failed to set aggregation bit ({s})\n",
-                        .{ fixture_path, case_name, formatStep(step_index), @errorName(err) },
-                    );
-                    return FixtureError.InvalidFixture;
-                };
-            }
-        }
+        var cloned_bits: types.AggregationBits = undefined;
+        types.sszClone(ctx.allocator, types.AggregationBits, aggregated_attestation.aggregation_bits, &cloned_bits) catch |err| {
+            std.debug.print(
+                "fixture {s} case {s}{f}: failed to clone aggregation bits ({s})\n",
+                .{ fixture_path, case_name, formatStep(step_index), @errorName(err) },
+            );
+            return FixtureError.InvalidFixture;
+        };
+        proof_template.participants.deinit();
+        proof_template.participants = cloned_bits;
 
         var validator_ids = ctx.allocator.alloc(types.ValidatorIndex, indices.items.len) catch |err| {
             std.debug.print(
@@ -1045,19 +1043,17 @@ fn processGossipAggregatedAttestationStep(
     };
     defer proof.deinit();
 
-    // Copy participant bits into proof.
-    const bits_len = aggregation_bits.len();
-    for (0..bits_len) |i| {
-        if (aggregation_bits.get(i) catch false) {
-            types.aggregationBitsSet(&proof.participants, i, true) catch |err| {
-                std.debug.print(
-                    "fixture {s} case {s}{f}: failed to set aggregation bit ({s})\n",
-                    .{ fixture_path, case_name, formatStep(step_index), @errorName(err) },
-                );
-                return FixtureError.InvalidFixture;
-            };
-        }
-    }
+    // Clone participant bits into proof.
+    var cloned_bits: types.AggregationBits = undefined;
+    types.sszClone(ctx.allocator, types.AggregationBits, aggregation_bits, &cloned_bits) catch |err| {
+        std.debug.print(
+            "fixture {s} case {s}{f}: failed to clone aggregation bits ({s})\n",
+            .{ fixture_path, case_name, formatStep(step_index), @errorName(err) },
+        );
+        return FixtureError.InvalidFixture;
+    };
+    proof.participants.deinit();
+    proof.participants = cloned_bits;
 
     ctx.fork_choice.storeAggregatedPayload(&attestation_data, proof, false) catch |err| {
         std.debug.print(

--- a/pkgs/state-transition/src/mock.zig
+++ b/pkgs/state-transition/src/mock.zig
@@ -307,13 +307,9 @@ pub fn genMockChain(allocator: Allocator, numBlocks: usize, from_genesis: ?types
             errdefer proof.deinit();
 
             // Clone participants for the attestation entry
-            var att_bits = try types.AggregationBits.init(allocator);
+            var att_bits: types.AggregationBits = undefined;
+            try types.sszClone(allocator, types.AggregationBits, proof.participants, &att_bits);
             errdefer att_bits.deinit();
-            for (0..proof.participants.len()) |i| {
-                if (proof.participants.get(i) catch false) {
-                    try types.aggregationBitsSet(&att_bits, i, true);
-                }
-            }
 
             try agg_attestations.append(.{ .aggregation_bits = att_bits, .data = att_data });
             try agg_signatures.append(proof);

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -1399,3 +1399,71 @@ test "encode decode signed block with non-empty attestation signatures" {
     const decoded_group = try decoded.signature.attestation_signatures.get(0);
     try std.testing.expect(decoded_group.participants.len() == 2);
 }
+
+// Regression: an AggregatedSignatureProof whose `participants` bitlist
+// has trailing zero bits (i.e., len() > highest_set_bit + 1) must still
+// produce an `aggregation_bits` that is byte-for-byte identical to
+// `participants`. Rebuilding `aggregation_bits` by re-setting only the
+// TRUE indices would shrink it to highest_set_bit + 1, changing its SSZ
+// encoding and causing other clients (e.g. ethlambda) to reject the
+// block with a ParticipantsMismatch error.
+test "compactSingleProof: aggregation_bits matches participants when participants has trailing zeros" {
+    const allocator = std.testing.allocator;
+
+    var proof = try aggregation.AggregatedSignatureProof.init(allocator);
+    defer proof.deinit();
+
+    // Force participants.len() == 6 with bits set only at {0, 2}.
+    // aggregationBitsSet(.., 5, false) extends to length 6 and leaves bit 5 clear.
+    try attestation.aggregationBitsSet(&proof.participants, 5, false);
+    try attestation.aggregationBitsSet(&proof.participants, 0, true);
+    try attestation.aggregationBitsSet(&proof.participants, 2, true);
+
+    try std.testing.expectEqual(@as(usize, 6), proof.participants.len());
+
+    const att_data = attestation.AttestationData{
+        .slot = 1,
+        .head = .{ .root = ZERO_HASH, .slot = 0 },
+        .target = .{ .root = ZERO_HASH, .slot = 0 },
+        .source = .{ .root = ZERO_HASH, .slot = 0 },
+    };
+
+    var result = try compactSingleProof(allocator, att_data, &proof);
+    defer {
+        result.attestation.deinit();
+        result.signature.deinit();
+    }
+
+    try std.testing.expectEqual(
+        result.signature.participants.len(),
+        result.attestation.aggregation_bits.len(),
+    );
+    for (0..result.signature.participants.len()) |i| {
+        try std.testing.expectEqual(
+            try result.signature.participants.get(i),
+            try result.attestation.aggregation_bits.get(i),
+        );
+    }
+
+    // SSZ-encoded forms must also be identical so cross-client strict
+    // equality checks pass.
+    var participants_bytes: std.ArrayList(u8) = .empty;
+    defer participants_bytes.deinit(allocator);
+    try ssz.serialize(
+        attestation.AggregationBits,
+        result.signature.participants,
+        &participants_bytes,
+        allocator,
+    );
+
+    var bits_bytes: std.ArrayList(u8) = .empty;
+    defer bits_bytes.deinit(allocator);
+    try ssz.serialize(
+        attestation.AggregationBits,
+        result.attestation.aggregation_bits,
+        &bits_bytes,
+        allocator,
+    );
+
+    try std.testing.expectEqualSlices(u8, participants_bytes.items, bits_bytes.items);
+}

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -633,14 +633,10 @@ pub const AggregatedAttestationsResult = struct {
             if (!has_gossip and selected_children.items.len == 1) {
                 const child = &selected_children.items[0];
 
-                // Create attestation bits from the child's participants
-                var att_bits: ?attestation.AggregationBits = try attestation.AggregationBits.init(allocator);
+                var att_bits_val: attestation.AggregationBits = undefined;
+                try utils.sszClone(allocator, attestation.AggregationBits, child.participants, &att_bits_val);
+                var att_bits: ?attestation.AggregationBits = att_bits_val;
                 defer if (att_bits) |*ab| ab.deinit();
-                for (0..child.participants.len()) |i| {
-                    if (child.participants.get(i) catch false) {
-                        try attestation.aggregationBitsSet(&att_bits.?, i, true);
-                    }
-                }
 
                 // Clone the child proof for the result (original will be freed by deferred cleanup)
                 var cloned_child: aggregation.AggregatedSignatureProof = undefined;
@@ -715,14 +711,10 @@ pub const AggregatedAttestationsResult = struct {
             if (xmss_participants) |*gp| gp.deinit();
             xmss_participants = null;
 
-            // Create attestation from the proof's merged participants
-            var att_bits: ?attestation.AggregationBits = try attestation.AggregationBits.init(allocator);
+            var att_bits_val: attestation.AggregationBits = undefined;
+            try utils.sszClone(allocator, attestation.AggregationBits, proof.participants, &att_bits_val);
+            var att_bits: ?attestation.AggregationBits = att_bits_val;
             defer if (att_bits) |*ab| ab.deinit();
-            for (0..proof.participants.len()) |i| {
-                if (proof.participants.get(i) catch false) {
-                    try attestation.aggregationBitsSet(&att_bits.?, i, true);
-                }
-            }
 
             try self.attestations.append(.{ .aggregation_bits = att_bits.?, .data = data });
             att_bits = null; // ownership transferred to self.attestations
@@ -859,13 +851,9 @@ fn compactSingleProof(
     try utils.sszClone(allocator, aggregation.AggregatedSignatureProof, sig.*, &cloned_proof);
     errdefer cloned_proof.deinit();
 
-    var att_bits = try attestation.AggregationBits.init(allocator);
+    var att_bits: attestation.AggregationBits = undefined;
+    try utils.sszClone(allocator, attestation.AggregationBits, cloned_proof.participants, &att_bits);
     errdefer att_bits.deinit();
-    for (0..cloned_proof.participants.len()) |i| {
-        if (cloned_proof.participants.get(i) catch false) {
-            try attestation.aggregationBitsSet(&att_bits, i, true);
-        }
-    }
 
     return .{
         .attestation = .{ .aggregation_bits = att_bits, .data = att_data },
@@ -911,13 +899,9 @@ fn compactMultiProofWithPrep(
         &proof,
     );
 
-    var att_bits = try attestation.AggregationBits.init(allocator);
+    var att_bits: attestation.AggregationBits = undefined;
+    try utils.sszClone(allocator, attestation.AggregationBits, proof.participants, &att_bits);
     errdefer att_bits.deinit();
-    for (0..proof.participants.len()) |i| {
-        if (proof.participants.get(i) catch false) {
-            try attestation.aggregationBitsSet(&att_bits, i, true);
-        }
-    }
 
     return .{
         .attestation = .{ .aggregation_bits = att_bits, .data = att_data },

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -633,10 +633,9 @@ pub const AggregatedAttestationsResult = struct {
             if (!has_gossip and selected_children.items.len == 1) {
                 const child = &selected_children.items[0];
 
-                var att_bits_val: attestation.AggregationBits = undefined;
-                try utils.sszClone(allocator, attestation.AggregationBits, child.participants, &att_bits_val);
-                var att_bits: ?attestation.AggregationBits = att_bits_val;
-                defer if (att_bits) |*ab| ab.deinit();
+                var att_bits: attestation.AggregationBits = undefined;
+                try utils.sszClone(allocator, attestation.AggregationBits, child.participants, &att_bits);
+                defer att_bits.deinit();
 
                 // Clone the child proof for the result (original will be freed by deferred cleanup)
                 var cloned_child: aggregation.AggregatedSignatureProof = undefined;
@@ -711,10 +710,9 @@ pub const AggregatedAttestationsResult = struct {
             if (xmss_participants) |*gp| gp.deinit();
             xmss_participants = null;
 
-            var att_bits_val: attestation.AggregationBits = undefined;
-            try utils.sszClone(allocator, attestation.AggregationBits, proof.participants, &att_bits_val);
-            var att_bits: ?attestation.AggregationBits = att_bits_val;
-            defer if (att_bits) |*ab| ab.deinit();
+            var att_bits: attestation.AggregationBits = undefined;
+            try utils.sszClone(allocator, attestation.AggregationBits, proof.participants, &att_bits);
+            defer att_bits.deinit();
 
             try self.attestations.append(.{ .aggregation_bits = att_bits.?, .data = data });
             att_bits = null; // ownership transferred to self.attestations

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -635,15 +635,14 @@ pub const AggregatedAttestationsResult = struct {
 
                 var att_bits: attestation.AggregationBits = undefined;
                 try utils.sszClone(allocator, attestation.AggregationBits, child.participants, &att_bits);
-                defer att_bits.deinit();
+                errdefer att_bits.deinit(); // ownership is for self.attestations
 
                 // Clone the child proof for the result (original will be freed by deferred cleanup)
                 var cloned_child: aggregation.AggregatedSignatureProof = undefined;
                 try utils.sszClone(allocator, aggregation.AggregatedSignatureProof, child.*, &cloned_child);
                 errdefer cloned_child.deinit();
 
-                try self.attestations.append(.{ .aggregation_bits = att_bits.?, .data = data });
-                att_bits = null; // ownership transferred to self.attestations
+                try self.attestations.append(.{ .aggregation_bits = att_bits, .data = data });
                 try self.attestation_signatures.append(cloned_child);
                 continue;
             }
@@ -712,10 +711,9 @@ pub const AggregatedAttestationsResult = struct {
 
             var att_bits: attestation.AggregationBits = undefined;
             try utils.sszClone(allocator, attestation.AggregationBits, proof.participants, &att_bits);
-            defer att_bits.deinit();
+            errdefer att_bits.deinit(); // ownership is for self.attestations
 
-            try self.attestations.append(.{ .aggregation_bits = att_bits.?, .data = data });
-            att_bits = null; // ownership transferred to self.attestations
+            try self.attestations.append(.{ .aggregation_bits = att_bits, .data = data });
             try self.attestation_signatures.append(proof);
         }
     }


### PR DESCRIPTION
When running a devnet with ream zeam ethlambda in 2 subnets we get the following error and ethlambda rejects zeams blocks at certain slots which lead to no finality in ethlambda during these devnets. 

```
  ethlambda_s0_p0.log:
  WARN ethlambda_blockchain: Failed to process block slot=7  proposer=1 block_root=6526aa5a parent_root=fa625e7b err=Aggregated proof
  participants don't match attestation aggregation bits
  WARN ethlambda_blockchain: Failed to process block slot=16 proposer=4 block_root=a5631b2f parent_root=5884dc6c err=Aggregated proof
  participants don't match attestation aggregation bits
```

Some AI context:
```
  When zeam builds an aggregated attestation, it has to produce two parallel pieces of data:

  - attestation.aggregation_bits — lives in the block body, marks which validators are covered.
  - proof.participants — lives in the signature group on the signed block, marks the same set.

  Both are SSZ Bitlists. They are supposed to represent the same set of validators, and ethlambda (and the spec) require them to be
  byte-for-byte equal when verifying a block:

  // ethlambda/crates/blockchain/src/store.rs:1187
  if attestation.aggregation_bits != aggregated_proof.participants {
      return Err(StoreError::ParticipantsMismatch);
  }

  zeam built aggregation_bits from proof.participants like this (in block.zig:compactSingleProof and compactMultiProofWithPrep):

  var att_bits = try attestation.AggregationBits.init(allocator);  // length 0
  for (0..cloned_proof.participants.len()) |i| {
      if (cloned_proof.participants.get(i) catch false) {
          try attestation.aggregationBitsSet(&att_bits, i, true);  // grows to i+1
      }
  }

  aggregationBitsSet only extends the bitlist up to index + 1. So the resulting att_bits.len() equals (highest set index) + 1, while
  proof.participants.len() is whatever the FFI aggregate routine returned — which can include trailing zero bits.

  Why the lengths can differ

  proof.participants is the merged bitfield from a recursive aggregation. The FFI aggregate() call merges multiple child proofs and
  gossip signatures, and the merged bitlist's length is determined by the highest index across all inputs — including children that
  contributed to coverage but whose own highest bit was higher than the highest bit in this proof.

  Concretely: if a parent proof merges children where one child covers validator 5 (length 6) and the final selected subset only ends
  up with validators {0, 2} set, participants.len() can stay at 6 while the bit at index 5 is 0. Rebuilding att_bits by re-setting TRUE
   bits produces a bitlist of length 3 (highest set is 2 → length 2+1).

  In SSZ encoding, those two bitlists are different:
  - length 3, bits 101 → encoded with the length delimiter at bit position 3
  - length 6, bits 101000 → encoded with the length delimiter at bit position 6
  
  Same set of set-bits, different bytes on the wire, different tree_hash_root, different BitList == BitList result.

  Why it was invisible inside zeam

  zeam's own block-verification path (chain.zig:2396) compares cardinality only:

  if (validator_indices.items.len != participant_indices.items.len) {
      ...
  }

  So zeam happily produced mismatched-length pairs and happily re-imported them. ream was also lenient enough not to fire. Only
  ethlambda's strict equality check caught the bug — but ethlambda then rejected every zeam block carrying an aggregated attestation,
  kept retrying it from the orphan queue, and cross-subnet attestations never reached ethlambda's chain. Justification stayed pinned to
   slot 0.

  Why slot 1/4 worked but slot 7/16 failed

  The path that diverges only fires when there's >0 attestations and the aggregation step actually runs. zeam blocks at slot 1 had
  attestation_count=0 (nothing to mismatch) and slot 4 had attestation_count=1 from a single-validator path that happened to produce a
  length-matched bitlist. From slot 7 onward, real aggregation kicked in and the lengths diverged.
  ```

I have tested this in the devnets and it fixes the issue. However feel free to request changes or close this PR.