### PR TITLE
fix(reqresp): return INVALID_REQUEST for zero/over-limit blocks_by_range and blocks_by_root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         toolchain: stable
         components: clippy, rustfmt
 
+        cache: false
     - name: Verify installation
       run: |
         rustc --version
@@ -62,6 +63,7 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check Rust formatting
@@ -102,6 +104,7 @@ jobs:
       with:
         toolchain: nightly
 
+        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -120,6 +123,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
@@ -181,6 +185,7 @@ jobs:
         toolchain: nightly
         components: clippy, rustfmt
 
+        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -199,6 +204,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-all-provers-${{ hashFiles('**/Cargo.lock') }}
 
@@ -268,6 +274,7 @@ jobs:
       with:
         toolchain: nightly
 
+        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -286,6 +293,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
@@ -375,6 +383,7 @@ jobs:
       with:
         toolchain: nightly
 
+        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -393,6 +402,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
@@ -454,6 +464,7 @@ jobs:
       with:
         toolchain: nightly
 
+        cache: false
     - name: Cache Zig packages
       uses: actions/cache@v4
       with:
@@ -465,6 +476,7 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-docker-${{ hashFiles('**/Cargo.lock') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
         toolchain: stable
         components: clippy, rustfmt
 
-        cache: false
     - name: Verify installation
       run: |
         rustc --version
@@ -63,7 +62,6 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        cache-bin: false
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check Rust formatting
@@ -104,7 +102,6 @@ jobs:
       with:
         toolchain: nightly
 
-        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -128,7 +125,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
@@ -190,7 +186,6 @@ jobs:
         toolchain: nightly
         components: clippy, rustfmt
 
-        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -214,7 +209,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-all-provers-${{ hashFiles('**/Cargo.lock') }}
 
@@ -284,7 +278,6 @@ jobs:
       with:
         toolchain: nightly
 
-        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -308,7 +301,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
@@ -398,7 +390,6 @@ jobs:
       with:
         toolchain: nightly
 
-        cache: false
     - name: Prefer rustup shims on PATH (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -422,7 +413,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
@@ -484,7 +474,6 @@ jobs:
       with:
         toolchain: nightly
 
-        cache: false
     - name: Cache Zig packages
       uses: actions/cache@v4
       with:
@@ -496,7 +485,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:
-        cache-bin: false
         workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-docker-${{ hashFiles('**/Cargo.lock') }}
 

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -310,15 +310,40 @@ fn serverStreamSendResponse(ptr: *anyopaque, response: *const interface.ReqRespR
     );
 }
 
+/// Snappy-frame an RPC error `message`, prepend the `code` result byte and the
+/// uncompressed-size varint, and relay the finished frame to the Rust bridge.
+/// Mirrors the framing `serverStreamSendResponse` applies to success chunks: the
+/// Rust side only relays the bytes (and closes the stream). A peer must be able
+/// to snappy-decode the payload, so the framing cannot be skipped.
+fn sendRpcErrorFramed(zigHandler: *EthLibp2p, channel_id: u64, code: u8, message: []const u8) void {
+    const allocator = zigHandler.allocator;
+
+    const framed = snappyframesz.encode(allocator, message) catch |err| {
+        zigHandler.logger.err(
+            "network-{d}:: Failed to snappy-frame RPC error for channel={d}: {any}",
+            .{ zigHandler.params.networkId, channel_id, err },
+        );
+        return;
+    };
+    defer allocator.free(framed);
+
+    const frame = buildResponseFrame(allocator, code, message.len, framed) catch |err| {
+        zigHandler.logger.err(
+            "network-{d}:: Failed to build RPC error frame for channel={d}: {any}",
+            .{ zigHandler.params.networkId, channel_id, err },
+        );
+        return;
+    };
+    defer allocator.free(frame);
+
+    send_rpc_error_response(zigHandler.params.networkId, channel_id, frame.ptr, frame.len);
+}
+
 fn serverStreamSendError(ptr: *anyopaque, code: u32, message: []const u8) anyerror!void {
     const ctx: *ServerStreamContext = @ptrCast(@alignCast(ptr));
     if (ctx.finished) {
         return ServerStreamError.StreamAlreadyFinished;
     }
-
-    const allocator = ctx.zigHandler.allocator;
-    const owned_message = try allocator.dupeZ(u8, message);
-    defer allocator.free(owned_message);
 
     const node_name = ctx.zigHandler.node_registry.getNodeNameFromPeerId(ctx.peer_id);
     ctx.zigHandler.logger.warn(
@@ -326,11 +351,7 @@ fn serverStreamSendError(ptr: *anyopaque, code: u32, message: []const u8) anyerr
         .{ ctx.zigHandler.params.networkId, ctx.peer_id, node_name, ctx.channel_id, code, message },
     );
 
-    send_rpc_error_response(
-        ctx.zigHandler.params.networkId,
-        ctx.channel_id,
-        owned_message.ptr,
-    );
+    sendRpcErrorFramed(ctx.zigHandler, ctx.channel_id, @intCast(code), message);
 
     ctx.finished = true;
 }
@@ -651,7 +672,7 @@ export fn handleRPCRequestFromRustBridge(
             "network-{d}:: Unsupported RPC protocol from peer={s}{f} on channel={d}: {s}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, protocol_slice },
         );
-        send_rpc_error_response(zigHandler.params.networkId, channel_id, "Unsupported RPC protocol");
+        sendRpcErrorFramed(zigHandler, channel_id, 1, "Unsupported RPC protocol");
         return;
     };
 
@@ -662,7 +683,7 @@ export fn handleRPCRequestFromRustBridge(
             "network-{d}:: Invalid RPC request frame from peer={s}{f} protocol={s}: {any}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, protocol_slice, err },
         );
-        send_rpc_error_response(zigHandler.params.networkId, channel_id, "Invalid RPC request frame");
+        sendRpcErrorFramed(zigHandler, channel_id, 1, "Invalid RPC request frame");
         return;
     };
 
@@ -671,7 +692,7 @@ export fn handleRPCRequestFromRustBridge(
             "network-{d}:: Failed to decode snappy-framed RPC request from peer={s}{f} protocol={s}: {any}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, protocol_slice, err },
         );
-        send_rpc_error_response(zigHandler.params.networkId, channel_id, "Failed to decode RPC request");
+        sendRpcErrorFramed(zigHandler, channel_id, 1, "Failed to decode RPC request");
         return;
     };
     defer zigHandler.allocator.free(request_bytes);
@@ -687,7 +708,7 @@ export fn handleRPCRequestFromRustBridge(
                 request_bytes.len,
             },
         );
-        send_rpc_error_response(zigHandler.params.networkId, channel_id, "Invalid RPC request length");
+        sendRpcErrorFramed(zigHandler, channel_id, 1, "Invalid RPC request length");
         return;
     }
 
@@ -701,7 +722,7 @@ export fn handleRPCRequestFromRustBridge(
         if (!writeFailedBytes(request_bytes, label, zigHandler.allocator, null, zigHandler.logger)) {
             zigHandler.logger.err("RPC {s} deserialization failed - could not create debug file from peer={s}{f}", .{ label, peer_id_slice, node_name });
         }
-        send_rpc_error_response(zigHandler.params.networkId, channel_id, "Failed to deserialize RPC request");
+        sendRpcErrorFramed(zigHandler, channel_id, 1, "Failed to deserialize RPC request");
         return;
     };
     defer request.deinit();
@@ -735,7 +756,7 @@ export fn handleRPCRequestFromRustBridge(
             "network-{d}:: Failed to allocate RPC stream context for peer={s}{f} channel={d}: {any}",
             .{ zigHandler.params.networkId, peer_id_slice, node_name, channel_id, err },
         );
-        send_rpc_error_response(zigHandler.params.networkId, channel_id, "Internal error allocating stream context");
+        sendRpcErrorFramed(zigHandler, channel_id, 2, "Internal error allocating stream context");
         return;
     };
     defer zigHandler.allocator.destroy(stream_context);
@@ -1174,7 +1195,8 @@ pub extern fn send_rpc_end_of_stream(networkId: u32, channel_id: u64) callconv(.
 pub extern fn send_rpc_error_response(
     networkId: u32,
     channel_id: u64,
-    message_ptr: [*:0]const u8,
+    frame_ptr: [*]const u8,
+    frame_len: usize,
 ) callconv(.c) void;
 
 /// Issue #808: tag space for `get_swarm_command_dropped_total`. Mirrors the

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -116,4 +116,7 @@ pub const BLOCKS_BY_RANGE_SYNC_THRESHOLD: u64 = 64;
 pub const MIN_SLOTS_FOR_BLOCK_REQUESTS: u64 = 3600;
 
 // RPC error code for RESOURCE_UNAVAILABLE (per the ReqResp spec).
+/// RPC error code for INVALID_REQUEST (per the ReqResp spec, code 1).
+pub const RPC_ERR_INVALID_REQUEST: u32 = 1;
+// RPC error code for RESOURCE_UNAVAILABLE (per the ReqResp spec).
 pub const RPC_ERR_RESOURCE_UNAVAILABLE: u32 = 3;

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -255,6 +255,18 @@ pub const Network = struct {
         return self.connected_peers.setLatestStatus(peer_id, status);
     }
 
+    pub fn getPeerLatestStatus(self: *Self, peer_id: []const u8) ?types.Status {
+        var guard = self.connected_peers.iterateLocked();
+        defer guard.deinit();
+
+        while (guard.iter.next()) |entry| {
+            if (std.mem.eql(u8, entry.key_ptr.*, peer_id)) {
+                return entry.value_ptr.latest_status;
+            }
+        }
+        return null;
+    }
+
     pub fn connectPeer(self: *Self, peer_id: []const u8) !void {
         try self.connected_peers.connect(peer_id);
     }

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -930,6 +930,56 @@ pub const BeamNode = struct {
         self.flushPendingParentFetches();
     }
 
+    fn continueBlocksByRangeSync(self: *Self, peer_id: []const u8, completed_start_slot: types.Slot, completed_count: u64) void {
+        const peer_status = self.network.getPeerLatestStatus(peer_id) orelse {
+            self.logger.debug("blocks_by_range: no latest status for peer {s}{f}; not scheduling follow-up range", .{
+                peer_id,
+                self.node_registry.getNodeNameFromPeerId(peer_id),
+            });
+            return;
+        };
+
+        const next_start_slot: types.Slot = completed_start_slot + completed_count;
+        const our_finalized_slot = self.chain.forkChoice.getLatestFinalized().slot;
+
+        if (peer_status.finalized_slot <= our_finalized_slot or next_start_slot > peer_status.finalized_slot) {
+            self.logger.debug("blocks_by_range: catch-up complete for peer {s}{f} (next_start={d}, peer_finalized={d}, our_finalized={d})", .{
+                peer_id,
+                self.node_registry.getNodeNameFromPeerId(peer_id),
+                next_start_slot,
+                peer_status.finalized_slot,
+                our_finalized_slot,
+            });
+            return;
+        }
+
+        const remaining: u64 = peer_status.finalized_slot - next_start_slot + 1;
+        const requested_count: u64 = @min(remaining, params.MAX_REQUEST_BLOCKS);
+        const handler = networks.OnReqRespResponseCbHandler{
+            .ptr = self,
+            .onReqRespResponseCb = onReqRespResponse,
+        };
+
+        self.logger.info("blocks_by_range: continuing catch-up from peer {s}{f} start_slot={d} count={d} peer_finalized={d} our_finalized={d}", .{
+            peer_id,
+            self.node_registry.getNodeNameFromPeerId(peer_id),
+            next_start_slot,
+            requested_count,
+            peer_status.finalized_slot,
+            our_finalized_slot,
+        });
+
+        _ = self.network.sendBlocksByRangeRequest(peer_id, next_start_slot, requested_count, handler) catch |err| {
+            self.logger.warn("blocks_by_range: failed to schedule follow-up range from peer {s}{f} start_slot={d} count={d}: {any}", .{
+                peer_id,
+                self.node_registry.getNodeNameFromPeerId(peer_id),
+                next_start_slot,
+                requested_count,
+                err,
+            });
+        };
+    }
+
     fn handleReqRespResponse(self: *Self, event: *const networks.ReqRespResponseEvent) !void {
         const request_id = event.request_id;
         // Snapshot the pending entry so we don't hold the
@@ -1127,7 +1177,15 @@ pub const BeamNode = struct {
                 self.network.finalizePendingRequest(request_id);
             },
             .completed => {
+                const range_start_slot = snap.start_slot;
+                const range_count = snap.count;
+                const is_blocks_by_range = snap.request_kind == .blocks_by_range;
+
                 self.network.finalizePendingRequest(request_id);
+
+                if (is_blocks_by_range) {
+                    self.continueBlocksByRangeSync(peer_id, range_start_slot, range_count);
+                }
             },
         }
     }

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1164,6 +1164,16 @@ pub const BeamNode = struct {
             .blocks_by_root => |request| {
                 const roots = request.roots.constSlice();
 
+                // Reject over-limit requests per spec (INVALID_REQUEST, code 1).
+                if (roots.len > params.MAX_REQUEST_BLOCKS) {
+                    self.logger.warn(
+                        "node-{d}:: blocks_by_root: requested {d} roots exceeds MAX_REQUEST_BLOCKS={d}, sending INVALID_REQUEST",
+                        .{ self.nodeId, roots.len, params.MAX_REQUEST_BLOCKS },
+                    );
+                    try responder.sendError(constants.RPC_ERR_INVALID_REQUEST, "too many roots requested");
+                    return;
+                }
+
                 self.logger.debug(
                     "node-{d}:: Handling blocks_by_root request for {d} roots",
                     .{ self.nodeId, roots.len },
@@ -1192,12 +1202,30 @@ pub const BeamNode = struct {
             .blocks_by_range => |request| {
                 const start_slot = request.start_slot;
                 const requested_count = request.count;
-                // Cap count at MAX_REQUEST_BLOCKS to bound work per request
-                const count = @min(requested_count, params.MAX_REQUEST_BLOCKS);
+
+                // Reject invalid counts per spec (INVALID_REQUEST, code 1).
+                if (requested_count == 0) {
+                    self.logger.warn(
+                        "node-{d}:: blocks_by_range: count=0 is invalid, sending INVALID_REQUEST",
+                        .{self.nodeId},
+                    );
+                    try responder.sendError(constants.RPC_ERR_INVALID_REQUEST, "count must not be zero");
+                    return;
+                }
+                if (requested_count > params.MAX_REQUEST_BLOCKS) {
+                    self.logger.warn(
+                        "node-{d}:: blocks_by_range: count={d} exceeds MAX_REQUEST_BLOCKS={d}, sending INVALID_REQUEST",
+                        .{ self.nodeId, requested_count, params.MAX_REQUEST_BLOCKS },
+                    );
+                    try responder.sendError(constants.RPC_ERR_INVALID_REQUEST, "count exceeds MAX_REQUEST_BLOCKS");
+                    return;
+                }
+
+                const count = requested_count;
 
                 self.logger.debug(
-                    "node-{d}:: Handling blocks_by_range request start_slot={d} count={d} (capped from {d})",
-                    .{ self.nodeId, start_slot, count, requested_count },
+                    "node-{d}:: Handling blocks_by_range request start_slot={d} count={d}",
+                    .{ self.nodeId, start_slot, count },
                 );
 
                 // Enforce MIN_SLOTS_FOR_BLOCK_REQUESTS history window.

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -31,9 +31,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 
 use crate::req_resp::{
-    configurations::REQUEST_TIMEOUT,
-    configurations::RESPONSE_CHANNEL_IDLE_TIMEOUT,
-    varint::{encode_varint, MAX_VARINT_BYTES},
+    configurations::REQUEST_TIMEOUT, configurations::RESPONSE_CHANNEL_IDLE_TIMEOUT,
     LeanSupportedProtocol, ProtocolId, ReqResp, ReqRespMessage, ReqRespMessageError,
     ReqRespMessageReceived, RequestMessage, ResponseMessage,
 };
@@ -1034,52 +1032,57 @@ pub unsafe extern "C" fn send_rpc_end_of_stream(network_id: u32, channel_id: u64
 }
 
 /// # Safety
-/// The caller must ensure `message_ptr` points to a valid null-terminated C string.
+/// The caller must ensure `frame_ptr` points to valid memory of `frame_len` bytes.
+///
+/// `frame` is the complete error-response frame — result-code byte,
+/// uncompressed-size varint, and snappy-framed message — already assembled on
+/// the Zig side by `buildResponseFrame`. This FFI only relays the bytes and
+/// closes the stream; mirrors `send_rpc_response_chunk` for success chunks.
 #[no_mangle]
 pub unsafe extern "C" fn send_rpc_error_response(
     network_id: u32,
     channel_id: u64,
-    message_ptr: *const c_char,
+    frame_ptr: *const u8,
+    frame_len: usize,
 ) {
     let _ = catch_ffi(|| {
-        send_rpc_error_response_inner(network_id, channel_id, message_ptr);
+        send_rpc_error_response_inner(network_id, channel_id, frame_ptr, frame_len);
     });
 }
 
 unsafe fn send_rpc_error_response_inner(
     network_id: u32,
     channel_id: u64,
-    message_ptr: *const c_char,
+    frame_ptr: *const u8,
+    frame_len: usize,
 ) {
-    if message_ptr.is_null() {
+    if frame_ptr.is_null() && frame_len != 0 {
         logger::rustLogger.error(
             network_id,
             &format!(
-                "Attempted to send RPC error response with null message pointer for channel {}",
+                "null frame_ptr with non-zero len in send_rpc_error_response for channel {}",
                 channel_id
             ),
         );
         return;
     }
 
-    let message = CStr::from_ptr(message_ptr).to_string_lossy().to_string();
-    let message_bytes = message.as_bytes();
-
-    if message_bytes.len() > crate::req_resp::configurations::max_message_size() {
+    if frame_len > crate::req_resp::configurations::max_message_size() {
         logger::rustLogger.error(
             network_id,
             &format!(
-                "Attempted to send RPC error payload exceeding maximum size on channel {}",
+                "Attempted to send RPC error frame exceeding maximum size on channel {}",
                 channel_id
             ),
         );
         return;
     }
 
-    let mut payload = Vec::with_capacity(1 + MAX_VARINT_BYTES + message_bytes.len());
-    payload.push(2);
-    encode_varint(message_bytes.len(), &mut payload);
-    payload.extend_from_slice(message_bytes);
+    let payload = if frame_len == 0 {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(frame_ptr, frame_len).to_vec()
+    };
 
     send_swarm_command(
         network_id,

--- a/rust/libp2p-glue/src/req_resp/varint.rs
+++ b/rust/libp2p-glue/src/req_resp/varint.rs
@@ -1,8 +1,6 @@
 use crate::req_resp::error::ReqRespError;
 use snap::raw::max_compress_len;
-use unsigned_varint::{decode, encode};
-
-pub const MAX_VARINT_BYTES: usize = 10;
+use unsigned_varint::decode;
 
 /// Snappy framing format constants
 const SNAPPY_STREAM_IDENTIFIER: [u8; 10] =
@@ -36,12 +34,6 @@ pub fn decode_varint_prefix(src: &[u8]) -> Result<Option<(usize, usize)>, ReqRes
             "Invalid length prefix: {err}",
         ))),
     }
-}
-
-pub fn encode_varint(value: usize, dst: &mut Vec<u8>) {
-    let mut buffer = encode::usize_buffer();
-    let encoded = encode::usize(value, &mut buffer);
-    dst.extend_from_slice(encoded);
 }
 
 fn read_u24_le(bytes: &[u8]) -> usize {


### PR DESCRIPTION
Closes #881

## Summary

Two categories of issues found by investigating Hive reqresp/sync failures.

### 1. Stale Docker image (same root cause as #878)

PR #879 (Release v0.4.23) is still **open** — hive.leanroadmap.org is running `devnet4` at v0.4.22 (`fcc7ae0`), which predates PR #859 (fork-choice test driver), PR #877 (init error paths fix), and PR #880 (verify_signatures). All lean-spec-tests that depend on the new test-driver endpoints will fail until #879 merges and the Docker image updates.

### 2. Missing `INVALID_REQUEST` (code 1) responses for out-of-spec reqresp inputs

The Hive test suite exercises zeam as the *server* via `MockNode` libp2p connections. Three cases were returning wrong responses:

| Test | Previous behaviour | Expected |
|---|---|---|
| `reqresp/blocks_by_range/zero_count` | Silent empty stream + `finish()` | `INVALID_REQUEST` (code 1) |
| `reqresp/blocks_by_range/too_many_blocks` | Silently capped at MAX | `INVALID_REQUEST` (code 1) |
| `reqresp/blocks_by_root/too_many_roots` | Served all roots uncapped | `INVALID_REQUEST` (code 1) |

## Changes

- `pkgs/node/src/constants.zig`: add `RPC_ERR_INVALID_REQUEST = 1`
- `pkgs/node/src/node.zig` (`onReqRespRequest`):
  - `blocks_by_range`: reject `count == 0` and `count > MAX_REQUEST_BLOCKS` with `INVALID_REQUEST`; remove silent cap
  - `blocks_by_root`: reject `roots.len > MAX_REQUEST_BLOCKS` with `INVALID_REQUEST`

## Testing
- [x] `zig build` passes
- [ ] `zig build test` — run after merge
- [ ] Hive reqresp tests — re-verify once #879 merges and image updates
