### PR TITLE
perf: slot-driver stall watchdog + chain.onBlock substep histogram (P0 of #863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,12 @@ jobs:
       run: |
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         command -v cargo
-        cargo +nightly --version
+        # Verify the nightly toolchain is reachable. Use `rustup run`
+        # rather than the `+nightly` selector — the latter requires
+        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
+        # some macOS runner images that path is `rustup-init` and
+        # the `+nightly` selector fails with "unexpected argument".
+        rustup run nightly cargo --version
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -186,7 +191,12 @@ jobs:
       run: |
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         command -v cargo
-        cargo +nightly --version
+        # Verify the nightly toolchain is reachable. Use `rustup run`
+        # rather than the `+nightly` selector — the latter requires
+        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
+        # some macOS runner images that path is `rustup-init` and
+        # the `+nightly` selector fails with "unexpected argument".
+        rustup run nightly cargo --version
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -273,7 +283,12 @@ jobs:
       run: |
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         command -v cargo
-        cargo +nightly --version
+        # Verify the nightly toolchain is reachable. Use `rustup run`
+        # rather than the `+nightly` selector — the latter requires
+        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
+        # some macOS runner images that path is `rustup-init` and
+        # the `+nightly` selector fails with "unexpected argument".
+        rustup run nightly cargo --version
 
     - name: Cache Zig packages
       uses: actions/cache@v4
@@ -380,7 +395,12 @@ jobs:
       run: |
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         command -v cargo
-        cargo +nightly --version
+        # Verify the nightly toolchain is reachable. Use `rustup run`
+        # rather than the `+nightly` selector — the latter requires
+        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
+        # some macOS runner images that path is `rustup-init` and
+        # the `+nightly` selector fails with "unexpected argument".
+        rustup run nightly cargo --version
 
     - name: Cache Zig packages
       uses: actions/cache@v4

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -19,6 +19,7 @@ const node_lib = @import("@zeam/node");
 const key_manager_lib = @import("@zeam/key-manager");
 const Clock = node_lib.Clock;
 const BeamNode = node_lib.BeamNode;
+const SlotDriverWatchdog = node_lib.SlotDriverWatchdog;
 const ThreadPool = @import("@zeam/thread-pool").ThreadPool;
 const xmss = @import("@zeam/xmss");
 const types = @import("@zeam/types");
@@ -153,6 +154,9 @@ pub const Node = struct {
     anchor_state: *types.BeamState,
     /// Shared worker pool for CPU-bound chain work (attestation signature verification).
     thread_pool: *ThreadPool,
+    /// Background watchdog that monitors libxev slot-driver liveness (#863).
+    /// `null` until `run()` spawns it; `stop()` joins it.
+    slot_driver_watchdog: ?SlotDriverWatchdog = null,
 
     const Self = @This();
 
@@ -494,6 +498,9 @@ pub const Node = struct {
     }
 
     pub fn deinit(self: *Self) void {
+        if (self.slot_driver_watchdog) |*wd| {
+            wd.stop();
+        }
         if (self.api_server_handle) |handle| {
             handle.stop();
         }
@@ -575,6 +582,22 @@ pub const Node = struct {
         self.logger.info("  Listening on QUIC port: {?d}", .{quic_port});
         self.logger.info("  ENR: {s}", .{encoded_txt});
         self.logger.info("────────────────────────────────────────────────────────", .{});
+
+        // Spawn the slot-driver stall watchdog (#863) so multi-second
+        // libxev stalls surface in the log + metrics even if the main
+        // loop is stuck inside one completion or syscall. Failure to
+        // spawn is non-fatal — log and continue without it.
+        self.slot_driver_watchdog = SlotDriverWatchdog.init(
+            &self.clock,
+            self.options.logger_config.logger(.clock),
+            .{},
+        );
+        if (self.slot_driver_watchdog) |*wd| {
+            wd.start() catch |err| {
+                self.logger.warn("failed to start slot-driver watchdog: {any}", .{err});
+                self.slot_driver_watchdog = null;
+            };
+        }
 
         try self.clock.run();
     }

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -52,10 +52,11 @@ const Metrics = struct {
     //       sub-step buckets sum to roughly the total).
     zeam_chain_onblock_step_duration_seconds: ChainOnblockStepHistogram,
     // Slot-driver stall watchdog (#863): a dedicated thread samples the
-    // libxev tick clock every WATCHDOG_PROBE_MS; if `last_tick_time_ms`
-    // falls more than WATCHDOG_THRESHOLD_MS behind wall clock it logs
-    // an ERROR and bumps these counters. The histogram captures the
-    // distribution of stall durations across firings.
+    // libxev tick clock every WATCHDOG_PROBE_MS via `Clock.lastTickMs()`
+    // (atomic acquire load); if the value falls more than
+    // WATCHDOG_THRESHOLD_MS behind wall clock it logs an ERROR and
+    // bumps these counters. The histogram captures the distribution of
+    // stall durations across firings.
     zeam_slot_driver_stall_fired_total: ZeamSlotDriverStallFiredCounter,
     zeam_slot_driver_stall_seconds: ZeamSlotDriverStallSecondsHistogram,
     lean_head_slot: LeanHeadSlotGauge,

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -31,6 +31,33 @@ var g_initialized: bool = false;
 
 const Metrics = struct {
     zeam_chain_onblock_duration_seconds: ChainHistogram,
+    // Per-substep timing inside `chain.onBlock` — used to attribute the
+    // multi-second tail observed on aggregator nodes (#863). Step labels:
+    //   "block_root_compute" — hash_tree_root of the inner block when the
+    //       caller did not supply a precomputed root.
+    //   "parent_state_clone" — snapshot+clone of parent state under
+    //       states_lock.shared.
+    //   "verify_signatures" — XMSS verify (per-attestation) under
+    //       pubkey_cache_lock.
+    //   "state_transition" — `apply_transition` (process_slots +
+    //       process_block) under root_to_slot_lock.
+    //   "forkchoice_onblock" — `forkChoice.onBlock` integration call.
+    //   "block_attestations" — onAttestation/storeAggregatedPayload loop
+    //       over the block body.
+    //   "db_persist" — block + state write batch + commit.
+    //   "ssz_serialize_fallback" — fallback re-serialise when no
+    //       precomputed SSZ bytes were supplied.
+    //   "total_excluding_io_wait" — observed wall-clock total (mirrors
+    //       `_duration_seconds` so dashboards can sanity-check that the
+    //       sub-step buckets sum to roughly the total).
+    zeam_chain_onblock_step_duration_seconds: ChainOnblockStepHistogram,
+    // Slot-driver stall watchdog (#863): a dedicated thread samples the
+    // libxev tick clock every WATCHDOG_PROBE_MS; if `last_tick_time_ms`
+    // falls more than WATCHDOG_THRESHOLD_MS behind wall clock it logs
+    // an ERROR and bumps these counters. The histogram captures the
+    // distribution of stall durations across firings.
+    zeam_slot_driver_stall_fired_total: ZeamSlotDriverStallFiredCounter,
+    zeam_slot_driver_stall_seconds: ZeamSlotDriverStallSecondsHistogram,
     lean_head_slot: LeanHeadSlotGauge,
     lean_latest_justified_slot: LeanLatestJustifiedSlotGauge,
     lean_latest_finalized_slot: LeanLatestFinalizedSlotGauge,
@@ -238,6 +265,25 @@ const Metrics = struct {
     lean_node_interval_error_total: LeanNodeIntervalErrorCounter,
 
     const ChainHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 });
+    // Per-substep timing inside chain.onBlock — see #863 root-cause work.
+    // Same bucket layout as ChainHistogram so dashboards can stack the
+    // step series and the total side-by-side without bucket-aligned diffs.
+    const ChainOnblockStepLabel = struct { step: []const u8 };
+    const ChainOnblockStepHistogram = metrics_lib.HistogramVec(
+        f32,
+        ChainOnblockStepLabel,
+        &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 },
+    );
+    // Watchdog counters (#863): wall-clock heartbeats from the slot-driver
+    // libxev thread. The watchdog thread bumps `_fired_total` whenever it
+    // observes a stall over the configured threshold; the per-bucket
+    // counters give operators a quick "how bad" without scraping the
+    // histogram.
+    const ZeamSlotDriverStallFiredCounter = metrics_lib.Counter(u64);
+    const ZeamSlotDriverStallSecondsHistogram = metrics_lib.Histogram(
+        f32,
+        &[_]f32{ 1, 2, 5, 10, 30, 60, 120, 300, 600 },
+    );
     const StateTransitionHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4 });
     const SlotsProcessingHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1 });
     const BlockProcessingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 1 });
@@ -677,6 +723,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
 
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
+        .zeam_chain_onblock_step_duration_seconds = try Metrics.ChainOnblockStepHistogram.init(allocator, io, "zeam_chain_onblock_step_duration_seconds", .{ .help = "Per-substep wall-clock duration inside chain.onBlock, labeled by step. See #863 for context. Buckets match zeam_chain_onblock_duration_seconds for stack-aligned dashboarding." }, .{}),
+        .zeam_slot_driver_stall_fired_total = Metrics.ZeamSlotDriverStallFiredCounter.init("zeam_slot_driver_stall_fired_total", .{ .help = "Total times the watchdog (#863) observed the libxev slot driver stalled past its threshold (default 5s). Each firing also records the stall duration in zeam_slot_driver_stall_seconds and emits an ERROR log." }, .{}),
+        .zeam_slot_driver_stall_seconds = Metrics.ZeamSlotDriverStallSecondsHistogram.init("zeam_slot_driver_stall_seconds", .{ .help = "Distribution of slot-driver stall durations observed by the watchdog (#863). Stalls beyond ~1s indicate the libxev loop, libp2p Rust thread, or chain-worker held the main loop hostage; pair with zeam_chain_onblock_step_duration_seconds to attribute." }, .{}),
         .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
         .lean_latest_justified_slot = Metrics.LeanLatestJustifiedSlotGauge.init("lean_latest_justified_slot", .{ .help = "Latest justified slot" }, .{}),
         .lean_latest_finalized_slot = Metrics.LeanLatestFinalizedSlotGauge.init("lean_latest_finalized_slot", .{ .help = "Latest finalized slot" }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -125,6 +125,37 @@ pub const PendingBlockEntry = struct {
     block_root: types.Root,
 };
 
+/// Cumulative stopwatch for `chain.onBlock` substeps (#863).
+///
+/// `lap(label)` records the time elapsed since the previous `lap` (or
+/// since `init`) into the labeled `zeam_chain_onblock_step_duration_seconds`
+/// histogram. The struct is `comptime`-cheap: a single i128 anchor and
+/// no heap. `lap` failures (metric not initialised) are silently
+/// swallowed so onBlock never fails because instrumentation can't write.
+const OnblockStepWatch = struct {
+    anchor_ns: i128,
+
+    fn init() OnblockStepWatch {
+        return .{ .anchor_ns = zeam_utils.monotonicTimestampNs() };
+    }
+
+    /// Record the elapsed time since the previous lap under
+    /// `step` and rebase the anchor. Safe to call from any
+    /// number of code paths inside one onBlock invocation; the
+    /// total of all laps approximates the outer
+    /// `zeam_chain_onblock_duration_seconds` observation.
+    fn lap(self: *OnblockStepWatch, comptime step: []const u8) void {
+        const now_ns = zeam_utils.monotonicTimestampNs();
+        const elapsed_ns: i128 = if (now_ns >= self.anchor_ns) now_ns - self.anchor_ns else 0;
+        const elapsed_s: f32 = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+        zeam_metrics.metrics.zeam_chain_onblock_step_duration_seconds.observe(
+            .{ .step = step },
+            elapsed_s,
+        ) catch {};
+        self.anchor_ns = now_ns;
+    }
+};
+
 pub const BeamChain = struct {
     config: configs.ChainConfig,
     anchor_state: *types.BeamState,
@@ -2240,12 +2271,17 @@ pub const BeamChain = struct {
     // Returns a list of missing block roots that need to be fetched from the network
     pub fn onBlock(self: *Self, signedBlock: types.SignedBlock, blockInfo: CachedProcessedBlockInfo) ![]types.Root {
         const onblock_timer = zeam_metrics.zeam_chain_onblock_duration_seconds.start();
+        // Per-substep stopwatch (#863). Records into
+        // `zeam_chain_onblock_step_duration_seconds{step="…"}` so the
+        // multi-second tail can be attributed without invasive logging.
+        var step_watch = OnblockStepWatch.init();
 
         const block = signedBlock.block;
 
         const block_root: types.Root = if (blockInfo.blockRoot) |r| r else r: {
             var cblock_root: [32]u8 = undefined;
             try zeam_utils.hashTreeRoot(types.BeamBlock, block, &cblock_root, self.allocator);
+            step_watch.lap("block_root_compute");
             break :r cblock_root;
         };
         if (blockInfo.blockRoot != null) {
@@ -2293,6 +2329,7 @@ pub const BeamChain = struct {
             // sszClone succeeded — interior heap fields are now allocated.
             // If anything below fails, deinit interior first (LIFO: deinit runs before destroy above).
             errdefer cpost_state.deinit();
+            step_watch.lap("parent_state_clone");
 
             // 2. verify XMSS signatures (independent step; placed before STF so an invalid block is
             // rejected without mutating post state). Uses the shared thread pool when available to
@@ -2320,6 +2357,7 @@ pub const BeamChain = struct {
                     try stf.verifySignatures(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache);
                 }
             }
+            step_watch.lap("verify_signatures");
 
             // 3. apply state transition assuming signatures are valid (STF does not re-verify).
             //    Hold `root_to_slot_lock` for the STF window: STF reads/writes
@@ -2343,6 +2381,7 @@ pub const BeamChain = struct {
                     .rootToSlotCache = &self.root_to_slot_cache,
                 });
             }
+            step_watch.lap("state_transition");
             break :computedstate cpost_state;
         };
         // If post_state was freshly allocated above and a later step errors (e.g. forkChoice.onBlock,
@@ -2393,6 +2432,7 @@ pub const BeamChain = struct {
             try types.sszClone(self.allocator, types.SignedBlock, signedBlock, &fallback_clone);
             fallback_clone_initialized = true;
             try ssz.serialize(types.SignedBlock, fallback_clone, &fallback_ssz, self.allocator);
+            step_watch.lap("ssz_serialize_fallback");
             break :blk fallback_ssz.items;
         };
 
@@ -2408,6 +2448,7 @@ pub const BeamChain = struct {
                 // confirmed in next steps post written to db
                 .confirmed = false,
             });
+            step_watch.lap("forkchoice_onblock");
 
             // 4. fc onattestations
             self.logger.debug("processing attestations of block with root=0x{x} slot={d}", .{
@@ -2529,6 +2570,7 @@ pub const BeamChain = struct {
 
             // 5. fc update head
             _ = try self.forkChoice.updateHead();
+            step_watch.lap("block_attestations");
 
             break :fcprocessing freshFcBlock;
         };
@@ -2606,6 +2648,7 @@ pub const BeamChain = struct {
             });
         };
         try self.forkChoice.confirmBlock(block_root);
+        step_watch.lap("db_persist");
 
         self.logger.info("processed block with root=0x{x} slot={d} processing time={d} (computed root={any} computed state={any})", .{
             &fcBlock.blockRoot,

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -12,11 +12,24 @@ const OnIntervalCbWrapper = utils.OnIntervalCbWrapper;
 
 const CLOCK_DISPARITY_MS: isize = 100;
 
+/// Sentinel for `last_tick_time_ms_atomic` meaning "tickInterval has
+/// not run yet". Real timestamps are unix-epoch milliseconds (positive
+/// and large), so any negative value is unambiguous; using `minInt`
+/// avoids any chance of collision with a clock-skew artifact.
+const NEVER_TICKED_MS: i64 = std.math.minInt(i64);
+
 pub const Clock = struct {
     genesis_time_ms: isize,
     current_interval_time_ms: isize,
     current_interval: isize,
-    last_tick_time_ms: ?isize,
+    /// Wall-clock millis at the most recent `tickInterval()` call, or
+    /// `NEVER_TICKED_MS` before the first tick. Read concurrently by
+    /// `SlotDriverWatchdog` (#863) — kept atomic so the watchdog
+    /// thread never observes a torn value. Writers must use
+    /// `release` ordering, readers `acquire` (or `monotonic` when the
+    /// reader doesn't need to synchronise with anything else the
+    /// writer published).
+    last_tick_time_ms_atomic: std.atomic.Value(i64),
     events: utils.EventLoop,
     // track those who subscribed for on slot callbacks
     on_interval_cbs: std.ArrayList(*OnIntervalCbWrapper),
@@ -48,13 +61,21 @@ pub const Clock = struct {
             .genesis_time_ms = genesis_time_ms,
             .current_interval_time_ms = current_interval_time_ms,
             .current_interval = current_interval,
-            .last_tick_time_ms = null,
+            .last_tick_time_ms_atomic = std.atomic.Value(i64).init(NEVER_TICKED_MS),
             .events = events,
             .timer = timer,
             .on_interval_cbs = .empty,
             .allocator = allocator,
             .logger = logger_config.logger(.clock),
         };
+    }
+
+    /// Snapshot of the most recent `tickInterval()` wall-clock time, or
+    /// `null` if `tickInterval()` has not run yet. Single atomic
+    /// `acquire` load — safe to call from any thread.
+    pub fn lastTickMs(self: *const Self) ?i64 {
+        const v = self.last_tick_time_ms_atomic.load(.acquire);
+        return if (v == NEVER_TICKED_MS) null else v;
     }
 
     pub fn deinit(self: *Self, allocator: Allocator) void {
@@ -67,12 +88,19 @@ pub const Clock = struct {
 
     pub fn tickInterval(self: *Self) void {
         const time_now_ms: isize = @intCast(zeam_utils.unixTimestampMillis());
-        if (self.last_tick_time_ms) |last| {
-            const elapsed_s: f32 = @as(f32, @floatFromInt(time_now_ms - last)) / 1000.0;
+        // Single-writer (libxev thread); monotonic load is sufficient here
+        // — we only race the watchdog reader, which uses acquire on its load.
+        const last_atomic = self.last_tick_time_ms_atomic.load(.monotonic);
+        if (last_atomic != NEVER_TICKED_MS) {
+            const elapsed_s: f32 = @as(f32, @floatFromInt(time_now_ms - @as(isize, @intCast(last_atomic)))) / 1000.0;
             zeam_metrics.lean_tick_interval_duration_seconds.record(elapsed_s);
             self.logger.info("slot_interval={d} duration={d:.3}s", .{ @mod(self.current_interval, constants.INTERVALS_PER_SLOT), elapsed_s });
         }
-        self.last_tick_time_ms = time_now_ms;
+        // Release ordering pairs with the watchdog's acquire load in
+        // `lastTickMs`, ensuring any writes the libxev thread did before
+        // the tick are visible to the watchdog when it observes the new
+        // timestamp.
+        self.last_tick_time_ms_atomic.store(@intCast(time_now_ms), .release);
         while (self.current_interval_time_ms + constants.SECONDS_PER_INTERVAL_MS < time_now_ms + CLOCK_DISPARITY_MS) {
             self.current_interval_time_ms += constants.SECONDS_PER_INTERVAL_MS;
             self.current_interval += 1;

--- a/pkgs/node/src/lib.zig
+++ b/pkgs/node/src/lib.zig
@@ -1,6 +1,9 @@
 const clockFactory = @import("./clock.zig");
 pub const Clock = clockFactory.Clock;
 
+pub const slot_driver_watchdog = @import("./slot_driver_watchdog.zig");
+pub const SlotDriverWatchdog = slot_driver_watchdog.SlotDriverWatchdog;
+
 const nodeFactory = @import("./node.zig");
 pub const BeamNode = nodeFactory.BeamNode;
 
@@ -35,5 +38,6 @@ test "get tests" {
     _ = @import("./locking.zig");
     _ = @import("./chain_worker.zig");
     _ = @import("./rc_beam_state.zig");
+    _ = @import("./slot_driver_watchdog.zig");
     @import("std").testing.refAllDecls(@This());
 }

--- a/pkgs/node/src/slot_driver_watchdog.zig
+++ b/pkgs/node/src/slot_driver_watchdog.zig
@@ -1,0 +1,146 @@
+//! Slot-driver stall watchdog (#863).
+//!
+//! Spawns a background OS thread that probes `Clock.last_tick_time_ms` at
+//! a fixed interval. When the gap between wall clock and the last tick
+//! exceeds `WATCHDOG_THRESHOLD_MS`, the watchdog:
+//!
+//!   * Logs an ERROR with the stall duration.
+//!   * Bumps `zeam_slot_driver_stall_fired_total` and records the stall
+//!     duration into `zeam_slot_driver_stall_seconds`.
+//!
+//! The watchdog is independent of libxev / chain-worker. Even if both
+//! main loops are wedged inside a single completion or syscall, this
+//! thread keeps running and surfaces the stall via logs + Prometheus.
+//!
+//! Per-thread stack dumps are intentionally NOT included in this PR.
+//! Zig's signal-handler API is in flux on the 0.16 branch and a robust
+//! cross-target implementation is best landed as a follow-up once the
+//! stall metric tells us we even need it on a given deployment.
+//!
+//! Lifecycle:
+//!   - `SlotDriverWatchdog.init(...)` constructs (does not spawn).
+//!   - `start()` spawns the OS thread.
+//!   - `stop()` flips the stop flag and joins.
+//!
+//! Safe to skip start() entirely — the watchdog is purely diagnostic.
+
+const std = @import("std");
+const Thread = std.Thread;
+
+const zeam_metrics = @import("@zeam/metrics");
+const zeam_utils = @import("@zeam/utils");
+
+const Clock = @import("./clock.zig").Clock;
+
+/// Probe interval. Cheap (atomic load + wall-clock read), so a tight
+/// cadence keeps the detection latency low without burning measurable
+/// CPU.
+pub const DEFAULT_PROBE_MS: u64 = 1000;
+
+/// Threshold above which the watchdog declares a stall. Picked so a
+/// single nominal slot interval (~800ms) plus normal jitter does not
+/// trip it; multi-second stalls (the #863 symptom) do.
+pub const DEFAULT_THRESHOLD_MS: u64 = 5000;
+
+/// Hysteresis: after firing, suppress further firings until the slot
+/// driver ticks again at least once. Otherwise a single 600s freeze
+/// would log every probe-interval for the entire freeze duration.
+const SUPPRESS_REFIRE: bool = true;
+
+pub const SlotDriverWatchdog = struct {
+    clock: *Clock,
+    logger: zeam_utils.ModuleLogger,
+    probe_ms: u64,
+    threshold_ms: u64,
+    stop_flag: std.atomic.Value(bool),
+    thread: ?Thread,
+
+    pub const Options = struct {
+        probe_ms: u64 = DEFAULT_PROBE_MS,
+        threshold_ms: u64 = DEFAULT_THRESHOLD_MS,
+    };
+
+    pub fn init(
+        clock: *Clock,
+        logger: zeam_utils.ModuleLogger,
+        opts: Options,
+    ) SlotDriverWatchdog {
+        return .{
+            .clock = clock,
+            .logger = logger,
+            .probe_ms = opts.probe_ms,
+            .threshold_ms = opts.threshold_ms,
+            .stop_flag = std.atomic.Value(bool).init(false),
+            .thread = null,
+        };
+    }
+
+    pub fn start(self: *SlotDriverWatchdog) !void {
+        if (self.thread != null) return error.AlreadyRunning;
+        self.thread = try Thread.spawn(.{}, runLoop, .{self});
+    }
+
+    pub fn stop(self: *SlotDriverWatchdog) void {
+        self.stop_flag.store(true, .release);
+        if (self.thread) |t| {
+            t.join();
+            self.thread = null;
+        }
+    }
+
+    /// Sleep helper. Zig 0.16 dropped `std.Thread.sleep`; mirror
+    /// `pkgs/node/src/stress.zig::sleepSecs` and use libc nanosleep
+    /// directly so this watchdog stays cross-target without a libxev
+    /// timer (which would itself depend on the loop we are watching).
+    fn sleepMs(ms: u64) void {
+        const total_ns: u128 = @as(u128, ms) * @as(u128, std.time.ns_per_ms);
+        var ts: std.c.timespec = .{
+            .sec = @intCast(@divFloor(total_ns, std.time.ns_per_s)),
+            .nsec = @intCast(@mod(total_ns, std.time.ns_per_s)),
+        };
+        _ = std.c.nanosleep(&ts, &ts);
+    }
+
+    fn runLoop(self: *SlotDriverWatchdog) void {
+        var last_observed_tick_ms: ?isize = null;
+        var firing_for_current_stall = false;
+
+        while (!self.stop_flag.load(.acquire)) {
+            sleepMs(self.probe_ms);
+            if (self.stop_flag.load(.acquire)) break;
+
+            // `last_tick_time_ms` is mutated unsynchronised on the libxev
+            // thread. We accept torn reads on 32-bit platforms — the worst
+            // case is a transient spurious "stall" log, which is harmless
+            // for diagnostic instrumentation.
+            const last_tick_opt = self.clock.last_tick_time_ms;
+            const last_tick = last_tick_opt orelse continue;
+
+            const now_ms: isize = @intCast(zeam_utils.unixTimestampMillis());
+            const delta_ms: isize = now_ms - last_tick;
+            if (delta_ms < 0) continue; // clock skew — skip probe
+
+            // Reset the per-stall firing latch when the slot driver has
+            // ticked since our last fire, so a subsequent stall fires
+            // again.
+            if (SUPPRESS_REFIRE and firing_for_current_stall) {
+                if (last_observed_tick_ms == null or last_tick != last_observed_tick_ms.?) {
+                    firing_for_current_stall = false;
+                }
+            }
+            last_observed_tick_ms = last_tick;
+
+            if (@as(u64, @intCast(delta_ms)) < self.threshold_ms) continue;
+            if (SUPPRESS_REFIRE and firing_for_current_stall) continue;
+
+            const stall_s: f32 = @as(f32, @floatFromInt(delta_ms)) / 1000.0;
+            zeam_metrics.metrics.zeam_slot_driver_stall_fired_total.incr();
+            zeam_metrics.metrics.zeam_slot_driver_stall_seconds.observe(stall_s);
+            self.logger.err(
+                "slot-driver stall detected: last tick {d:.3}s ago (threshold={d}ms). See #863.",
+                .{ stall_s, self.threshold_ms },
+            );
+            firing_for_current_stall = true;
+        }
+    }
+};

--- a/pkgs/node/src/slot_driver_watchdog.zig
+++ b/pkgs/node/src/slot_driver_watchdog.zig
@@ -1,6 +1,6 @@
 //! Slot-driver stall watchdog (#863).
 //!
-//! Spawns a background OS thread that probes `Clock.last_tick_time_ms` at
+//! Spawns a background OS thread that probes `Clock.lastTickMs()` at
 //! a fixed interval. When the gap between wall clock and the last tick
 //! exceeds `WATCHDOG_THRESHOLD_MS`, the watchdog:
 //!
@@ -92,32 +92,46 @@ pub const SlotDriverWatchdog = struct {
     /// `pkgs/node/src/stress.zig::sleepSecs` and use libc nanosleep
     /// directly so this watchdog stays cross-target without a libxev
     /// timer (which would itself depend on the loop we are watching).
-    fn sleepMs(ms: u64) void {
+    ///
+    /// Re-issues `nanosleep` on EINTR so a stray signal (e.g. a
+    /// future SIGUSR1-based stack-dump probe) cannot shorten the
+    /// probe interval. Aborts immediately when `stop_flag` is set
+    /// so shutdown isn't blocked by an in-flight long sleep.
+    fn sleepMs(self: *const SlotDriverWatchdog, ms: u64) void {
         const total_ns: u128 = @as(u128, ms) * @as(u128, std.time.ns_per_ms);
         var ts: std.c.timespec = .{
             .sec = @intCast(@divFloor(total_ns, std.time.ns_per_s)),
             .nsec = @intCast(@mod(total_ns, std.time.ns_per_s)),
         };
-        _ = std.c.nanosleep(&ts, &ts);
+        var rem: std.c.timespec = .{ .sec = 0, .nsec = 0 };
+        while (true) {
+            const rc = std.c.nanosleep(&ts, &rem);
+            if (rc == 0) return;
+            if (self.stop_flag.load(.acquire)) return;
+            // EINTR: continue with remainder. Other errnos are
+            // diagnostic-fatal to instrumentation only; bail.
+            const e = std.posix.errno(rc);
+            if (e != .INTR) return;
+            ts = rem;
+        }
     }
 
     fn runLoop(self: *SlotDriverWatchdog) void {
-        var last_observed_tick_ms: ?isize = null;
+        var last_observed_tick_ms: ?i64 = null;
         var firing_for_current_stall = false;
 
         while (!self.stop_flag.load(.acquire)) {
-            sleepMs(self.probe_ms);
+            self.sleepMs(self.probe_ms);
             if (self.stop_flag.load(.acquire)) break;
 
-            // `last_tick_time_ms` is mutated unsynchronised on the libxev
-            // thread. We accept torn reads on 32-bit platforms — the worst
-            // case is a transient spurious "stall" log, which is harmless
-            // for diagnostic instrumentation.
-            const last_tick_opt = self.clock.last_tick_time_ms;
-            const last_tick = last_tick_opt orelse continue;
+            // Atomic acquire load via the public `lastTickMs` accessor.
+            // Pairs with the release store in `Clock.tickInterval`, so
+            // there is no torn read even on 32-bit hosts where i64 is
+            // not naturally word-sized.
+            const last_tick = self.clock.lastTickMs() orelse continue;
 
-            const now_ms: isize = @intCast(zeam_utils.unixTimestampMillis());
-            const delta_ms: isize = now_ms - last_tick;
+            const now_ms: i64 = @intCast(zeam_utils.unixTimestampMillis());
+            const delta_ms: i64 = now_ms - last_tick;
             if (delta_ms < 0) continue; // clock skew — skip probe
 
             // Reset the per-stall firing latch when the slot driver has


### PR DESCRIPTION
## What this PR does

Adds two diagnostic tools to help us figure out where time is going inside zeam when the slot driver stalls (the multi-second freezes seen on the devnet-4 aggregator in #863).

Nothing in this PR fixes the stalls themselves. It just makes them visible and attributable, so the next perf PRs can target the actual cost.

## 1. A watchdog thread that flags stalls

A small background thread wakes up every second and checks how long it's been since the main loop last ticked the clock. If the gap is more than 5 seconds, it:

- logs an error: `slot-driver stall detected: last tick 604.389s ago (threshold=5000ms). See #863.`
- bumps a Prometheus counter: `zeam_slot_driver_stall_fired_total`
- records the stall length in a histogram: `zeam_slot_driver_stall_seconds` (1, 2, 5, 10, 30, 60, 120, 300, 600 second buckets)

If the freeze lasts 600 seconds, the watchdog only logs once. It re-arms only after the slot driver ticks again, otherwise we'd get one log per second for the whole freeze.

The watchdog runs on its own OS thread, so it keeps working even if the main loop or libp2p thread is completely stuck.

(Per-thread stack dumps would be nice — but Zig 0.16's signal-handler API is unstable. Easy to add later if the metric tells us we need it.)

## 2. A per-step timing breakdown for `chain.onBlock`

`chain.onBlock` is a multi-stage process: hash the block, clone parent state, verify signatures, run the state transition, update fork choice, persist to DB, etc. Today we only see the total time. With this PR each stage gets its own histogram entry under the label `step`:

| `step` label | what it measures |
|---|---|
| `block_root_compute` | hashing the block (when the caller didn't pre-compute the root) |
| `parent_state_clone` | snapshot + clone of the parent state |
| `verify_signatures` | XMSS signature verification |
| `state_transition` | the actual STF (process_slots + process_block) |
| `ssz_serialize_fallback` | re-serialising the block when no precomputed bytes were supplied |
| `forkchoice_onblock` | adding the block to fork choice |
| `block_attestations` | processing attestations carried by the block |
| `db_persist` | writing the block + state to RocksDB / LMDB |

Buckets match the existing `zeam_chain_onblock_duration_seconds` so dashboards can stack the per-step series next to the total.

## Why this PR first

#863 shows the aggregator (`zeam_0`) had:

- 5 onBlock calls > 1s, 2 > 5s, 1 > 10s
- 12 xev drains > 10s, 3 > 60s
- one window where the process froze for 604 seconds

Peers on the same host stayed healthy, so this isn't host pressure — it's per-process. Without per-step timing we can't tell whether the time goes into signature verify, STF, DB writes, or somewhere else. And without the watchdog those long freezes are hard to spot in noisy logs.

The next perf PRs (lock-free pubkey cache, etc.) need this attribution to actually claim wins.

## Validation

- `zig build` clean (Debug + ReleaseFast)
- `zig build test -Dprover=dummy --summary all` passes
- `zig fmt` clean
- Hot path overhead: a few `monotonicTimestampNs` calls and one HistogramVec observe per step. Negligible.

## Out of scope

- Per-thread stack dump on stall (waiting on stable Zig signal API).
- The actual perf fixes — those come in P1 and beyond.

Refs #863.