### PR TITLE
perf(node): fix slot-driver starvation under gossip flood (#863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,10 @@ jobs:
       with:
         toolchain: stable
         components: clippy, rustfmt
-        # The action bundles Swatinem/rust-cache at repo root; our Cargo
-        # workspace lives under rust/. Disable here and use an explicit
-        # rust-cache step with workspaces: rust -> target.
+        # Infra (not #863 perf): setup-rust-toolchain's bundled rust-cache
+        # runs `cargo metadata` at repo root, but zeam's workspace is rust/.
+        # macOS runners also need the Ensure-rustup shim step before any
+        # plain `cargo` call — see workflow comments on that step.
         cache: false
 
     - name: Verify installation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,4 +575,7 @@ jobs:
         push: false  # Don't push, just build to verify
         tags: zeam:ci-${{ github.run_number }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # `ignore-error=true`: cache export talks to GitHub's Actions Cache
+        # API; intermittent 502/HTML responses fail the whole job even when
+        # the image build succeeded (see docker-build ubuntu-22.04-arm on #886).
+        cache-to: type=gha,mode=max,ignore-error=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       with:
         toolchain: stable
         components: clippy, rustfmt
+        # The action bundles Swatinem/rust-cache at repo root; our Cargo
+        # workspace lives under rust/. Disable here and use an explicit
+        # rust-cache step with workspaces: rust -> target.
+        cache: false
 
     - name: Verify installation
       run: |
@@ -62,6 +66,7 @@ jobs:
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
       with:
+        workspaces: "rust -> target"
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Check Rust formatting
@@ -101,6 +106,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
+        cache: false
 
     - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
@@ -118,12 +124,17 @@ jobs:
         # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
         # because the `actions-rust-lang/setup-rust-toolchain` step has
         # already done that.
-        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+        #
+        # Swatinem/rust-cache and other steps invoke plain `cargo` on PATH.
+        # `rustup run nightly cargo` can still work while ~/.cargo/bin/cargo
+        # is broken, so we must not use only the latter as the health check.
+        if ! command -v cargo >/dev/null 2>&1 || ! cargo --version >/dev/null 2>&1; then
           echo "Rustup proxy shims are broken; reinstalling via rustup-init"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
             | sh -s -- -y --default-toolchain nightly --no-modify-path \
                        --profile minimal --force
         fi
+        cargo --version
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -197,6 +208,7 @@ jobs:
       with:
         toolchain: nightly
         components: clippy, rustfmt
+        cache: false
 
     - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
@@ -214,12 +226,17 @@ jobs:
         # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
         # because the `actions-rust-lang/setup-rust-toolchain` step has
         # already done that.
-        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+        #
+        # Swatinem/rust-cache and other steps invoke plain `cargo` on PATH.
+        # `rustup run nightly cargo` can still work while ~/.cargo/bin/cargo
+        # is broken, so we must not use only the latter as the health check.
+        if ! command -v cargo >/dev/null 2>&1 || ! cargo --version >/dev/null 2>&1; then
           echo "Rustup proxy shims are broken; reinstalling via rustup-init"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
             | sh -s -- -y --default-toolchain nightly --no-modify-path \
                        --profile minimal --force
         fi
+        cargo --version
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -301,6 +318,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
+        cache: false
 
     - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
@@ -318,12 +336,17 @@ jobs:
         # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
         # because the `actions-rust-lang/setup-rust-toolchain` step has
         # already done that.
-        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+        #
+        # Swatinem/rust-cache and other steps invoke plain `cargo` on PATH.
+        # `rustup run nightly cargo` can still work while ~/.cargo/bin/cargo
+        # is broken, so we must not use only the latter as the health check.
+        if ! command -v cargo >/dev/null 2>&1 || ! cargo --version >/dev/null 2>&1; then
           echo "Rustup proxy shims are broken; reinstalling via rustup-init"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
             | sh -s -- -y --default-toolchain nightly --no-modify-path \
                        --profile minimal --force
         fi
+        cargo --version
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -425,6 +448,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
+        cache: false
 
     - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
@@ -442,12 +466,17 @@ jobs:
         # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
         # because the `actions-rust-lang/setup-rust-toolchain` step has
         # already done that.
-        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+        #
+        # Swatinem/rust-cache and other steps invoke plain `cargo` on PATH.
+        # `rustup run nightly cargo` can still work while ~/.cargo/bin/cargo
+        # is broken, so we must not use only the latter as the health check.
+        if ! command -v cargo >/dev/null 2>&1 || ! cargo --version >/dev/null 2>&1; then
           echo "Rustup proxy shims are broken; reinstalling via rustup-init"
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
             | sh -s -- -y --default-toolchain nightly --no-modify-path \
                        --profile minimal --force
         fi
+        cargo --version
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -521,6 +550,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
+        cache: false
 
     - name: Cache Zig packages
       uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,16 +102,28 @@ jobs:
       with:
         toolchain: nightly
 
-    - name: Prefer rustup shims on PATH (macOS)
+    - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
       run: |
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        command -v cargo
-        # Verify the nightly toolchain is reachable. Use `rustup run`
-        # rather than the `+nightly` selector — the latter requires
-        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
-        # some macOS runner images that path is `rustup-init` and
-        # the `+nightly` selector fails with "unexpected argument".
+        # The macos-15-arm64 GitHub Actions runner image ships with
+        # `~/.cargo/bin/{cargo,rustup}` as symlinks that resolve to the
+        # `rustup-init` installer (same multi-call binary, but rustup picks
+        # its mode from the resolved exe basename, so the shims behave as
+        # the installer rather than as the rustup/cargo proxies). That
+        # breaks every `cargo` / `rustup run` invocation with
+        # `error: unexpected argument 'foo' found / Usage: rustup-init…`.
+        #
+        # The official installer fixes this by recreating the proxy shims
+        # as hardlinks, so we re-run it (with --force) before any cargo
+        # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
+        # because the `actions-rust-lang/setup-rust-toolchain` step has
+        # already done that.
+        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+          echo "Rustup proxy shims are broken; reinstalling via rustup-init"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain nightly --no-modify-path \
+                       --profile minimal --force
+        fi
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -186,16 +198,28 @@ jobs:
         toolchain: nightly
         components: clippy, rustfmt
 
-    - name: Prefer rustup shims on PATH (macOS)
+    - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
       run: |
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        command -v cargo
-        # Verify the nightly toolchain is reachable. Use `rustup run`
-        # rather than the `+nightly` selector — the latter requires
-        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
-        # some macOS runner images that path is `rustup-init` and
-        # the `+nightly` selector fails with "unexpected argument".
+        # The macos-15-arm64 GitHub Actions runner image ships with
+        # `~/.cargo/bin/{cargo,rustup}` as symlinks that resolve to the
+        # `rustup-init` installer (same multi-call binary, but rustup picks
+        # its mode from the resolved exe basename, so the shims behave as
+        # the installer rather than as the rustup/cargo proxies). That
+        # breaks every `cargo` / `rustup run` invocation with
+        # `error: unexpected argument 'foo' found / Usage: rustup-init…`.
+        #
+        # The official installer fixes this by recreating the proxy shims
+        # as hardlinks, so we re-run it (with --force) before any cargo
+        # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
+        # because the `actions-rust-lang/setup-rust-toolchain` step has
+        # already done that.
+        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+          echo "Rustup proxy shims are broken; reinstalling via rustup-init"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain nightly --no-modify-path \
+                       --profile minimal --force
+        fi
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -278,16 +302,28 @@ jobs:
       with:
         toolchain: nightly
 
-    - name: Prefer rustup shims on PATH (macOS)
+    - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
       run: |
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        command -v cargo
-        # Verify the nightly toolchain is reachable. Use `rustup run`
-        # rather than the `+nightly` selector — the latter requires
-        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
-        # some macOS runner images that path is `rustup-init` and
-        # the `+nightly` selector fails with "unexpected argument".
+        # The macos-15-arm64 GitHub Actions runner image ships with
+        # `~/.cargo/bin/{cargo,rustup}` as symlinks that resolve to the
+        # `rustup-init` installer (same multi-call binary, but rustup picks
+        # its mode from the resolved exe basename, so the shims behave as
+        # the installer rather than as the rustup/cargo proxies). That
+        # breaks every `cargo` / `rustup run` invocation with
+        # `error: unexpected argument 'foo' found / Usage: rustup-init…`.
+        #
+        # The official installer fixes this by recreating the proxy shims
+        # as hardlinks, so we re-run it (with --force) before any cargo
+        # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
+        # because the `actions-rust-lang/setup-rust-toolchain` step has
+        # already done that.
+        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+          echo "Rustup proxy shims are broken; reinstalling via rustup-init"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain nightly --no-modify-path \
+                       --profile minimal --force
+        fi
         rustup run nightly cargo --version
 
     - name: Cache Zig packages
@@ -390,16 +426,28 @@ jobs:
       with:
         toolchain: nightly
 
-    - name: Prefer rustup shims on PATH (macOS)
+    - name: Ensure rustup proxy shims (macOS)
       if: runner.os == 'macOS'
       run: |
-        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-        command -v cargo
-        # Verify the nightly toolchain is reachable. Use `rustup run`
-        # rather than the `+nightly` selector — the latter requires
-        # `~/.cargo/bin/cargo` to be the rustup proxy shim, but on
-        # some macOS runner images that path is `rustup-init` and
-        # the `+nightly` selector fails with "unexpected argument".
+        # The macos-15-arm64 GitHub Actions runner image ships with
+        # `~/.cargo/bin/{cargo,rustup}` as symlinks that resolve to the
+        # `rustup-init` installer (same multi-call binary, but rustup picks
+        # its mode from the resolved exe basename, so the shims behave as
+        # the installer rather than as the rustup/cargo proxies). That
+        # breaks every `cargo` / `rustup run` invocation with
+        # `error: unexpected argument 'foo' found / Usage: rustup-init…`.
+        #
+        # The official installer fixes this by recreating the proxy shims
+        # as hardlinks, so we re-run it (with --force) before any cargo
+        # call. We don't add `~/.cargo/bin` to GITHUB_PATH explicitly
+        # because the `actions-rust-lang/setup-rust-toolchain` step has
+        # already done that.
+        if ! rustup run nightly cargo --version >/dev/null 2>&1; then
+          echo "Rustup proxy shims are broken; reinstalling via rustup-init"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain nightly --no-modify-path \
+                       --profile minimal --force
+        fi
         rustup run nightly cargo --version
 
     - name: Cache Zig packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ZIG_VERSION="0.16.0" && \
     mv "zig-${ZIG_ARCH}-linux-${ZIG_VERSION}" /opt/zig && \
     ln -s /opt/zig/zig /usr/local/bin/zig
 
-# Install Rust nightly (required by build.zig: cargo +nightly …)
+# Install Rust nightly (required by build.zig: rustup run nightly cargo …)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/build.zig
+++ b/build.zig
@@ -864,32 +864,47 @@ fn build_rust_project(b: *Builder, path: []const u8, prover: ProverChoice) *Buil
     // Every Rust glue crate is routed through the `zeam-glue` staticlib shim;
     // feature flags control which per-prover rlibs get linked in. See the
     // comment on `addRustGlueLib` and blockblaz/zeam#773.
-    // `cargo +nightly` requires rustup's Cargo shim (not Homebrew's standalone Cargo).
-    // CI prepends `$HOME/.cargo/bin` on macOS before rust-cache / zig build (see ci.yml).
+    //
+    // We invoke `rustup run nightly cargo …` rather than `cargo +nightly`.
+    // Both reach the same toolchain on a properly-installed rustup, but
+    // the `+nightly` selector requires `cargo` on PATH to be rustup's
+    // proxy shim (i.e. `~/.cargo/bin/cargo`). On the GitHub-Actions
+    // `macos-latest` runner image that path is the `rustup-init`
+    // installer, which doesn't recognise the `+toolchain` syntax and
+    // exits with `error: unexpected argument '+nightly' found`. Going
+    // through `rustup run` resolves the toolchain inside rustup itself
+    // (`rustup` IS the proxy on every supported install), so we don't
+    // depend on `cargo` being a particular flavour of binary.
+    //
+    // Local-dev requirement: rustup must be installed. Standalone
+    // Cargo (e.g. Homebrew-only) won't satisfy `rustup run nightly`
+    // any more than it satisfied the previous `cargo +nightly` shape.
     const cargo_build = switch (prover) {
         .dummy => b.addSystemCommand(&.{
-            "cargo",                   "+nightly",         "-C",                    path,
-            "-Z",                      "unstable-options", "build",                 "--release",
-            "-p",                      "zeam-glue",        "--no-default-features", "--features",
-            "libp2p,hashsig,multisig",
+            "rustup",                  "run",              "nightly",               "cargo",
+            "-C",                      path,               "-Z",                    "unstable-options",
+            "build",                   "--release",        "-p",                    "zeam-glue",
+            "--no-default-features",   "--features",       "libp2p,hashsig,multisig",
         }),
         .risc0 => b.addSystemCommand(&.{
-            "cargo",         "+nightly",                      "-C",        path,
-            "-Z",            "unstable-options",              "build",     "--profile",
-            "risc0-release", "-p",                            "zeam-glue", "--no-default-features",
+            "rustup",        "run",                           "nightly",   "cargo",
+            "-C",            path,                            "-Z",        "unstable-options",
+            "build",         "--profile",                     "risc0-release",
+            "-p",            "zeam-glue",                     "--no-default-features",
             "--features",    "libp2p,hashsig,multisig,risc0",
         }),
         .openvm => b.addSystemCommand(&.{
-            "cargo",          "+nightly",                       "-C",        path,
-            "-Z",             "unstable-options",               "build",     "--profile",
-            "openvm-release", "-p",                             "zeam-glue", "--no-default-features",
+            "rustup",         "run",                            "nightly",   "cargo",
+            "-C",             path,                             "-Z",        "unstable-options",
+            "build",          "--profile",                      "openvm-release",
+            "-p",             "zeam-glue",                      "--no-default-features",
             "--features",     "libp2p,hashsig,multisig,openvm",
         }),
         .all => b.addSystemCommand(&.{
-            "cargo",                                "+nightly",         "-C",                    path,
-            "-Z",                                   "unstable-options", "build",                 "--release",
-            "-p",                                   "zeam-glue",        "--no-default-features", "--features",
-            "libp2p,hashsig,multisig,risc0,openvm",
+            "rustup",                               "run",              "nightly",               "cargo",
+            "-C",                                   path,               "-Z",                    "unstable-options",
+            "build",                                "--release",        "-p",                    "zeam-glue",
+            "--no-default-features",                "--features",       "libp2p,hashsig,multisig,risc0,openvm",
         }),
     };
 

--- a/build.zig
+++ b/build.zig
@@ -881,30 +881,28 @@ fn build_rust_project(b: *Builder, path: []const u8, prover: ProverChoice) *Buil
     // any more than it satisfied the previous `cargo +nightly` shape.
     const cargo_build = switch (prover) {
         .dummy => b.addSystemCommand(&.{
-            "rustup",                  "run",              "nightly",               "cargo",
-            "-C",                      path,               "-Z",                    "unstable-options",
-            "build",                   "--release",        "-p",                    "zeam-glue",
-            "--no-default-features",   "--features",       "libp2p,hashsig,multisig",
+            "rustup",                "run",        "nightly",                 "cargo",
+            "-C",                    path,         "-Z",                      "unstable-options",
+            "build",                 "--release",  "-p",                      "zeam-glue",
+            "--no-default-features", "--features", "libp2p,hashsig,multisig",
         }),
         .risc0 => b.addSystemCommand(&.{
-            "rustup",        "run",                           "nightly",   "cargo",
-            "-C",            path,                            "-Z",        "unstable-options",
-            "build",         "--profile",                     "risc0-release",
-            "-p",            "zeam-glue",                     "--no-default-features",
-            "--features",    "libp2p,hashsig,multisig,risc0",
+            "rustup",    "run",                   "nightly",       "cargo",
+            "-C",        path,                    "-Z",            "unstable-options",
+            "build",     "--profile",             "risc0-release", "-p",
+            "zeam-glue", "--no-default-features", "--features",    "libp2p,hashsig,multisig,risc0",
         }),
         .openvm => b.addSystemCommand(&.{
-            "rustup",         "run",                            "nightly",   "cargo",
-            "-C",             path,                             "-Z",        "unstable-options",
-            "build",          "--profile",                      "openvm-release",
-            "-p",             "zeam-glue",                      "--no-default-features",
-            "--features",     "libp2p,hashsig,multisig,openvm",
+            "rustup",    "run",                   "nightly",        "cargo",
+            "-C",        path,                    "-Z",             "unstable-options",
+            "build",     "--profile",             "openvm-release", "-p",
+            "zeam-glue", "--no-default-features", "--features",     "libp2p,hashsig,multisig,openvm",
         }),
         .all => b.addSystemCommand(&.{
-            "rustup",                               "run",              "nightly",               "cargo",
-            "-C",                                   path,               "-Z",                    "unstable-options",
-            "build",                                "--release",        "-p",                    "zeam-glue",
-            "--no-default-features",                "--features",       "libp2p,hashsig,multisig,risc0,openvm",
+            "rustup",                "run",        "nightly",                              "cargo",
+            "-C",                    path,         "-Z",                                   "unstable-options",
+            "build",                 "--release",  "-p",                                   "zeam-glue",
+            "--no-default-features", "--features", "libp2p,hashsig,multisig,risc0,openvm",
         }),
     };
 

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -311,6 +311,30 @@ const Metrics = struct {
     // ~1.25 Hz at 4s slots) is a quick liveness signal independent of
     // the existing `lean_tick_interval_duration_seconds` histogram.
     zeam_xev_clock_drain_passes_total: ZeamXevClockDrainPassesCounter,
+    // leanSpec parity (`subspecs/sync/service.py`): gossip attestations
+    // and aggregations whose referenced source/target/head block isn't
+    // yet imported, or whose slot is still in the future, are buffered
+    // for replay after the next successful `onBlock` import (see
+    // `_replay_pending_attestations` in the spec; mirrored as
+    // `replayPendingAttestations` in `chain.zig`).
+    //
+    //   * `lean_pending_attestations_buffered_total{kind, reason}` —
+    //     cumulative entries pushed into the pending-attestation buffer.
+    //     `kind={attestation,aggregation}`, `reason={unknown_block,future_slot}`.
+    //   * `lean_pending_attestations_evicted_total{kind}` — entries
+    //     dropped via FIFO eviction at MAX_PENDING_ATTESTATIONS (1024,
+    //     spec value).
+    //   * `lean_pending_attestations_replay_total{kind, outcome}` —
+    //     replay attempts. `outcome={accepted,buffered,dropped}`:
+    //     `accepted` = validate+verify succeeded after replay,
+    //     `buffered` = still missing block (re-enqueued), `dropped` =
+    //     permanent failure (signature, malformed, etc).
+    //   * `lean_pending_attestations_size{kind}` — instantaneous buffer
+    //     depth, refreshed after every enqueue/replay drain.
+    lean_pending_attestations_buffered_total: LeanPendingAttsBufferedCounter,
+    lean_pending_attestations_evicted_total: LeanPendingAttsEvictedCounter,
+    lean_pending_attestations_replay_total: LeanPendingAttsReplayCounter,
+    lean_pending_attestations_size: LeanPendingAttsSizeGauge,
     // Per-site errors swallowed by `BeamNode.onInterval`; sustained non-zero
     // rates mean the node is ticking but a duty/publish layer is failing.
     lean_node_interval_error_total: LeanNodeIntervalErrorCounter,
@@ -449,6 +473,10 @@ const Metrics = struct {
     const ZeamGossipAttsDroppedCounter = metrics_lib.CounterVec(u64, struct { kind: []const u8, reason: []const u8 });
     const ZeamBlocksByRootInflightGauge = metrics_lib.Gauge(u64);
     const ZeamXevClockDrainPassesCounter = metrics_lib.Counter(u64);
+    const LeanPendingAttsBufferedCounter = metrics_lib.CounterVec(u64, struct { kind: []const u8, reason: []const u8 });
+    const LeanPendingAttsEvictedCounter = metrics_lib.CounterVec(u64, struct { kind: []const u8 });
+    const LeanPendingAttsReplayCounter = metrics_lib.CounterVec(u64, struct { kind: []const u8, outcome: []const u8 });
+    const LeanPendingAttsSizeGauge = metrics_lib.GaugeVec(u64, struct { kind: []const u8 });
     // Issue #837 — see `lean_node_interval_error_total` field doc.
     const LeanNodeIntervalErrorCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
     const AggregateSkipCounter = metrics_lib.CounterVec(u64, struct { reason: []const u8 });
@@ -882,9 +910,15 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_gossip_atts_dropped_total = try Metrics.ZeamGossipAttsDroppedCounter.init(allocator, io, "zeam_gossip_atts_dropped_total", .{ .help = "Total number of gossip attestations/aggregations dropped on the libxev main thread before chain-worker dispatch. Labeled by kind={attestation,aggregation} and reason={syncing,future_slot,worker_validation_failed}. zeam-specific. See blockblaz/zeam#863." }, .{}),
         .zeam_blocks_by_root_inflight = Metrics.ZeamBlocksByRootInflightGauge.init("zeam_blocks_by_root_inflight", .{ .help = "Instantaneous count of outbound `BlocksByRoot` RPCs that have been dispatched but not yet finalized via `finalizePendingRequest`. Capped at MAX_CONCURRENT_BLOCKS_BY_ROOT (8) to bound per-flood dispatch fan-out. zeam-specific. See blockblaz/zeam#863." }, .{}),
         .zeam_xev_clock_drain_passes_total = Metrics.ZeamXevClockDrainPassesCounter.init("zeam_xev_clock_drain_passes_total", .{ .help = "Cumulative passes through `Clock.run`'s libxev drain (one io_uring CQE batch per pass via `events.run(.once)`). Compare scrape deltas against the expected ~1.25 Hz at 4s slots / 5 intervals to detect slot-driver wedges independent of `lean_tick_interval_duration_seconds`. See blockblaz/zeam#863." }, .{}),
+        .lean_pending_attestations_buffered_total = try Metrics.LeanPendingAttsBufferedCounter.init(allocator, io, "lean_pending_attestations_buffered_total", .{ .help = "Gossip attestations / aggregations buffered for replay after a future onBlock import. Mirrors leanSpec subspecs/sync/service.py::_pending_attestations buffer push. Labeled by kind={attestation,aggregation} and reason={unknown_block,future_slot}." }, .{}),
+        .lean_pending_attestations_evicted_total = try Metrics.LeanPendingAttsEvictedCounter.init(allocator, io, "lean_pending_attestations_evicted_total", .{ .help = "Pending-attestation buffer FIFO evictions when MAX_PENDING_ATTESTATIONS (1024, leanSpec subspecs/sync/config.py) is reached. Labeled by kind={attestation,aggregation}." }, .{}),
+        .lean_pending_attestations_replay_total = try Metrics.LeanPendingAttsReplayCounter.init(allocator, io, "lean_pending_attestations_replay_total", .{ .help = "Outcomes of replayPendingAttestations attempts (mirrors leanSpec _replay_pending_attestations). Labeled by kind={attestation,aggregation} and outcome={accepted,buffered,dropped}." }, .{}),
+        .lean_pending_attestations_size = try Metrics.LeanPendingAttsSizeGauge.init(allocator, io, "lean_pending_attestations_size", .{ .help = "Instantaneous pending-attestation buffer depth, labeled by kind={attestation,aggregation}. Bounded by MAX_PENDING_ATTESTATIONS (1024)." }, .{}),
         .lean_node_interval_error_total = try Metrics.LeanNodeIntervalErrorCounter.init(allocator, io, "lean_node_interval_error_total", .{ .help = "Total number of application-layer failures inside `BeamNode.onInterval` that were logged-and-continued (issue #837). Sustained non-zero rate per site means 'node alive, validator/aggregator silently failing' — ALERT ON THIS, the slot/interval cursor itself no longer wedges. Labeled by site: chain.onInterval, chain.runPeriodicPruning, validator.onInterval, publishBlock, publishAttestation, publishAggregation, maybeAggregateOnInterval, publishProducedAggregations." }, .{}),
     };
     metrics.zeam_blocks_by_root_inflight.set(0);
+    metrics.lean_pending_attestations_size.set(.{ .kind = "attestation" }, 0) catch {};
+    metrics.lean_pending_attestations_size.set(.{ .kind = "aggregation" }, 0) catch {};
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
     metrics.lean_validators_count.set(0);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -261,6 +261,56 @@ const Metrics = struct {
     //     review followup). The benign TOCTOU window is documented
     //     in `BeamNode.fetchBlockByRoots`.
     lean_block_fetch_dedup_total: LeanBlockFetchDedupCounter,
+    // Issue #863 P2: gossip attestation/aggregation drops on the libxev
+    // main thread BEFORE they are routed to the chain-worker. Bumped by
+    // `chain.onGossip` for raw attestations and aggregations. zeam-
+    // specific (other lean clients shape this differently). Labels:
+    //   * `kind` — `attestation` (raw gossip att) or `aggregation`
+    //     (aggregated payload).
+    //   * `reason`:
+    //     - `syncing` — chain.getSyncStatus() is `behind_peers` /
+    //       `fc_initing` / `no_peers`; suppress validation work and the
+    //       follow-up `BlocksByRoot` fetch enqueue (the death-spiral fix).
+    //       Recovery comes from `BlocksByRange` / gossip block import.
+    //     - `future_slot` — `att.slot > current_slot + GOSSIP_FUTURE_SLOT_TOLERANCE`;
+    //       no point validating against a head we don't know yet, and the
+    //       missing-root would be unhelpful (it's a head we're racing
+    //       against, not a real fetch target).
+    //     - `worker_validation_failed` — attestation reached the chain-
+    //       worker but `validateAttestationData` rejected it on-thread;
+    //       includes the unknown-{head,source,target} cases that used to
+    //       trigger a fetch storm. The chain-worker path silently drops
+    //       these (per the established `chainWorkerOn*Thunk` no-feedback
+    //       contract) so this counter is the only signal.
+    zeam_gossip_atts_dropped_total: ZeamGossipAttsDroppedCounter,
+    // Issue #863 P3: per-resource concurrency cap on outbound
+    // `BlocksByRoot` RPCs. The pre-#863 path issued one RPC per
+    // attestation that referenced an unknown head, multiplied by 4x
+    // subnet fanout for an aggregator — under flood the libxev thread
+    // would fork off hundreds of RPCs that themselves timed out and
+    // retried, saturating the loop. The cap pins concurrent outbound
+    // BlocksByRoot to MAX_CONCURRENT_BLOCKS_BY_ROOT (typically 8) so
+    // gossip pressure can't run the request fan-out away. zeam-specific
+    // (the cap is a zeam implementation detail, not a spec constraint).
+    //   * `zeam_blocks_by_root_inflight` — instantaneous count of
+    //     outbound `BlocksByRoot` RPCs that have been dispatched but
+    //     have not yet been finalized via `finalizePendingRequest`.
+    //   * the cap-rejection bucket is folded into
+    //     `lean_block_fetch_dedup_total{outcome="inflight_cap"}` so
+    //     dashboards see all suppression-by-this-PR causes side by side
+    //     with the existing dedup outcomes — keeps the
+    //     `sum(rate(... by outcome)) == sum(rate(...))` invariant.
+    zeam_blocks_by_root_inflight: ZeamBlocksByRootInflightGauge,
+    // Issue #863 P4: Clock.run drain bounding visibility. The pre-#863
+    // shape called `events.run(.until_done)` per pass, which under
+    // flood drained for many seconds and starved `tickInterval`.
+    // P4 swaps to `.once` (one io_uring CQE batch per pass), which
+    // returns to `tickInterval` as soon as the next-interval timer or
+    // any other completion fires. This counter is the rate of clock
+    // passes — comparing scrape deltas to expected (`5 / SECONDS_PER_SLOT`,
+    // ~1.25 Hz at 4s slots) is a quick liveness signal independent of
+    // the existing `lean_tick_interval_duration_seconds` histogram.
+    zeam_xev_clock_drain_passes_total: ZeamXevClockDrainPassesCounter,
     // Per-site errors swallowed by `BeamNode.onInterval`; sustained non-zero
     // rates mean the node is ticking but a duty/publish layer is failing.
     lean_node_interval_error_total: LeanNodeIntervalErrorCounter,
@@ -395,6 +445,10 @@ const Metrics = struct {
     // Slice (d)/(e) of #803.
     const LeanBlockRootComputeSkippedCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
     const LeanBlockFetchDedupCounter = metrics_lib.CounterVec(u64, struct { outcome: []const u8 });
+    // Issue #863 P2/P3 metric types.
+    const ZeamGossipAttsDroppedCounter = metrics_lib.CounterVec(u64, struct { kind: []const u8, reason: []const u8 });
+    const ZeamBlocksByRootInflightGauge = metrics_lib.Gauge(u64);
+    const ZeamXevClockDrainPassesCounter = metrics_lib.Counter(u64);
     // Issue #837 — see `lean_node_interval_error_total` field doc.
     const LeanNodeIntervalErrorCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
     const AggregateSkipCounter = metrics_lib.CounterVec(u64, struct { reason: []const u8 });
@@ -823,10 +877,14 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.
         .lean_block_root_compute_skipped_total = try Metrics.LeanBlockRootComputeSkippedCounter.init(allocator, io, "lean_block_root_compute_skipped_total", .{ .help = "Total number of times a downstream consumer skipped a `hashTreeRoot(BeamBlock)` because the producer threaded a precomputed root through (slice (e) of #803). Labeled by skip site." }, .{}),
-        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched, fetch_no_peers, fetch_failed, dedup_lost_race." }, .{}),
-        // Issue #837 — see field doc for label semantics.
+        .lean_block_fetch_dedup_total = try Metrics.LeanBlockFetchDedupCounter.init(allocator, io, "lean_block_fetch_dedup_total", .{ .help = "Total number of `fetchBlockByRoots` per-root outcomes (slice (d) of #803). Labeled by outcome: already_in_forkchoice, already_in_block_cache, already_pending, fetched, fetch_no_peers, fetch_failed, dedup_lost_race, inflight_cap." }, .{}),
+        // Issue #863 P2/P3/P4 — see field doc for label semantics.
+        .zeam_gossip_atts_dropped_total = try Metrics.ZeamGossipAttsDroppedCounter.init(allocator, io, "zeam_gossip_atts_dropped_total", .{ .help = "Total number of gossip attestations/aggregations dropped on the libxev main thread before chain-worker dispatch. Labeled by kind={attestation,aggregation} and reason={syncing,future_slot,worker_validation_failed}. zeam-specific. See blockblaz/zeam#863." }, .{}),
+        .zeam_blocks_by_root_inflight = Metrics.ZeamBlocksByRootInflightGauge.init("zeam_blocks_by_root_inflight", .{ .help = "Instantaneous count of outbound `BlocksByRoot` RPCs that have been dispatched but not yet finalized via `finalizePendingRequest`. Capped at MAX_CONCURRENT_BLOCKS_BY_ROOT (8) to bound per-flood dispatch fan-out. zeam-specific. See blockblaz/zeam#863." }, .{}),
+        .zeam_xev_clock_drain_passes_total = Metrics.ZeamXevClockDrainPassesCounter.init("zeam_xev_clock_drain_passes_total", .{ .help = "Cumulative passes through `Clock.run`'s libxev drain (one io_uring CQE batch per pass via `events.run(.once)`). Compare scrape deltas against the expected ~1.25 Hz at 4s slots / 5 intervals to detect slot-driver wedges independent of `lean_tick_interval_duration_seconds`. See blockblaz/zeam#863." }, .{}),
         .lean_node_interval_error_total = try Metrics.LeanNodeIntervalErrorCounter.init(allocator, io, "lean_node_interval_error_total", .{ .help = "Total number of application-layer failures inside `BeamNode.onInterval` that were logged-and-continued (issue #837). Sustained non-zero rate per site means 'node alive, validator/aggregator silently failing' — ALERT ON THIS, the slot/interval cursor itself no longer wedges. Labeled by site: chain.onInterval, chain.runPeriodicPruning, validator.onInterval, publishBlock, publishAttestation, publishAggregation, maybeAggregateOnInterval, publishProducedAggregations." }, .{}),
     };
+    metrics.zeam_blocks_by_root_inflight.set(0);
 
     // Initialize validators count to 0 by default (spec requires "On scrape" availability)
     metrics.lean_validators_count.set(0);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -311,6 +311,26 @@ pub const BeamChain = struct {
     /// stop/deinit/destroy ordering at the top of `BeamChain.deinit`.
     chain_worker: ?*chain_worker.ChainWorker = null,
 
+    /// leanSpec parity (`subspecs/sync/service.py::_pending_attestations`,
+    /// `_pending_aggregated_attestations`): gossip attestations whose
+    /// referenced source/target/head block is not yet imported, OR whose
+    /// slot is still in the future, are buffered here for replay after
+    /// the next successful `onBlock` import (`_replay_pending_attestations`
+    /// in the spec; mirrored by `replayPendingAttestations` below).
+    ///
+    /// Capacity bounded by `constants.MAX_PENDING_ATTESTATIONS` (1024,
+    /// the spec's `MAX_PENDING_ATTESTATIONS`); FIFO eviction once full.
+    ///
+    /// Concurrency: appends happen on the chain-worker thread (gossip
+    /// dispatch lands in `chainWorkerOn*Thunk`) and on the calling
+    /// thread when the worker is disabled (tests / single-threaded
+    /// mode). Reads happen during `replayPendingAttestations` from the
+    /// chain-worker thread. Guarded by a mutex so the test path stays
+    /// safe even though prod uses a single writer.
+    pending_attestations_mutex: zeam_utils.SyncMutex = .{},
+    pending_attestations: std.ArrayListUnmanaged(networks.AttestationGossip) = .empty,
+    pending_aggregated_attestations: std.ArrayListUnmanaged(types.SignedAggregatedAttestation) = .empty,
+
     pub const PruneCachedBlocksFn = *const fn (ptr: *anyopaque, finalized: types.Checkpoint) usize;
 
     const Self = @This();
@@ -402,6 +422,12 @@ pub const BeamChain = struct {
             // aggregate_io: dedicated Io.Threaded for aggregate FFI worker (issue #873).
             .aggregate_io = agg_io,
             .aggregate_group = .init,
+            // leanSpec _pending_attestations / _pending_aggregated_attestations
+            // buffers — empty at init; FIFO-bounded by
+            // constants.MAX_PENDING_ATTESTATIONS in the enqueue helpers.
+            .pending_attestations_mutex = .{},
+            .pending_attestations = .empty,
+            .pending_aggregated_attestations = .empty,
         };
         // Initialize cache with anchor block root and any post-finalized entries from state
         try chain.root_to_slot_cache.put(fork_choice.head.blockRoot, opts.anchorState.slot);
@@ -469,6 +495,253 @@ pub const BeamChain = struct {
     }
 
     // ------------------------------------------------------------------
+    // leanSpec pending-attestation buffer (subspecs/sync/service.py)
+    // ------------------------------------------------------------------
+    //
+    // Direct mirror of the spec's `_pending_attestations` and
+    // `_pending_aggregated_attestations` lists plus
+    // `_replay_pending_attestations`. The spec's contract:
+    //
+    //   * Validation failure (AssertionError / KeyError) on a gossip
+    //     attestation/aggregation → append to the pending list.
+    //   * Buffer is bounded by `MAX_PENDING_ATTESTATIONS` (1024 in
+    //     `subspecs/sync/config.py`); FIFO eviction when full.
+    //   * After every successful `on_gossip_block` import, the spec
+    //     calls `_replay_pending_attestations` which drains both
+    //     lists, retries each entry, and re-enqueues anything that
+    //     still fails (next replay attempt).
+    //
+    // Retryable validation errors (per leanSpec
+    // `forks/lstar/spec.py::validate_attestation`):
+    //
+    //   * `error.UnknownHeadBlock` / `UnknownSourceBlock` /
+    //     `UnknownTargetBlock` — the spec's `assert ... in store.blocks`.
+    //   * `error.AttestationTooFarInFuture` — the spec's
+    //     `assert attestation_start_interval <= store.time + GOSSIP_DISPARITY_INTERVALS`.
+    //
+    // Permanent failures (signature mismatch, malformed checkpoint
+    // ordering, slot mismatch) are dropped without buffering.
+
+    /// Append a gossip attestation to the pending buffer for replay
+    /// after the next `onBlock` import. FIFO-evicts the oldest entry
+    /// when the buffer is at `MAX_PENDING_ATTESTATIONS`.
+    ///
+    /// `gossip` is plain-old-data (`AttestationGossip` carries no
+    /// heap allocations — see `network/src/interface.zig`), so the
+    /// value is copied by-value; no clone needed.
+    fn enqueuePendingAttestation(
+        self: *Self,
+        gossip: networks.AttestationGossip,
+        reason: []const u8,
+    ) void {
+        self.pending_attestations_mutex.lock();
+        defer self.pending_attestations_mutex.unlock();
+
+        if (self.pending_attestations.items.len >= constants.MAX_PENDING_ATTESTATIONS) {
+            // FIFO eviction: drop the oldest entry to make room. Spec
+            // semantics — `subspecs/sync/service.py::_pending_attestations[
+            // -MAX_PENDING_ATTESTATIONS:]` slice.
+            _ = self.pending_attestations.orderedRemove(0);
+            zeam_metrics.metrics.lean_pending_attestations_evicted_total.incr(.{ .kind = "attestation" }) catch {};
+        }
+        self.pending_attestations.append(self.allocator, gossip) catch {
+            // OOM on append shouldn't drop the contract — log and
+            // surface via metric. The attestation is lost (same effect
+            // as if FIFO eviction caught it next pass).
+            zeam_metrics.metrics.lean_pending_attestations_evicted_total.incr(.{ .kind = "attestation" }) catch {};
+            return;
+        };
+        zeam_metrics.metrics.lean_pending_attestations_buffered_total.incr(.{ .kind = "attestation", .reason = reason }) catch {};
+        zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "attestation" }, self.pending_attestations.items.len) catch {};
+    }
+
+    /// Append a cloned aggregated attestation to the pending buffer.
+    /// Caller MUST pass an owned clone — the buffer takes ownership and
+    /// will `deinit()` the entry on FIFO eviction, replay drop, or
+    /// `BeamChain.deinit`.
+    fn enqueuePendingAggregation(
+        self: *Self,
+        agg: types.SignedAggregatedAttestation,
+        reason: []const u8,
+    ) void {
+        self.pending_attestations_mutex.lock();
+        defer self.pending_attestations_mutex.unlock();
+
+        if (self.pending_aggregated_attestations.items.len >= constants.MAX_PENDING_ATTESTATIONS) {
+            var evicted = self.pending_aggregated_attestations.orderedRemove(0);
+            evicted.deinit();
+            zeam_metrics.metrics.lean_pending_attestations_evicted_total.incr(.{ .kind = "aggregation" }) catch {};
+        }
+        self.pending_aggregated_attestations.append(self.allocator, agg) catch {
+            // OOM: free the clone we were handed and bump evicted.
+            var lost = agg;
+            lost.deinit();
+            zeam_metrics.metrics.lean_pending_attestations_evicted_total.incr(.{ .kind = "aggregation" }) catch {};
+            return;
+        };
+        zeam_metrics.metrics.lean_pending_attestations_buffered_total.incr(.{ .kind = "aggregation", .reason = reason }) catch {};
+        zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "aggregation" }, self.pending_aggregated_attestations.items.len) catch {};
+    }
+
+    /// Drain and retry both pending buffers. Mirrors leanSpec
+    /// `subspecs/sync/service.py::_replay_pending_attestations` which
+    /// the spec calls after every successful `on_gossip_block`.
+    ///
+    /// For each buffered entry: re-run the same validate / verify path
+    /// the libxev-arrived gossip would. Outcomes:
+    ///
+    ///   * `accepted` — validate + signature-verify both succeed; the
+    ///     entry is consumed (storage is per-role: aggregators store
+    ///     in fork-choice, non-aggregators just verify-and-drop).
+    ///   * `buffered` — still missing block / still future-slot; the
+    ///     entry is re-appended to the back of the buffer (spec FIFO
+    ///     "kept in the buffer for the next replay attempt").
+    ///   * `dropped` — permanent failure (signature mismatch, malformed
+    ///     checkpoint ordering); the entry is discarded.
+    ///
+    /// MUST be called from the chain-worker thread (or the calling
+    /// thread when the worker is disabled). Holds the buffer mutex
+    /// only across the swap-out / re-append; validation runs lock-free
+    /// over locally-owned slices.
+    pub fn replayPendingAttestations(self: *Self) void {
+        // Swap the buffers out under lock so producers can keep
+        // appending into fresh empty buffers while we drain.
+        self.pending_attestations_mutex.lock();
+        var atts = self.pending_attestations;
+        self.pending_attestations = .empty;
+        var aggs = self.pending_aggregated_attestations;
+        self.pending_aggregated_attestations = .empty;
+        zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "attestation" }, 0) catch {};
+        zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "aggregation" }, 0) catch {};
+        self.pending_attestations_mutex.unlock();
+        defer atts.deinit(self.allocator);
+        defer aggs.deinit(self.allocator);
+
+        const is_agg = self.is_aggregator_enabled.load(.acquire);
+
+        for (atts.items) |gossip| {
+            self.replayOneAttestation(gossip, is_agg);
+        }
+        for (aggs.items) |*agg| {
+            self.replayOneAggregation(agg);
+        }
+    }
+
+    /// Inner replay step for a single buffered attestation. The entry
+    /// is consumed unconditionally: on retryable failure we re-enqueue
+    /// (which copies — `AttestationGossip` is POD), on success or
+    /// permanent failure we just drop.
+    fn replayOneAttestation(
+        self: *Self,
+        gossip: networks.AttestationGossip,
+        is_aggregator_role: bool,
+    ) void {
+        self.validateAttestationData(gossip.message.message, false) catch |err| {
+            switch (err) {
+                error.UnknownHeadBlock,
+                error.UnknownSourceBlock,
+                error.UnknownTargetBlock,
+                error.MissingState,
+                => {
+                    self.enqueuePendingAttestation(gossip, "unknown_block");
+                    zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "attestation", .outcome = "buffered" }) catch {};
+                },
+                error.AttestationTooFarInFuture => {
+                    self.enqueuePendingAttestation(gossip, "future_slot");
+                    zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "attestation", .outcome = "buffered" }) catch {};
+                },
+                else => {
+                    zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "attestation", .outcome = "dropped" }) catch {};
+                },
+            }
+            return;
+        };
+
+        // Validation passed on replay. Run signature verify + (for
+        // aggregators) fork-choice tracker update. leanSpec stores in
+        // `attestation_signatures` only for `is_aggregator`; non-
+        // aggregators "validate and drop".
+        self.runVerifiedGossipAttestation(gossip, is_aggregator_role) catch {
+            zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "attestation", .outcome = "dropped" }) catch {};
+            return;
+        };
+        zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "attestation", .outcome = "accepted" }) catch {};
+    }
+
+    /// Inner replay step for a single buffered aggregation. The buffer
+    /// owns the aggregation; on success or permanent failure we
+    /// `deinit()` it; on retryable failure we move ownership back into
+    /// the buffer via `enqueuePendingAggregation` (no clone).
+    fn replayOneAggregation(self: *Self, agg: *types.SignedAggregatedAttestation) void {
+        // Re-run the full gossip aggregation path. `onGossipAggregatedAttestation`
+        // does validate + signature verify + fork-choice store; on
+        // unknown-block we re-enqueue without dropping the clone.
+        self.onGossipAggregatedAttestation(agg.*) catch |err| {
+            switch (err) {
+                error.UnknownHeadBlock,
+                error.UnknownSourceBlock,
+                error.UnknownTargetBlock,
+                error.MissingState,
+                => {
+                    // Move ownership back into the buffer.
+                    self.enqueuePendingAggregation(agg.*, "unknown_block");
+                    zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "aggregation", .outcome = "buffered" }) catch {};
+                    return;
+                },
+                error.AttestationTooFarInFuture => {
+                    self.enqueuePendingAggregation(agg.*, "future_slot");
+                    zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "aggregation", .outcome = "buffered" }) catch {};
+                    return;
+                },
+                else => {
+                    agg.deinit();
+                    zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "aggregation", .outcome = "dropped" }) catch {};
+                    return;
+                },
+            }
+        };
+        agg.deinit();
+        zeam_metrics.metrics.lean_pending_attestations_replay_total.incr(.{ .kind = "aggregation", .outcome = "accepted" }) catch {};
+    }
+
+    /// Run the post-validation gossip-attestation steps that match the
+    /// spec's `on_gossip_attestation` (signature verify + role-gated
+    /// store). `validateAttestationData` MUST have already run and
+    /// succeeded. Splitting this out lets both the libxev-dispatched
+    /// thunk and `replayOneAttestation` share the same code path.
+    fn runVerifiedGossipAttestation(
+        self: *Self,
+        gossip: networks.AttestationGossip,
+        is_aggregator_role: bool,
+    ) !void {
+        const attestation = gossip.message.toAttestation();
+
+        // Signature verification — run for ALL nodes (spec:
+        // `forks/lstar/spec.py::on_gossip_attestation`, lines 1090-1131).
+        // Non-aggregators verify + drop; aggregators verify + store.
+        var borrow = self.statesGet(attestation.data.target.root) orelse return AttestationValidationError.MissingState;
+        defer borrow.assertReleasedOrPanic();
+        defer borrow.deinit();
+        try stf.verifySingleAttestation(
+            self.allocator,
+            borrow.state,
+            @intCast(gossip.message.validator_id),
+            &gossip.message.message,
+            &gossip.message.signature,
+        );
+
+        // Role-gated storage — leanSpec: `if is_aggregator: ...`.
+        // zeam's analog of `attestation_signatures` is the per-validator
+        // attestation tracker maintained by `forkChoice.onSignedAttestation`,
+        // which in turn feeds head selection. Skipping it for non-
+        // aggregators matches the spec's "Non-aggregator nodes validate
+        // and drop — they never store gossip signatures" contract.
+        if (is_aggregator_role) {
+            try self.forkChoice.onSignedAttestation(gossip.message);
+        }
+    }
+
+    // ------------------------------------------------------------------
     // chain_worker handler thunks (slice c-2b commit 3)
     // ------------------------------------------------------------------
     //
@@ -530,6 +803,12 @@ pub const BeamChain = struct {
         // ignores the parameter (see the explicit `_ = signedBlock`
         // at its top), so the value is functionally unused here.
         self.onBlockFollowup(prune_forkchoice, &signed_block);
+        // leanSpec parity: `subspecs/sync/service.py::on_gossip_block`
+        // calls `_replay_pending_attestations` after every successful
+        // block import so attestations that referenced unknown blocks
+        // / future slots get a fresh validation attempt against the
+        // updated store.
+        self.replayPendingAttestations();
     }
 
     fn chainWorkerOnGossipAttestationThunk(
@@ -537,25 +816,52 @@ pub const BeamChain = struct {
         gossip: networks.AttestationGossip,
     ) void {
         const self: *Self = @ptrCast(@alignCast(ctx));
-        // Issue #863 P5: validation moved here from the libxev gossip
-        // path. `validateAttestationData` does the proto-array reads
-        // (source/target/head lookups under `forkChoice.mutex`) plus
-        // slot/checkpoint relationship checks; running it on the
-        // worker thread keeps it off the libxev critical path. All
-        // failures are silently dropped (the established no-feedback
-        // contract — gossip is liberal, the same data is rebroadcast)
-        // and bucketed in `zeam_gossip_atts_dropped_total{reason="worker_validation_failed"}`
-        // so dashboards still attribute the drop rate.
+        // leanSpec parity (`forks/lstar/spec.py::on_gossip_attestation`,
+        // `subspecs/sync/service.py::on_gossip_attestation`):
+        //
+        //   1. Validate (block availability + topology + consistency +
+        //      future-slot bound). On AssertionError-equivalent →
+        //      buffer for replay (`_pending_attestations`). On
+        //      permanent failure → drop.
+        //   2. Verify the XMSS signature. Run for ALL roles (spec's
+        //      `assert self.sig_scheme.verify(...)`).
+        //   3. Store ONLY if `is_aggregator` (spec's `if is_aggregator:
+        //      new_committee_sigs.setdefault(...).add(...)`).
+        const is_aggregator_role = self.is_aggregator_enabled.load(.acquire);
+
         self.validateAttestationData(gossip.message.message, false) catch |err| {
-            zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "worker_validation_failed" }) catch {};
-            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-            self.logger.debug(
-                "chain-worker: attestation validation failed slot={d} validator={d}: {any}",
-                .{ gossip.message.message.slot, gossip.message.validator_id, err },
-            );
-            return;
+            switch (err) {
+                error.UnknownHeadBlock,
+                error.UnknownSourceBlock,
+                error.UnknownTargetBlock,
+                error.MissingState,
+                => {
+                    // Spec says buffer for replay after the next
+                    // `on_gossip_block` import.
+                    self.enqueuePendingAttestation(gossip, "unknown_block");
+                    return;
+                },
+                error.AttestationTooFarInFuture => {
+                    // Spec buffers future-slot attestations too: the
+                    // wall-clock `store.time` may have advanced past the
+                    // slot by the time the next block lands and replay
+                    // runs.
+                    self.enqueuePendingAttestation(gossip, "future_slot");
+                    return;
+                },
+                else => {
+                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "worker_validation_failed" }) catch {};
+                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                    self.logger.debug(
+                        "chain-worker: attestation validation failed slot={d} validator={d}: {any}",
+                        .{ gossip.message.message.slot, gossip.message.validator_id, err },
+                    );
+                    return;
+                },
+            }
         };
-        self.onGossipAttestation(gossip) catch |err| {
+
+        self.runVerifiedGossipAttestation(gossip, is_aggregator_role) catch |err| {
             zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
             self.logger.warn(
                 "chain-worker: onGossipAttestation failed slot={d} validator={d}: {any}",
@@ -571,28 +877,55 @@ pub const BeamChain = struct {
         agg: types.SignedAggregatedAttestation,
     ) void {
         const self: *Self = @ptrCast(@alignCast(ctx));
-        // Issue #863 P5: same as the attestation thunk —
-        // `onGossipAggregatedAttestation` itself calls
-        // `validateAttestationData` then the heavy XMSS aggregate-
-        // verify. Both run on the worker thread now.
+        // leanSpec parity (`forks/lstar/spec.py::on_gossip_aggregated_attestation`,
+        // `subspecs/sync/service.py::on_gossip_aggregated_attestation`):
+        // validate + verify. On retryable error → buffer for replay
+        // after the next `on_gossip_block` (`_pending_aggregated_attestations`).
+        // The Message-owned `agg` is freed by chain_worker.dispatch
+        // (defer m.deinit()) when this function returns; to retain
+        // ownership in the buffer we MUST clone before re-handing to
+        // the buffer.
         self.onGossipAggregatedAttestation(agg) catch |err| {
             zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
             switch (err) {
-                error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock, error.MissingState => {
-                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "worker_validation_failed" }) catch {};
-                    self.logger.debug(
-                        "chain-worker: aggregated attestation worker-validation failed slot={d}: {any}",
-                        .{ agg.data.slot, err },
-                    );
+                error.UnknownHeadBlock,
+                error.UnknownSourceBlock,
+                error.UnknownTargetBlock,
+                error.MissingState,
+                => {
+                    var cloned: types.SignedAggregatedAttestation = undefined;
+                    types.sszClone(self.allocator, types.SignedAggregatedAttestation, agg, &cloned) catch |clone_err| {
+                        zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "worker_validation_failed" }) catch {};
+                        self.logger.warn(
+                            "chain-worker: aggregation buffer clone failed slot={d}: {any}",
+                            .{ agg.data.slot, clone_err },
+                        );
+                        return;
+                    };
+                    self.enqueuePendingAggregation(cloned, "unknown_block");
+                    return;
+                },
+                error.AttestationTooFarInFuture => {
+                    var cloned: types.SignedAggregatedAttestation = undefined;
+                    types.sszClone(self.allocator, types.SignedAggregatedAttestation, agg, &cloned) catch |clone_err| {
+                        zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "worker_validation_failed" }) catch {};
+                        self.logger.warn(
+                            "chain-worker: aggregation buffer clone failed slot={d}: {any}",
+                            .{ agg.data.slot, clone_err },
+                        );
+                        return;
+                    };
+                    self.enqueuePendingAggregation(cloned, "future_slot");
+                    return;
                 },
                 else => {
                     self.logger.warn(
                         "chain-worker: onGossipAggregatedAttestation failed slot={d}: {any}",
                         .{ agg.data.slot, err },
                     );
+                    return;
                 },
             }
-            return;
         };
         zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "aggregation" }) catch {};
     }
@@ -796,6 +1129,18 @@ pub const BeamChain = struct {
             entry.signed_block.deinit();
         }
         self.pending_blocks.deinit(self.allocator);
+
+        // leanSpec _pending_attestations / _pending_aggregated_attestations
+        // buffers. Attestations are POD (no heap); aggregations were cloned
+        // on enqueue and need explicit `.deinit()` per entry to free the
+        // proof participants BitList + signature bytes.
+        self.pending_attestations_mutex.lock();
+        self.pending_attestations.deinit(self.allocator);
+        for (self.pending_aggregated_attestations.items) |*agg| {
+            agg.deinit();
+        }
+        self.pending_aggregated_attestations.deinit(self.allocator);
+        self.pending_attestations_mutex.unlock();
 
         // assume the allocator of config is same as self.allocator
         self.config.deinit(self.allocator);
@@ -2185,138 +2530,106 @@ pub const BeamChain = struct {
                     sender_node_name,
                 });
 
-                // Issue #863 P2: sync-aware gating. While the chain is
-                // syncing (no_peers / fc_initing / behind_peers) gossip
-                // attestation processing is a strict net loss — head/
-                // source/target lookups will overwhelmingly miss against
-                // a forkchoice that hasn't caught up yet, each miss
-                // would derive a missing-root and enqueue a
-                // `BlocksByRoot` fetch, and the fetch would bottom out
-                // (the head we'd be chasing is the same head our peers
-                // are chasing — we recover via `BlocksByRange` and
-                // gossip block import, NOT per-attestation point
-                // lookups). The pre-fix path turned this into a
-                // self-reinforcing storm on aggregators.
-                //
-                // Block gossip is intentionally NOT gated — it's the
-                // primary recovery vector during sync.
+                // leanSpec sync-state gating
+                // (`subspecs/sync/service.py::on_gossip_attestation`):
+                // gossip is processed in `SYNCING` and `SYNCED`; only
+                // dropped in `IDLE` (no peers / forkchoice not yet
+                // initialised). The behind_peers state maps to spec
+                // `SYNCING` — accept attestations and let the buffer
+                // catch unknown-block / future-slot ones for replay
+                // after the next gossip block lands.
                 switch (self.getSyncStatus()) {
-                    .synced => {},
-                    .no_peers, .fc_initing, .behind_peers => {
+                    .synced, .behind_peers => {},
+                    .no_peers, .fc_initing => {
                         zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "syncing" }) catch {};
                         return .{};
                     },
                 }
 
-                // Issue #863 P3 fast-drop: future-slot rejection is the
-                // O(1) sub-check that doesn't touch proto-array. Run
-                // it on the libxev thread so future-slot floods don't
-                // cost a worker-queue slot or a chain-worker dispatch
-                // round trip. `validateAttestationData` repeats this
-                // check (so the worker path is correct in isolation),
-                // but the steady-state hit rate of the worker repeat is
-                // negligible because almost every future-slot attestation
-                // gets caught here first.
-                if (self.attestationIsTooFarInFuture(signed_attestation.message.message)) {
-                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "future_slot" }) catch {};
-                    return .{};
-                }
-
-                if (self.is_aggregator_enabled.load(.acquire)) {
-                    if (self.chain_worker != null) {
-                        // Issue #863 P5: pure dispatch on the libxev
-                        // thread — `validateAttestationData` (the
-                        // expensive proto-array reads under
-                        // `forkChoice.mutex`) is moved to the chain-
-                        // worker via `chainWorkerOnGossipAttestationThunk`.
-                        // The worker thread holds no contended locks
-                        // on the libxev critical path, so the heavy
-                        // validation no longer competes with `onBlock`
-                        // writers for the forkchoice mutex.
-                        //
-                        // Trade-off: we lose the synchronous
-                        // `missing_attestation_roots` feedback for
-                        // unknown-source/target/head — the existing
-                        // chain-worker block path documents (and
-                        // accepts) the same trade-off. Worker-side
-                        // validation failures are bucketed in
-                        // `zeam_gossip_atts_dropped_total{reason="worker_validation_failed"}`
-                        // so dashboards still attribute them.
-                        //
-                        // `AttestationGossip` is POD so no clone is
-                        // required — the value is copied into the
-                        // `Message` enum at queue push time.
-                        self.submitGossipAttestation(signed_attestation) catch |err| switch (err) {
-                            error.QueueFull => {
-                                zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-                                self.logger.warn(
-                                    "chain-worker: attestation queue full, dropping slot={d} validator={d}",
-                                    .{ slot, validator_id },
-                                );
-                                return .{};
-                            },
-                            error.QueueClosed => {
-                                self.logger.warn(
-                                    "chain-worker: attestation queue closed, dropping slot={d} validator={d}",
-                                    .{ slot, validator_id },
-                                );
-                                return .{};
-                            },
-                            error.ChainWorkerDisabled => unreachable,
-                        };
-                    } else {
-                        // Worker-disabled path (typically tests / single-
-                        // threaded mode). Validate inline as before so
-                        // `missing_attestation_roots` is returned to the
-                        // caller and `BlocksByRoot` still gets enqueued
-                        // — without the worker we have no other place to
-                        // do the validation.
-                        self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
+                // leanSpec parity for non-aggregators: spec runs
+                // validate + signature verify even when not storing
+                // (`forks/lstar/spec.py::on_gossip_attestation` gates
+                // ONLY the `attestation_signatures` write on
+                // `is_aggregator`). Dispatching through the chain-
+                // worker for both roles keeps the libxev thread out
+                // of the heavy XMSS verify; the worker thunk skips
+                // the fork-choice tracker update for non-aggregators.
+                if (self.chain_worker != null) {
+                    // Pure dispatch on the libxev thread —
+                    // `validateAttestationData` (proto-array reads
+                    // under `forkChoice.mutex`) and the XMSS verify
+                    // both run on the worker thread. The worker thunk
+                    // runs them for ALL roles (leanSpec parity); only
+                    // the fork-choice tracker update is gated on
+                    // `is_aggregator_enabled`.
+                    //
+                    // Retryable validation failures (unknown block /
+                    // future slot) land in the spec's pending buffer
+                    // for replay after the next `onBlock` import; see
+                    // `enqueuePendingAttestation` and
+                    // `replayPendingAttestations`. `BlocksByRoot`
+                    // fetch storms are absorbed by that buffer
+                    // instead of being amplified into per-attestation
+                    // RPCs.
+                    //
+                    // `AttestationGossip` is POD so no clone is
+                    // required — the value is copied into the
+                    // `Message` enum at queue push time.
+                    self.submitGossipAttestation(signed_attestation) catch |err| switch (err) {
+                        error.QueueFull => {
                             zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-                            switch (err) {
-                                error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
-                                    const att_data = signed_attestation.message.message;
-                                    const missing_root = if (err == error.UnknownHeadBlock)
-                                        att_data.head.root
-                                    else if (err == error.UnknownSourceBlock)
-                                        att_data.source.root
-                                    else
-                                        att_data.target.root;
-                                    var roots: std.ArrayListUnmanaged(types.Root) = .empty;
-                                    errdefer roots.deinit(self.allocator);
-                                    try roots.append(self.allocator, missing_root);
-                                    return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
-                                },
-                                error.AttestationTooFarInFuture => {
-                                    // Should be unreachable after the fast-drop
-                                    // above, but bucket it correctly anyway.
-                                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "future_slot" }) catch {};
-                                    return .{};
-                                },
-                                else => {
-                                    self.logger.warn("gossip attestation validation failed: {any}", .{err});
-                                    return .{};
-                                },
-                            }
-                        };
-                        self.onGossipAttestation(signed_attestation) catch |err| {
-                            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-                            self.logger.err("attestation processing error: {any}", .{err});
-                            return err;
-                        };
-                    }
-                    self.logger.info("processed gossip attestation for slot={d} validator={d}{f}", .{
-                        slot,
-                        validator_id,
-                        validator_node_name,
-                    });
+                            self.logger.warn(
+                                "chain-worker: attestation queue full, dropping slot={d} validator={d}",
+                                .{ slot, validator_id },
+                            );
+                            return .{};
+                        },
+                        error.QueueClosed => {
+                            self.logger.warn(
+                                "chain-worker: attestation queue closed, dropping slot={d} validator={d}",
+                                .{ slot, validator_id },
+                            );
+                            return .{};
+                        },
+                        error.ChainWorkerDisabled => unreachable,
+                    };
                 } else {
-                    self.logger.debug("skipping gossip attestation import (not aggregator): subnet={d} slot={d} validator={d}", .{
-                        signed_attestation.subnet_id,
-                        slot,
-                        validator_id,
-                    });
+                    // Worker-disabled path (tests / single-threaded
+                    // mode). Run validate + verify inline; on retryable
+                    // error, buffer for replay (matches spec's
+                    // `_pending_attestations` semantics).
+                    const is_aggregator_role = self.is_aggregator_enabled.load(.acquire);
+                    self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
+                        switch (err) {
+                            error.UnknownHeadBlock,
+                            error.UnknownSourceBlock,
+                            error.UnknownTargetBlock,
+                            => {
+                                self.enqueuePendingAttestation(signed_attestation, "unknown_block");
+                                return .{};
+                            },
+                            error.AttestationTooFarInFuture => {
+                                self.enqueuePendingAttestation(signed_attestation, "future_slot");
+                                return .{};
+                            },
+                            else => {
+                                zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                                self.logger.warn("gossip attestation validation failed: {any}", .{err});
+                                return .{};
+                            },
+                        }
+                    };
+                    self.runVerifiedGossipAttestation(signed_attestation, is_aggregator_role) catch |err| {
+                        zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                        self.logger.err("attestation processing error: {any}", .{err});
+                        return err;
+                    };
                 }
+                self.logger.info("processed gossip attestation for slot={d} validator={d}{f}", .{
+                    slot,
+                    validator_id,
+                    validator_node_name,
+                });
                 zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "gossip" }) catch {};
                 return .{};
             },
@@ -2327,25 +2640,17 @@ pub const BeamChain = struct {
                     self.node_registry.getNodeNameFromPeerId(sender_peer_id),
                 });
 
-                // Issue #863 P2: same sync-aware gating as the raw
-                // attestation arm. Aggregations are 4× heavier per
-                // message (XMSS aggregate verify) so gating them while
-                // syncing is even more critical. See the rationale
-                // comment in the `.attestation` arm.
+                // leanSpec sync-state gating (same as `.attestation`
+                // arm): accept gossip in `SYNCING` and `SYNCED`; drop
+                // only in `IDLE` (no peers / fc not initialised).
+                // Retryable validation failures land in the pending
+                // buffer for replay.
                 switch (self.getSyncStatus()) {
-                    .synced => {},
-                    .no_peers, .fc_initing, .behind_peers => {
+                    .synced, .behind_peers => {},
+                    .no_peers, .fc_initing => {
                         zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "syncing" }) catch {};
                         return .{};
                     },
-                }
-
-                // Issue #863 P3 fast-drop (same as `.attestation` arm).
-                // Cheap O(1) check; `validateAttestationData` repeats it
-                // for the worker-thread path's correctness in isolation.
-                if (self.attestationIsTooFarInFuture(signed_aggregation.data)) {
-                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "future_slot" }) catch {};
-                    return .{};
                 }
 
                 if (self.chain_worker != null) {
@@ -2389,42 +2694,37 @@ pub const BeamChain = struct {
                     return .{};
                 }
 
-                // Worker-disabled path: validate inline so the caller
-                // gets `missing_attestation_roots` and can fetch via
-                // `BlocksByRoot`. Same shape as the pre-P5 path and as
-                // the attestation arm's worker-disabled branch.
-                self.validateAttestationData(signed_aggregation.data, false) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                // Worker-disabled path (tests / single-threaded mode):
+                // run validate + verify + store inline. On retryable
+                // failure, clone-and-buffer for replay so spec's
+                // `_pending_aggregated_attestations` semantics hold
+                // even without the chain-worker.
+                self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
                     switch (err) {
-                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
-                            const att_data = signed_aggregation.data;
-                            const missing_root = if (err == error.UnknownHeadBlock)
-                                att_data.head.root
-                            else if (err == error.UnknownSourceBlock)
-                                att_data.source.root
-                            else
-                                att_data.target.root;
-                            var roots: std.ArrayListUnmanaged(types.Root) = .empty;
-                            errdefer roots.deinit(self.allocator);
-                            try roots.append(self.allocator, missing_root);
-                            return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
+                        error.UnknownHeadBlock,
+                        error.UnknownSourceBlock,
+                        error.UnknownTargetBlock,
+                        error.MissingState,
+                        => {
+                            var cloned: types.SignedAggregatedAttestation = undefined;
+                            types.sszClone(self.allocator, types.SignedAggregatedAttestation, signed_aggregation, &cloned) catch {
+                                zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
+                                return .{};
+                            };
+                            self.enqueuePendingAggregation(cloned, "unknown_block");
+                            return .{};
                         },
                         error.AttestationTooFarInFuture => {
-                            zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "future_slot" }) catch {};
+                            var cloned: types.SignedAggregatedAttestation = undefined;
+                            types.sszClone(self.allocator, types.SignedAggregatedAttestation, signed_aggregation, &cloned) catch {
+                                zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
+                                return .{};
+                            };
+                            self.enqueuePendingAggregation(cloned, "future_slot");
                             return .{};
                         },
                         else => {
-                            self.logger.warn("gossip aggregation validation failed: {any}", .{err});
-                            return .{};
-                        },
-                    }
-                };
-
-                self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
-                    switch (err) {
-                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
-                        else => {
+                            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
                             self.logger.warn("gossip aggregation processing error: {any}", .{err});
                             return .{};
                         },

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2441,7 +2441,8 @@ pub const BeamChain = struct {
                     // asynchronously, so it needs an independent
                     // allocation. On `submitBlock` success the worker
                     // owns the clone (and will deinit it after
-                    // dispatch); on failure the errdefer frees it.
+                    // dispatch); on failure or queue-full/closed, `defer` frees
+                    // the clone if the worker did not take ownership.
                     //
                     // Trade-offs of the worker path:
                     //   * `missing_attestation_roots` feedback is
@@ -2461,7 +2462,10 @@ pub const BeamChain = struct {
                         var cloned: types.SignedBlock = undefined;
                         try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
                         var cloned_consumed = false;
-                        errdefer if (!cloned_consumed) cloned.deinit();
+                        // `defer` (not `errdefer`): QueueFull / QueueClosed return
+                        // `.{}` from the catch arm — a normal return — so `errdefer`
+                        // would not run and the clone would leak (zclawz review, #886).
+                        defer if (!cloned_consumed) cloned.deinit();
                         // Slice (e): forward the block_root we already computed
                         // above so the worker thread doesn't re-hash the block.
                         self.submitBlock(cloned, true, block_root) catch |err| switch (err) {
@@ -2666,11 +2670,13 @@ pub const BeamChain = struct {
                     // for the duration of this callback. Submitting to
                     // the worker transfers ownership to the worker, so
                     // we need an independent allocation. On submit
-                    // failure the errdefer frees the clone.
+                    // failure or queue-full/closed, `defer` frees the clone if the
+                    // worker did not take ownership (`errdefer` would miss the
+                    // catch-arm `return .{}` paths — zclawz review, #886).
                     var cloned: types.SignedAggregatedAttestation = undefined;
                     try types.sszClone(self.allocator, types.SignedAggregatedAttestation, signed_aggregation, &cloned);
                     var cloned_consumed = false;
-                    errdefer if (!cloned_consumed) cloned.deinit();
+                    defer if (!cloned_consumed) cloned.deinit();
                     self.submitGossipAggregatedAttestation(cloned) catch |err| switch (err) {
                         error.QueueFull => {
                             zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
@@ -7089,7 +7095,7 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
     var cloned: types.SignedBlock = undefined;
     try types.sszClone(std.testing.allocator, types.SignedBlock, signed_block, &cloned);
     var cloned_consumed = false;
-    errdefer if (!cloned_consumed) cloned.deinit();
+    defer if (!cloned_consumed) cloned.deinit();
 
     // Slice (e) of #803: pass `null` for `block_root` so the
     // worker recomputes — this test deliberately exercises the

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2146,6 +2146,29 @@ pub const BeamChain = struct {
                     sender_node_name,
                 });
 
+                // Issue #863 P2: sync-aware gating. While the chain is
+                // syncing (no_peers / fc_initing / behind_peers) gossip
+                // attestation processing is a strict net loss — head/
+                // source/target lookups will overwhelmingly miss against
+                // a forkchoice that hasn't caught up yet, each miss
+                // would derive a missing-root and enqueue a
+                // `BlocksByRoot` fetch, and the fetch would bottom out
+                // (the head we'd be chasing is the same head our peers
+                // are chasing — we recover via `BlocksByRange` and
+                // gossip block import, NOT per-attestation point
+                // lookups). The pre-fix path turned this into a
+                // self-reinforcing storm on aggregators.
+                //
+                // Block gossip is intentionally NOT gated — it's the
+                // primary recovery vector during sync.
+                switch (self.getSyncStatus()) {
+                    .synced => {},
+                    .no_peers, .fc_initing, .behind_peers => {
+                        zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "syncing" }) catch {};
+                        return .{};
+                    },
+                }
+
                 // Validate attestation before processing (gossip = not from block)
                 self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
@@ -2163,6 +2186,17 @@ pub const BeamChain = struct {
                             errdefer roots.deinit(self.allocator);
                             try roots.append(self.allocator, missing_root);
                             return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
+                        },
+                        error.AttestationTooFarInFuture => {
+                            // Issue #863 P3: see `validateAttestationData`'s
+                            // hoisted future-slot check. We bump the
+                            // dedicated counter rather than letting this
+                            // fall into the generic warn-and-drop branch
+                            // so dashboards can attribute the drop rate
+                            // to flood symptoms vs. genuinely malformed
+                            // attestations.
+                            zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "future_slot" }) catch {};
+                            return .{};
                         },
                         else => {
                             self.logger.warn("gossip attestation validation failed: {any}", .{err});
@@ -2227,6 +2261,19 @@ pub const BeamChain = struct {
                     self.node_registry.getNodeNameFromPeerId(sender_peer_id),
                 });
 
+                // Issue #863 P2: same sync-aware gating as the raw
+                // attestation arm. Aggregations are 4× heavier per
+                // message (XMSS aggregate verify) so gating them while
+                // syncing is even more critical. See the rationale
+                // comment in the `.attestation` arm.
+                switch (self.getSyncStatus()) {
+                    .synced => {},
+                    .no_peers, .fc_initing, .behind_peers => {
+                        zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "syncing" }) catch {};
+                        return .{};
+                    },
+                }
+
                 // Validate attestation data before processing (same rules as individual gossip attestations)
                 self.validateAttestationData(signed_aggregation.data, false) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
@@ -2244,6 +2291,10 @@ pub const BeamChain = struct {
                             errdefer roots.deinit(self.allocator);
                             try roots.append(self.allocator, missing_root);
                             return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
+                        },
+                        error.AttestationTooFarInFuture => {
+                            zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "future_slot" }) catch {};
+                            return .{};
                         },
                         else => {
                             self.logger.warn("gossip aggregation validation failed: {any}", .{err});
@@ -3135,6 +3186,39 @@ pub const BeamChain = struct {
         const timer = zeam_metrics.lean_attestation_validation_time_seconds.start();
         defer _ = timer.observe();
 
+        // Issue #863 P3 part 1: future-slot drop is hoisted to BEFORE the
+        // proto-node lookups. Pre-fix order ran the lookups first, so an
+        // attestation for `current_slot + 100` referencing future blocks
+        // bottomed out at `UnknownHeadBlock` and the caller dutifully
+        // enqueued a `BlocksByRoot` for that future head — which always
+        // 404'd because the block didn't exist anywhere. Multiplied by
+        // 4× subnet fan-out on aggregators this was a fetch-storm
+        // amplifier and a primary contributor to the slot-driver
+        // starvation in #863. Rejecting the attestation here means we
+        // never derive a missing root for it and the fetch is simply
+        // never enqueued.
+        //
+        // Bound is intervals-based (`GOSSIP_DISPARITY_INTERVALS`, =1) so
+        // we still accept the very first interval of the next slot —
+        // attestations clients legitimately publish at the slot
+        // boundary tick — without bumping the disparity tolerance. The
+        // bound only applies to gossip; block-included attestations are
+        // trusted under the block's own validation.
+        if (!is_from_block) {
+            const current_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
+            const attestation_start_interval = data.slot * constants.INTERVALS_PER_SLOT;
+            const max_allowed_interval = current_time + constants.GOSSIP_DISPARITY_INTERVALS;
+            if (attestation_start_interval > max_allowed_interval) {
+                self.logger.debug("attestation validation failed: gossip attestation start interval {d} > max allowed interval {d} (slot={d}, time={d})", .{
+                    attestation_start_interval,
+                    max_allowed_interval,
+                    data.slot,
+                    current_time,
+                });
+                return AttestationValidationError.AttestationTooFarInFuture;
+            }
+        }
+
         // 1. Validate that source, target, and head blocks exist in proto array (thread-safe)
         const source_block = self.forkChoice.getProtoNode(data.source.root) orelse {
             self.logger.debug("Attestation validation failed: unknown source block root=0x{x}", .{
@@ -3213,26 +3297,9 @@ pub const BeamChain = struct {
             return AttestationValidationError.HeadCheckpointSlotMismatch;
         }
 
-        // 4. Validate gossip attestation is not too far in the future.
-        //
-        //    Bound is in intervals, not slots, and only applies to the gossip
-        //    path. Block-included attestations are trusted under the block's
-        //    own validation (matching leanSpec on_block, which doesn't run
-        //    validate_attestation on block-body attestations at all).
-        if (!is_from_block) {
-            const current_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
-            const attestation_start_interval = data.slot * constants.INTERVALS_PER_SLOT;
-            const max_allowed_interval = current_time + constants.GOSSIP_DISPARITY_INTERVALS;
-            if (attestation_start_interval > max_allowed_interval) {
-                self.logger.debug("attestation validation failed: gossip attestation start interval {d} > max allowed interval {d} (slot={d}, time={d})", .{
-                    attestation_start_interval,
-                    max_allowed_interval,
-                    data.slot,
-                    current_time,
-                });
-                return AttestationValidationError.AttestationTooFarInFuture;
-            }
-        }
+        // (Future-slot bound check is hoisted above the proto-node
+        // lookups — see the issue-#863 P3 comment at the top of this
+        // function.)
         self.logger.debug("attestation validation passed: slot={d} source={d} target={d} is_from_block={any}", .{
             data.slot,
             data.source.slot,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -599,10 +599,12 @@ pub const BeamChain = struct {
     ///   * `dropped` — permanent failure (signature mismatch, malformed
     ///     checkpoint ordering); the entry is discarded.
     ///
-    /// MUST be called from the chain-worker thread (or the calling
-    /// thread when the worker is disabled). Holds the buffer mutex
-    /// only across the swap-out / re-append; validation runs lock-free
-    /// over locally-owned slices.
+    /// MUST be called from the chain-worker thread, or from the libxev
+    /// thread when the worker is disabled / when `BeamChain` handles
+    /// `onBlock` + `onBlockFollowup` directly (gossip, RPC, pending-queue,
+    /// publish paths — same thread as other chain mutations). Holds the
+    /// buffer mutex only across the swap-out / re-append; validation runs
+    /// lock-free over locally-owned slices.
     pub fn replayPendingAttestations(self: *Self) void {
         // Swap the buffers out under lock so producers can keep
         // appending into fresh empty buffers while we drain.
@@ -1883,6 +1885,7 @@ pub const BeamChain = struct {
 
                 zeam_metrics.metrics.lean_pending_blocks_replayed_total.incr(.{ .result = "accepted" }) catch {};
                 self.onBlockFollowup(true, &queued_entry.signed_block);
+                self.replayPendingAttestations();
 
                 // Accumulate missing roots so the caller can fetch them.
                 all_missing_roots.appendSlice(self.allocator, missing_roots) catch {};
@@ -2501,6 +2504,7 @@ pub const BeamChain = struct {
                     };
                     // followup with additional housekeeping tasks
                     self.onBlockFollowup(true, &signed_block);
+                    self.replayPendingAttestations();
                     // NOTE: ownership of `missing_roots` is transferred to the caller (BeamNode),
                     // which is responsible for freeing it after optionally fetching those roots.
 

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -537,12 +537,33 @@ pub const BeamChain = struct {
         gossip: networks.AttestationGossip,
     ) void {
         const self: *Self = @ptrCast(@alignCast(ctx));
+        // Issue #863 P5: validation moved here from the libxev gossip
+        // path. `validateAttestationData` does the proto-array reads
+        // (source/target/head lookups under `forkChoice.mutex`) plus
+        // slot/checkpoint relationship checks; running it on the
+        // worker thread keeps it off the libxev critical path. All
+        // failures are silently dropped (the established no-feedback
+        // contract — gossip is liberal, the same data is rebroadcast)
+        // and bucketed in `zeam_gossip_atts_dropped_total{reason="worker_validation_failed"}`
+        // so dashboards still attribute the drop rate.
+        self.validateAttestationData(gossip.message.message, false) catch |err| {
+            zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "worker_validation_failed" }) catch {};
+            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+            self.logger.debug(
+                "chain-worker: attestation validation failed slot={d} validator={d}: {any}",
+                .{ gossip.message.message.slot, gossip.message.validator_id, err },
+            );
+            return;
+        };
         self.onGossipAttestation(gossip) catch |err| {
+            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
             self.logger.warn(
                 "chain-worker: onGossipAttestation failed slot={d} validator={d}: {any}",
                 .{ gossip.message.message.slot, gossip.message.validator_id, err },
             );
+            return;
         };
+        zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "gossip" }) catch {};
     }
 
     fn chainWorkerOnGossipAggregatedAttestationThunk(
@@ -550,12 +571,30 @@ pub const BeamChain = struct {
         agg: types.SignedAggregatedAttestation,
     ) void {
         const self: *Self = @ptrCast(@alignCast(ctx));
+        // Issue #863 P5: same as the attestation thunk —
+        // `onGossipAggregatedAttestation` itself calls
+        // `validateAttestationData` then the heavy XMSS aggregate-
+        // verify. Both run on the worker thread now.
         self.onGossipAggregatedAttestation(agg) catch |err| {
-            self.logger.warn(
-                "chain-worker: onGossipAggregatedAttestation failed slot={d}: {any}",
-                .{ agg.data.slot, err },
-            );
+            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
+            switch (err) {
+                error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock, error.MissingState => {
+                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "worker_validation_failed" }) catch {};
+                    self.logger.debug(
+                        "chain-worker: aggregated attestation worker-validation failed slot={d}: {any}",
+                        .{ agg.data.slot, err },
+                    );
+                },
+                else => {
+                    self.logger.warn(
+                        "chain-worker: onGossipAggregatedAttestation failed slot={d}: {any}",
+                        .{ agg.data.slot, err },
+                    );
+                },
+            }
+            return;
         };
+        zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "aggregation" }) catch {};
     }
 
     fn chainWorkerProcessPendingBlocksThunk(
@@ -2169,50 +2208,44 @@ pub const BeamChain = struct {
                     },
                 }
 
-                // Validate attestation before processing (gossip = not from block)
-                self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
-                    zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
-                    switch (err) {
-                        error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
-                            // Add the missing root to the result so node's onGossip can enqueue it for fetching
-                            const att_data = signed_attestation.message.message;
-                            const missing_root = if (err == error.UnknownHeadBlock)
-                                att_data.head.root
-                            else if (err == error.UnknownSourceBlock)
-                                att_data.source.root
-                            else
-                                att_data.target.root;
-                            var roots: std.ArrayListUnmanaged(types.Root) = .empty;
-                            errdefer roots.deinit(self.allocator);
-                            try roots.append(self.allocator, missing_root);
-                            return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
-                        },
-                        error.AttestationTooFarInFuture => {
-                            // Issue #863 P3: see `validateAttestationData`'s
-                            // hoisted future-slot check. We bump the
-                            // dedicated counter rather than letting this
-                            // fall into the generic warn-and-drop branch
-                            // so dashboards can attribute the drop rate
-                            // to flood symptoms vs. genuinely malformed
-                            // attestations.
-                            zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "future_slot" }) catch {};
-                            return .{};
-                        },
-                        else => {
-                            self.logger.warn("gossip attestation validation failed: {any}", .{err});
-                            return .{};
-                        },
-                    }
-                };
+                // Issue #863 P3 fast-drop: future-slot rejection is the
+                // O(1) sub-check that doesn't touch proto-array. Run
+                // it on the libxev thread so future-slot floods don't
+                // cost a worker-queue slot or a chain-worker dispatch
+                // round trip. `validateAttestationData` repeats this
+                // check (so the worker path is correct in isolation),
+                // but the steady-state hit rate of the worker repeat is
+                // negligible because almost every future-slot attestation
+                // gets caught here first.
+                if (self.attestationIsTooFarInFuture(signed_attestation.message.message)) {
+                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "future_slot" }) catch {};
+                    return .{};
+                }
 
                 if (self.is_aggregator_enabled.load(.acquire)) {
-                    // Slice c-2b commit 3 of #803: when the chain-worker
-                    // is enabled, route the validated attestation
-                    // through its queue. `AttestationGossip` is plain-
-                    // old-data (see `Message.deinit` in chain_worker.zig),
-                    // so no clone is required — the value is copied into
-                    // the `Message` enum at queue push time.
                     if (self.chain_worker != null) {
+                        // Issue #863 P5: pure dispatch on the libxev
+                        // thread — `validateAttestationData` (the
+                        // expensive proto-array reads under
+                        // `forkChoice.mutex`) is moved to the chain-
+                        // worker via `chainWorkerOnGossipAttestationThunk`.
+                        // The worker thread holds no contended locks
+                        // on the libxev critical path, so the heavy
+                        // validation no longer competes with `onBlock`
+                        // writers for the forkchoice mutex.
+                        //
+                        // Trade-off: we lose the synchronous
+                        // `missing_attestation_roots` feedback for
+                        // unknown-source/target/head — the existing
+                        // chain-worker block path documents (and
+                        // accepts) the same trade-off. Worker-side
+                        // validation failures are bucketed in
+                        // `zeam_gossip_atts_dropped_total{reason="worker_validation_failed"}`
+                        // so dashboards still attribute them.
+                        //
+                        // `AttestationGossip` is POD so no clone is
+                        // required — the value is copied into the
+                        // `Message` enum at queue push time.
                         self.submitGossipAttestation(signed_attestation) catch |err| switch (err) {
                             error.QueueFull => {
                                 zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
@@ -2232,7 +2265,40 @@ pub const BeamChain = struct {
                             error.ChainWorkerDisabled => unreachable,
                         };
                     } else {
-                        // Process validated attestation synchronously.
+                        // Worker-disabled path (typically tests / single-
+                        // threaded mode). Validate inline as before so
+                        // `missing_attestation_roots` is returned to the
+                        // caller and `BlocksByRoot` still gets enqueued
+                        // — without the worker we have no other place to
+                        // do the validation.
+                        self.validateAttestationData(signed_attestation.message.message, false) catch |err| {
+                            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
+                            switch (err) {
+                                error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
+                                    const att_data = signed_attestation.message.message;
+                                    const missing_root = if (err == error.UnknownHeadBlock)
+                                        att_data.head.root
+                                    else if (err == error.UnknownSourceBlock)
+                                        att_data.source.root
+                                    else
+                                        att_data.target.root;
+                                    var roots: std.ArrayListUnmanaged(types.Root) = .empty;
+                                    errdefer roots.deinit(self.allocator);
+                                    try roots.append(self.allocator, missing_root);
+                                    return .{ .missing_attestation_roots = try roots.toOwnedSlice(self.allocator) };
+                                },
+                                error.AttestationTooFarInFuture => {
+                                    // Should be unreachable after the fast-drop
+                                    // above, but bucket it correctly anyway.
+                                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "future_slot" }) catch {};
+                                    return .{};
+                                },
+                                else => {
+                                    self.logger.warn("gossip attestation validation failed: {any}", .{err});
+                                    return .{};
+                                },
+                            }
+                        };
                         self.onGossipAttestation(signed_attestation) catch |err| {
                             zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
                             self.logger.err("attestation processing error: {any}", .{err});
@@ -2274,12 +2340,63 @@ pub const BeamChain = struct {
                     },
                 }
 
-                // Validate attestation data before processing (same rules as individual gossip attestations)
+                // Issue #863 P3 fast-drop (same as `.attestation` arm).
+                // Cheap O(1) check; `validateAttestationData` repeats it
+                // for the worker-thread path's correctness in isolation.
+                if (self.attestationIsTooFarInFuture(signed_aggregation.data)) {
+                    zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "future_slot" }) catch {};
+                    return .{};
+                }
+
+                if (self.chain_worker != null) {
+                    // Issue #863 P5: same as the attestation arm — pure
+                    // dispatch on the libxev thread; the worker thunk
+                    // runs `onGossipAggregatedAttestation` (which itself
+                    // calls `validateAttestationData` then the heavy
+                    // XMSS aggregate-verify).
+                    //
+                    // Clone is required: `SignedAggregatedAttestation`
+                    // owns heap (the `proof.participants` BitList and
+                    // `proof.signature`) which the gossip layer borrows
+                    // for the duration of this callback. Submitting to
+                    // the worker transfers ownership to the worker, so
+                    // we need an independent allocation. On submit
+                    // failure the errdefer frees the clone.
+                    var cloned: types.SignedAggregatedAttestation = undefined;
+                    try types.sszClone(self.allocator, types.SignedAggregatedAttestation, signed_aggregation, &cloned);
+                    var cloned_consumed = false;
+                    errdefer if (!cloned_consumed) cloned.deinit();
+                    self.submitGossipAggregatedAttestation(cloned) catch |err| switch (err) {
+                        error.QueueFull => {
+                            zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
+                            self.logger.warn(
+                                "chain-worker: aggregated attestation queue full, dropping slot={d}",
+                                .{signed_aggregation.data.slot},
+                            );
+                            return .{};
+                        },
+                        error.QueueClosed => {
+                            self.logger.warn(
+                                "chain-worker: aggregated attestation queue closed, dropping slot={d}",
+                                .{signed_aggregation.data.slot},
+                            );
+                            return .{};
+                        },
+                        error.ChainWorkerDisabled => unreachable,
+                    };
+                    cloned_consumed = true;
+                    zeam_metrics.metrics.lean_attestations_valid_total.incr(.{ .source = "aggregation" }) catch {};
+                    return .{};
+                }
+
+                // Worker-disabled path: validate inline so the caller
+                // gets `missing_attestation_roots` and can fetch via
+                // `BlocksByRoot`. Same shape as the pre-P5 path and as
+                // the attestation arm's worker-disabled branch.
                 self.validateAttestationData(signed_aggregation.data, false) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "gossip" }) catch {};
                     switch (err) {
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => {
-                            // Add the missing root to the result so node's onGossip can enqueue it for fetching
                             const att_data = signed_aggregation.data;
                             const missing_root = if (err == error.UnknownHeadBlock)
                                 att_data.head.root
@@ -2306,7 +2423,6 @@ pub const BeamChain = struct {
                 self.onGossipAggregatedAttestation(signed_aggregation) catch |err| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "aggregation" }) catch {};
                     switch (err) {
-                        // Propagate unknown block errors to node.zig for context-aware logging
                         error.UnknownHeadBlock, error.UnknownSourceBlock, error.UnknownTargetBlock => return err,
                         else => {
                             self.logger.warn("gossip aggregation processing error: {any}", .{err});
@@ -3182,6 +3298,21 @@ pub const BeamChain = struct {
     ///
     /// Block-included attestations skip the time check; they are trusted under
     /// the block's own validation. `is_from_block` is retained as a log marker.
+    /// Issue #863 P3: cheap O(1) future-slot bound check for gossip
+    /// attestations — extracted so the libxev main thread can fast-drop
+    /// future-slot attestations BEFORE dispatching to the chain-worker
+    /// (rec 5: keep the libxev hot path doing only constant-time
+    /// per-message work). The check is identical to the one inside
+    /// `validateAttestationData`'s pre-lookup section and is repeated
+    /// there so the worker-thread path remains correct under future
+    /// callers that bypass the libxev fast-drop.
+    pub fn attestationIsTooFarInFuture(self: *Self, data: types.AttestationData) bool {
+        const current_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
+        const attestation_start_interval = data.slot * constants.INTERVALS_PER_SLOT;
+        const max_allowed_interval = current_time + constants.GOSSIP_DISPARITY_INTERVALS;
+        return attestation_start_interval > max_allowed_interval;
+    }
+
     pub fn validateAttestationData(self: *Self, data: types.AttestationData, is_from_block: bool) !void {
         const timer = zeam_metrics.lean_attestation_validation_time_seconds.start();
         defer _ = timer.observe();
@@ -3204,19 +3335,12 @@ pub const BeamChain = struct {
         // boundary tick — without bumping the disparity tolerance. The
         // bound only applies to gossip; block-included attestations are
         // trusted under the block's own validation.
-        if (!is_from_block) {
-            const current_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
-            const attestation_start_interval = data.slot * constants.INTERVALS_PER_SLOT;
-            const max_allowed_interval = current_time + constants.GOSSIP_DISPARITY_INTERVALS;
-            if (attestation_start_interval > max_allowed_interval) {
-                self.logger.debug("attestation validation failed: gossip attestation start interval {d} > max allowed interval {d} (slot={d}, time={d})", .{
-                    attestation_start_interval,
-                    max_allowed_interval,
-                    data.slot,
-                    current_time,
-                });
-                return AttestationValidationError.AttestationTooFarInFuture;
-            }
+        if (!is_from_block and self.attestationIsTooFarInFuture(data)) {
+            self.logger.debug("attestation validation failed: future slot=(slot={d}, time={d})", .{
+                data.slot,
+                self.forkChoice.fcStore.slot_clock.time.load(.monotonic),
+            });
+            return AttestationValidationError.AttestationTooFarInFuture;
         }
 
         // 1. Validate that source, target, and head blocks exist in proto array (thread-safe)

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -144,17 +144,72 @@ pub const Clock = struct {
     }
 
     pub fn run(self: *Self) !void {
+        // Issue #863 P4: bound each xev drain pass to ONE io_uring CQE
+        // batch via `.once` rather than `.until_done`.
+        //
+        // The pre-#863 shape called `events.run(.until_done)` per pass,
+        // which loops until `loop.active == 0`. Under sustained gossip
+        // pressure (especially on a 4-subnet aggregator that sees 4×
+        // attestation traffic, with ~74% of those attestations referring
+        // to head blocks the node hadn't imported yet — see the issue
+        // for the full trace), every callback enqueues additional work
+        // (chain submits, peer-event broadcasts, RPC retries) so the
+        // active-completion count never reaches zero and `tickInterval`
+        // doesn't run again until the storm subsides. Devnet-4 saw
+        // multi-second slot-driver stalls and ~96 finalized vs ~196 head
+        // delta on the aggregator as a direct consequence.
+        //
+        // `.once` blocks until at least one completion is ready, drains
+        // whatever the kernel has queued in that batch (up to 128 CQEs
+        // per the io_uring backend), and returns. The next-interval
+        // timer is itself a completion, so under no-flood conditions
+        // we still wake every ~800ms and call `tickInterval` exactly
+        // once per interval — the steady-state behaviour is unchanged.
+        // Under flood the loop returns to the body of this function
+        // after each batch; we re-tick `tickInterval` only when wall
+        // clock has actually crossed the next interval boundary so
+        // the per-tick log line and `lean_tick_interval_duration_seconds`
+        // histogram retain their interval-cadence semantics (and don't
+        // get spammed at the CQE-batch rate).
+        //
+        // The existing `zeam_xev_clock_until_done_drain_seconds`
+        // histogram is repurposed: each pass is now bounded by one
+        // batch, so values are expected to drop sharply (sub-ms median
+        // under steady load). The two slow-drain counters
+        // (>=500ms / >=1s) now flag pathologically large single CQE
+        // batches rather than unbounded drain queues — still a useful
+        // signal but rarely fires now. `zeam_xev_clock_drain_passes_total`
+        // is the new pass-rate liveness counter.
+
+        // Bootstrap: register the first interval timer so `.once` has
+        // something to wait on. Subscribers must have called
+        // `subscribeOnSlot` before `run`; if none did, `.once` would
+        // block forever (which is the same observable behaviour the
+        // pre-P4 `.until_done` loop produced — the busy-while exited
+        // each pass with `loop.active == 0`).
+        self.tickInterval();
         while (true) {
-            self.tickInterval();
             const drain_timer = zeam_metrics.zeam_xev_clock_until_done_drain_seconds.start();
-            try self.events.run(.until_done);
+            try self.events.run(.once);
+            zeam_metrics.metrics.zeam_xev_clock_drain_passes_total.incr();
             const drain_s = drain_timer.observe();
             if (drain_s >= 0.5) {
                 zeam_metrics.metrics.zeam_xev_clock_until_done_slow_ge_500ms_total.incr();
             }
             if (drain_s >= 1.0) {
                 zeam_metrics.metrics.zeam_xev_clock_until_done_slow_ge_1s_total.incr();
-                self.logger.warn("xev until_done drain took {d:.3}s (slot driver backlog; see #863)", .{drain_s});
+                self.logger.warn("xev .once drain batch took {d:.3}s (slot driver backlog; see #863)", .{drain_s});
+            }
+
+            // Only re-tick when wall clock has crossed the next
+            // interval boundary. The boundary check mirrors the one
+            // inside `tickInterval` itself (`current_interval_time_ms +
+            // SECONDS_PER_INTERVAL_MS < time_now_ms + CLOCK_DISPARITY_MS`),
+            // kept synchronised so a future change to either side
+            // doesn't silently drift them apart.
+            const time_now_ms: isize = @intCast(zeam_utils.unixTimestampMillis());
+            if (self.current_interval_time_ms + constants.SECONDS_PER_INTERVAL_MS < time_now_ms + CLOCK_DISPARITY_MS) {
+                self.tickInterval();
             }
         }
     }

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -201,14 +201,19 @@ pub const Clock = struct {
                 self.logger.warn("xev .once drain batch took {d:.3}s (slot driver backlog; see #863)", .{drain_s});
             }
 
-            // Only re-tick when wall clock has crossed the next
-            // interval boundary. The boundary check mirrors the one
-            // inside `tickInterval` itself (`current_interval_time_ms +
-            // SECONDS_PER_INTERVAL_MS < time_now_ms + CLOCK_DISPARITY_MS`),
-            // kept synchronised so a future change to either side
-            // doesn't silently drift them apart.
+            // Only re-tick when wall clock has reached the next interval
+            // boundary — **without** `CLOCK_DISPARITY_MS` slack on this
+            // outer trigger. The inner `tickInterval` while-loop still
+            // applies disparity for multi-interval catch-up once we enter
+            // `tickInterval`. Using `+ CLOCK_DISPARITY_MS` here matched the
+            // inner inequality and could fire a full `tickInterval()` up to
+            // ~`CLOCK_DISPARITY_MS` early while the interval timer was still
+            // legitimately pending; `tickInterval` then re-armed/canceled that
+            // timer and the canceled completion does not run `onInterval`,
+            // so gossip-heavy `.once` batches could skip slot duties (#886
+            // review).
             const time_now_ms: isize = @intCast(zeam_utils.unixTimestampMillis());
-            if (self.current_interval_time_ms + constants.SECONDS_PER_INTERVAL_MS < time_now_ms + CLOCK_DISPARITY_MS) {
+            if (self.current_interval_time_ms + constants.SECONDS_PER_INTERVAL_MS <= time_now_ms) {
                 self.tickInterval();
             }
         }

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -70,6 +70,17 @@ pub const MAX_FUTURE_SLOT_QUEUE_TOLERANCE: u64 = 256;
 // can find the spec source when leanSpec test vectors land.
 pub const MAX_PENDING_BLOCKS: usize = 1024;
 
+// Maximum buffered gossip attestations / aggregations awaiting their
+// referenced block to be processed. Direct mirror of leanSpec
+// `subspecs/sync/config.py::MAX_PENDING_ATTESTATIONS` (also 1024).
+//
+// The buffer underwrites the spec's "validate, on AssertionError buffer
+// for replay" lifecycle (`subspecs/sync/service.py::on_gossip_attestation`,
+// retried on every successful `on_gossip_block`). Keeping the bound in
+// sync with the spec value ensures replay churn stays within spec test
+// vectors. FIFO eviction matches the spec's "drop oldest" policy.
+pub const MAX_PENDING_ATTESTATIONS: usize = 1024;
+
 // Maximum depth for recursive block fetching
 // When fetching parent blocks, we stop after this many levels to avoid infinite loops
 pub const MAX_BLOCK_FETCH_DEPTH = 512;

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -3,6 +3,7 @@ const networks = @import("@zeam/network");
 const types = @import("@zeam/types");
 const params = @import("@zeam/params");
 const zeam_utils = @import("@zeam/utils");
+const zeam_metrics = @import("@zeam/metrics");
 const ssz = @import("ssz");
 const locking = @import("./locking.zig");
 
@@ -95,6 +96,23 @@ pub const BlocksByRootRequestResult = struct {
     }
 };
 
+/// Issue #863 P3: cap on outbound `BlocksByRoot` RPCs in flight at any
+/// given moment. The pre-#863 path issued one RPC per attestation that
+/// referenced an unknown head, multiplied by 4× subnet fanout for an
+/// aggregator — under flood the libxev thread fanned hundreds of
+/// concurrent RPCs that themselves timed out (8s default per
+/// `RPC_REQUEST_TIMEOUT_SECONDS`) and retried, saturating the loop and
+/// the timed-out-requests sweep.
+///
+/// 8 is empirically generous: each RPC fetches up to MAX_BLOCKS_BY_ROOT
+/// roots in one batch, so 8 in-flight covers ~64 missing roots
+/// concurrently — comfortably above the worst observed sustained
+/// missing-root rate while keeping the RPC dispatch fan-out bounded.
+/// Tune by watching `zeam_blocks_by_root_inflight` saturate at this
+/// value combined with `lean_block_fetch_dedup_total{outcome="inflight_cap"}`
+/// climbing — under healthy operation neither should be hot.
+pub const MAX_CONCURRENT_BLOCKS_BY_ROOT: u32 = 8;
+
 pub const Network = struct {
     allocator: Allocator,
     backend: networks.NetworkInterface,
@@ -113,6 +131,17 @@ pub const Network = struct {
     /// no other thread reads it).
     timed_out_requests: std.ArrayList(u64) = .empty,
     timed_out_requests_lock: zeam_utils.SyncMutex = .{},
+
+    /// Issue #863 P3: in-flight outbound `BlocksByRoot` RPC count.
+    /// Incremented by `ensureBlocksByRootRequest` after a successful
+    /// dispatch, decremented by `finalizePendingRequest` regardless of
+    /// success / timeout / peer disconnect. Read by
+    /// `ensureBlocksByRootRequest` to enforce
+    /// `MAX_CONCURRENT_BLOCKS_BY_ROOT` and exported as
+    /// `zeam_blocks_by_root_inflight`. Atomic so the timeout sweep
+    /// thread (`processTimedOutRequests`) and the gossip dispatch
+    /// path on the libxev thread don't tear it.
+    blocks_by_root_inflight: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
 
     const Self = @This();
 
@@ -699,6 +728,14 @@ pub const Network = struct {
         return request_id;
     }
 
+    /// Issue #863 P3: errors that signal "request would exceed the
+    /// in-flight cap" so the caller can bucket them as a soft-rejection
+    /// rather than a hard error. This is intentionally a separate error
+    /// from `error.NoPeersAvailable` because the calling code in
+    /// `BeamNode.fetchBlockByRoots` accounts for both in different
+    /// `lean_block_fetch_dedup_total{outcome=…}` buckets.
+    pub const EnsureBlocksByRootError = error{InFlightCapReached};
+
     pub fn ensureBlocksByRootRequest(
         self: *Self,
         roots: []const types.Root,
@@ -709,12 +746,43 @@ pub const Network = struct {
 
         if (!self.shouldRequestBlocksByRoot(roots)) return null;
 
+        // Issue #863 P3: enforce the in-flight cap BEFORE `selectPeer`
+        // so a saturated cap doesn't burn a peer-selection round trip.
+        // The compare-and-set loop is monotonic; under contention each
+        // attempt observes the latest count, so a concurrent finalize
+        // (decrement) is reflected on the next iteration.
+        while (true) {
+            const cur = self.blocks_by_root_inflight.load(.monotonic);
+            if (cur >= MAX_CONCURRENT_BLOCKS_BY_ROOT) {
+                return error.InFlightCapReached;
+            }
+            if (self.blocks_by_root_inflight.cmpxchgWeak(cur, cur + 1, .acq_rel, .monotonic) == null) {
+                // Reservation succeeded — we now own one in-flight slot
+                // until either (a) the dispatch path below errors and we
+                // release explicitly, or (b) the request completes and
+                // `finalizePendingRequest` releases it.
+                break;
+            }
+        }
+
+        // Reservation released on any error path before the request_id
+        // is recorded in `pending_rpc_requests`. After dispatch, the
+        // slot stays held until `finalizePendingRequest` runs.
+        var reservation_owned = true;
+        errdefer if (reservation_owned) {
+            _ = self.blocks_by_root_inflight.fetchSub(1, .acq_rel);
+            zeam_metrics.metrics.zeam_blocks_by_root_inflight.set(self.blocks_by_root_inflight.load(.monotonic));
+        };
+
         const peer = (try self.selectPeer()) orelse return error.NoPeersAvailable;
         var peer_owned = true;
         errdefer if (peer_owned) self.allocator.free(peer);
 
         const request_id = try self.sendBlocksByRootRequest(peer, roots, depth, handler);
         peer_owned = false; // ownership transferred to result
+        reservation_owned = false; // ownership transferred to pending_rpc_requests
+
+        zeam_metrics.metrics.zeam_blocks_by_root_inflight.set(self.blocks_by_root_inflight.load(.monotonic));
 
         return BlocksByRootRequestResult{
             .peer_id = peer,
@@ -820,6 +888,12 @@ pub const Network = struct {
                     for (block_ctx.requested_roots) |root| {
                         _ = self.removePendingBlockRoot(root);
                     }
+                    // Issue #863 P3: release the in-flight slot reserved by
+                    // `ensureBlocksByRootRequest`. Decrement is unconditional
+                    // (success / timeout / disconnect / cancellation all flow
+                    // through here).
+                    _ = self.blocks_by_root_inflight.fetchSub(1, .acq_rel);
+                    zeam_metrics.metrics.zeam_blocks_by_root_inflight.set(self.blocks_by_root_inflight.load(.monotonic));
                 },
                 .blocks_by_range => {},
                 .status => {},

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1466,6 +1466,29 @@ pub const BeamNode = struct {
                         missing_roots.items.len,
                     ) catch {};
                 },
+                error.InFlightCapReached => {
+                    // Issue #863 P3: outbound `BlocksByRoot` cap was hit
+                    // before this batch could dispatch. The cap (8 in
+                    // flight, see `network.MAX_CONCURRENT_BLOCKS_BY_ROOT`)
+                    // is the gossip-flood backpressure that prevented the
+                    // libxev thread from forking hundreds of concurrent
+                    // RPCs, each of which would then time out at
+                    // `RPC_REQUEST_TIMEOUT_SECONDS` (8s) and re-trigger
+                    // the storm. Bucket as `inflight_cap` so Grafana
+                    // distinguishes "cap-saturated" from "no peers" /
+                    // "send failed" — sustained non-zero rate combined
+                    // with `zeam_blocks_by_root_inflight` pinned at the
+                    // cap is the canonical signal that flood is being
+                    // contained rather than absorbed.
+                    self.logger.debug(
+                        "blocks-by-root in-flight cap reached, deferring fetch of {d} root(s)",
+                        .{missing_roots.items.len},
+                    );
+                    zeam_metrics.metrics.lean_block_fetch_dedup_total.incrBy(
+                        .{ .outcome = "inflight_cap" },
+                        missing_roots.items.len,
+                    ) catch {};
+                },
                 else => {
                     self.logger.warn(
                         "failed to send blocks-by-root request to peer: {any}",

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -558,6 +558,7 @@ pub const BeamNode = struct {
                 // iteration of a deep cached-block chain. Correct semantically; a future optimisation
                 // could pass false during catch-up and prune once at the end.
                 self.chain.onBlockFollowup(true, &cached_block);
+                self.chain.replayPendingAttestations();
 
                 // Remove from cache now that it's been processed. Note:
                 // we own `cached` (clone), so this `removeFetchedBlock`
@@ -846,6 +847,7 @@ pub const BeamNode = struct {
             // Store aggregated signature proofs from this block so they can be reused
             // in future block production. This is the same followup done for gossiped blocks.
             self.chain.onBlockFollowup(true, signed_block);
+            self.chain.replayPendingAttestations();
 
             // Block was successfully added, try to process any cached descendants
             self.processCachedDescendants(block_root);
@@ -923,6 +925,7 @@ pub const BeamNode = struct {
         defer self.allocator.free(missing_roots);
 
         self.chain.onBlockFollowup(true, signed_block);
+        self.chain.replayPendingAttestations();
         self.processCachedDescendants(block_root);
         self.fetchBlockByRoots(missing_roots, 0) catch |err| {
             self.logger.warn("blocks_by_range: failed to fetch {d} missing block(s): {any}", .{ missing_roots.len, err });
@@ -1949,6 +1952,7 @@ pub const BeamNode = struct {
 
         // 4. Followup with additional housekeeping tasks.
         self.chain.onBlockFollowup(true, &signed_block);
+        self.chain.replayPendingAttestations();
     }
 
     pub fn publishAttestation(self: *Self, signed_attestation: networks.AttestationGossip) !void {


### PR DESCRIPTION
## Summary

Issue #863 reported the zeam_0 aggregator on devnet-4 falling badly behind
the rest of the network: head trailed finalized by ~100 slots, the slot
clock missed its tick deadline for seconds at a time, and ~74% of incoming
attestations referenced blocks the node hadn't seen yet — every one of
those attestations triggered a block-fetch RPC that itself timed out, so
the node spent its time chasing blocks instead of running fork choice.

This PR fixes the underlying starvation. It also brings zeam's gossip
attestation handling in line with `leanSpec` so the behaviour matches the
reference implementation rather than diverging quietly.

## What goes wrong today

The aggregator does almost everything on a single thread: receive gossip,
validate attestations against fork choice, run state transitions on new
blocks, fire the every-800ms slot tick, etc. Under load four problems
compound:

1. The event loop drains every queued I/O completion before handing
   control back, which can take seconds when peers are flooding.
2. Each attestation that references an unknown block fans out into a
   point-lookup RPC, four times over for an aggregator subscribed to four
   subnets. The fan-out itself becomes the load.
3. The slot tick is best-effort: if it doesn't get CPU in time, the node
   silently runs fork choice on stale state.
4. Incoming attestations are validated on the same thread that imports
   blocks, so they fight each other for the fork-choice lock.

## What this PR changes

The series is layered so each commit is independently reviewable.

1. **`metrics: add #863 P2/P3/P4 gating + cap counters`** — registers
   three new metrics consumed by the rest of the series. No behaviour
   change.
2. **`clock: bound xev drain to one CQE batch per pass (#863 P4)`** —
   the event loop now returns to the slot driver after one batch of I/O
   completions instead of draining everything in sight. The slot tick is
   still rate-gated to its own cadence, so timing histograms stay
   meaningful.
3. **`network: cap concurrent BlocksByRoot RPCs in-flight (#863 P3)`** —
   caps in-flight outbound block-fetch RPCs at 8. Anything beyond that
   is rejected on the spot and counted, so a flood can't run the
   fan-out away.
4. **`chain: future-slot drop + sync-aware gossip gating (#863 P2)`** —
   drops two classes of attestation cheaply on the receive path: ones
   for slots that haven't happened yet, and ones that arrive while the
   node is still catching up to peers. Block gossip is intentionally not
   gated — that's the recovery vector during sync.
5. **`chain: move gossip attestation validation to chain-worker
   (#863 P5)`** — the receive path becomes pure dispatch. The expensive
   work (fork-choice reads, signature verification) moves onto a
   dedicated chain-worker thread so it stops competing with block
   import.
6. **`chain: align gossip attestation lifecycle with leanSpec
   (#863 spec parity)`** — closes the gaps between zeam and the
   reference implementation:
   * Attestations whose referenced block isn't yet imported, or whose
     slot is just slightly in the future, are now buffered (capped at
     1024 entries, FIFO eviction) and replayed after every successful
     block import — same as `leanSpec`'s `_pending_attestations` /
     `_replay_pending_attestations`.
   * Sync-state gating now matches the spec: while the node is syncing
     it accepts gossip and uses the buffer to absorb out-of-order
     arrivals; only IDLE-equivalent states (no peers, fork choice not
     initialised) drop gossip.
   * Non-aggregators now run validation and signature verification on
     received attestations and then drop them, matching the spec's
     "validate and drop" path. Storage in fork choice stays gated on
     the aggregator role.
7. **`build: invoke rust nightly via 'rustup run' …`** + **`build: fix
   zig fmt of rustup run cargo argv`** — CI fix for `macos-latest`
   where `cargo +nightly` was hitting the rustup installer instead of
   the proxy and failing immediately. Switching to
   `rustup run nightly cargo …` works on every supported install
   without depending on which binary `cargo` happens to point at.

## What this PR does not change

A few things look related but are deliberately out of scope:

* The fork-choice attestation tracker (zeam's per-validator `latestNew`
  / `latestKnown`) stays as the head-selection mechanism. The spec
  doesn't define it and zeam relies on it; this PR doesn't touch that
  shape.
* The `BlocksByRoot` in-flight cap and the one-batch event-loop bound
  are zeam-specific performance knobs the spec is silent on; they stay.
* The `--aggregate-subnet-ids` selection policy (own + neighbour) is a
  separate change that lives in `lean-quickstart`, not here.

## New metrics

* `zeam_gossip_atts_dropped_total{kind, reason}` — drops on the receive
  thread before chain-worker dispatch (`syncing` / `worker_validation_failed`).
* `zeam_blocks_by_root_inflight` — instantaneous outbound block-fetch
  RPC count, capped at 8.
* `zeam_xev_clock_drain_passes_total` — passes through the bounded
  event-loop drain.
* `lean_pending_attestations_buffered_total{kind, reason}` — entries
  pushed into the spec-style replay buffer.
* `lean_pending_attestations_evicted_total{kind}` — FIFO evictions at
  the 1024 cap.
* `lean_pending_attestations_replay_total{kind, outcome}` — replay
  outcomes (`accepted` / `buffered` / `dropped`).
* `lean_pending_attestations_size{kind}` — instantaneous buffer depth.

`lean_block_fetch_dedup_total` gains a new `outcome="inflight_cap"`
label so the existing "every dedup outcome is accounted for" invariant
still holds.

## Test plan

- [x] `zig build` clean on macOS aarch64.
- [x] `zig build test` — all test binaries pass (271 tests across 14
      binaries).
- [x] `zig fmt --check .` clean.
- [x] CI on `perf/863-loop-fairness-and-fetch-coalesce` after the
      rustup-invocation fix: `lint` and `Dummy prove (macos-latest)`
      passing on the latest commit; `build` / `test` /
      `build-all-provers` running.
- [ ] Devnet redeploy — watch for:
      * `zeam_blocks_by_root_inflight` bounded by 8 under load.
      * `lean_block_fetch_dedup_total{outcome="inflight_cap"}` only
        non-zero during flood, zero in steady state.
      * `zeam_gossip_atts_dropped_total{reason="syncing"}` clears as
        nodes catch up.
      * `lean_pending_attestations_size` non-zero only during sync /
        during reorgs; replay outcomes weighted toward `accepted`.
      * Slot-tick latency back below the slot duration on the
        aggregator.
      * Head-vs-finalized gap stays bounded (vs ~100 slots pre-fix).

Refs blockblaz/zeam#863