### PR TITLE
fix(test_driver): wire gossip XMSS verify + restore state-transition assertions

### DIFF
--- a/pkgs/cli/src/test_driver.zig
+++ b/pkgs/cli/src/test_driver.zig
@@ -22,6 +22,7 @@ const forkchoice = node.fcFactory;
 const state_transition = @import("@zeam/state-transition");
 const node_constants = node.constants;
 const params = @import("@zeam/params");
+const xmss = @import("@zeam/xmss");
 
 pub const read_max_bytes: usize = 16 * 1024 * 1024;
 
@@ -758,7 +759,9 @@ fn parseAttestationData(obj: std.json.ObjectMap) !types.AttestationData {
 }
 
 /// "attestation" step: single-validator gossip attestation.
-/// Fixture format: {"validatorId": N, "data": {...}, "signature": "0x..." (optional)}
+/// Fixture format: {"validatorId": N, "data": {...}, "signature": "0x..."}
+/// The XMSS signature is required and verified against the validator's
+/// attestation pubkey (hashTreeRoot of AttestationData as the message).
 fn processAttestationStep(
     driver: *ForkChoiceDriverState,
     step_obj: std.json.ObjectMap,
@@ -770,9 +773,32 @@ fn processAttestationStep(
     const validator_id = try parseU64Field(att_obj, &.{ "validatorId", "validator_id" });
     const data_obj = try parseObjectField(att_obj, &.{"data"});
     const att_data = try parseAttestationData(data_obj);
-    const num_validators = driver.fork_choice.anchorState.validators.constSlice().len;
-    if (validator_id >= num_validators) return error.UnknownValidator;
+    const validators_slice = driver.fork_choice.anchorState.validators.constSlice();
+    if (validator_id >= validators_slice.len) return error.UnknownValidator;
     try validateAttestationDataForGossip(driver, att_data);
+
+    // XMSS signature verification. The hive lean-spec-tests fixtures embed a
+    // SignedAttestation per gossip step (see leanSpec/.../gossip_attestation_spec.py:
+    // valid_signature=False produces an all-zero structurally-valid signature
+    // that must fail XMSS verification). Hive fixtures use leanEnv=prod, so we
+    // dispatch to xmss.verifySsz (the test-scheme path is exercised by the
+    // local spectest runner instead).
+    const sig_value = att_obj.get("signature") orelse return error.SignatureVerificationFailed;
+    const sig_hex = parseStringValue(sig_value) catch return error.SignatureVerificationFailed;
+    const sig_body = if (std.mem.startsWith(u8, sig_hex, "0x")) sig_hex[2..] else sig_hex;
+    if (sig_body.len % 2 != 0) return error.SignatureVerificationFailed;
+    const sig_bytes = try driver.allocator.alloc(u8, sig_body.len / 2);
+    defer driver.allocator.free(sig_bytes);
+    _ = std.fmt.hexToBytes(sig_bytes, sig_body) catch return error.SignatureVerificationFailed;
+
+    var msg_hash: [32]u8 = undefined;
+    zeam_utils.hashTreeRoot(types.AttestationData, att_data, &msg_hash, driver.allocator) catch
+        return error.SignatureVerificationFailed;
+
+    const att_pubkey = validators_slice[validator_id].getAttestationPubkey();
+    const epoch: u32 = @intCast(att_data.slot);
+    xmss.verifySsz(att_pubkey, &msg_hash, epoch, sig_bytes) catch
+        return error.SignatureVerificationFailed;
 
     const att = types.Attestation{
         .validator_id = @intCast(validator_id),
@@ -1023,6 +1049,19 @@ pub fn runStateTransition(allocator: Allocator, body_bytes: []const u8) ![]u8 {
     const stf_logger = logger_config.logger(.state_transition);
 
     var transition_error: ?[]const u8 = null;
+
+    // Slots-only monotonicity fixtures (leanSpec PR #643: test_process_slots_*)
+    // ship `pre` + `expectException` with no blocks. The test asserts that
+    // `process_slots(state, state.slot)` (or any `target <= state.slot`) is
+    // rejected. zeam's `state.process_slots` returns `InvalidPreState` on
+    // violation, which the spec calls `AssertionError`.
+    if (blocks_arr.items.len == 0 and expect_exception != null) {
+        const target_slot = pre_state.slot;
+        pre_state.process_slots(aa, target_slot, stf_logger) catch |err| {
+            transition_error = @errorName(err);
+        };
+    }
+
     for (blocks_arr.items) |block_val| {
         var block = buildBlockFromJson(aa, block_val) catch |err| {
             transition_error = @errorName(err);
@@ -1031,7 +1070,6 @@ pub fn runStateTransition(allocator: Allocator, body_bytes: []const u8) ![]u8 {
         defer block.deinit();
         state_transition.apply_transition(aa, &pre_state, block, .{
             .logger = stf_logger,
-            .validateResult = false,
         }) catch |err| {
             transition_error = @errorName(err);
             break;


### PR DESCRIPTION
## Summary

Closes the four zeam_devnet4 false positives in `lean-spec-tests-fork-choice` and `lean-spec-tests-state-transition` on [hive.leanroadmap.org](https://hive.leanroadmap.org/) (2026-05-15 run, commit 28dd293):

| Suite | Failure | Root cause |
|-------|---------|------------|
| fork-choice | `test_gossip_attestation_with_invalid_signature` | `processAttestationStep` ignored the `signature` field |
| state-transition | `test_block_with_invalid_state_root` | `apply_transition(.., .validateResult = false)` skipped post-state-root check |
| state-transition | `test_block_with_wrong_slot` | Same as above |
| state-transition | `test_process_slots_target_equal_to_state_slot_rejected` | No branch for `blocks.len == 0 && expectException != null` |

The HTTP test driver had drifted from the local spectest runner in three places. This PR re-aligns them.

## Changes

`pkgs/cli/src/test_driver.zig` (+42 / -4):

1. **Gossip XMSS verify in `processAttestationStep`**. Parse `attestation.signature`, hashTreeRoot the `AttestationData`, look up the validator's `attestation_pubkey`, and call `xmss.verifySsz(pubkey, msg, slot, sig)`. Hive fixtures use `leanEnv=prod`, so we dispatch to `verifySsz` (the test-scheme path stays exercised by the local spectest runner). Verification failure / missing / malformed signature → `error.SignatureVerificationFailed`, which the upstream `stepForkChoiceDriver` surfaces as `accepted:false`.

2. **Drop `.validateResult = false`** in `runStateTransition`'s `apply_transition` call. The local runner uses the default `true` (state_transition_runner.zig:291); our HTTP driver was the only path that opted out.

3. **Empty-blocks-with-expectException branch** in `runStateTransition`. Mirrors the local runner at state_transition_runner.zig:201-224 — when `blocks.len == 0 && expectException != null`, call `pre_state.process_slots(state.slot)` directly so its `InvalidPreState` reject becomes the expected `AssertionError`.

## Verification

- `zig build` clean
- `zig fmt --check .` clean
- `zig build test`: 291 unit tests pass across 14 module suites (forkchoice 149, locking, chain_worker, rc_beam_state, hashsig 18, aggregation, node, network, cli, etc.)
- **Local hive** (zeam image built from this branch's HEAD):
    - `lean-spec-tests-fork-choice`: **85/85 pass** (was 84/85)
    - `lean-spec-tests-state-transition`: **51/51 pass** (was 47/50)
  - Observed the new error paths firing live in the simulator log:
    - `[stf] state root=d123... block root=deaddead...` — `validateResult: true` rejecting bad state root
    - `[stf] Invalid block slot=1 >= pre-state slot=1` — empty-blocks branch calling `process_slots(state.slot)`

## Out of scope

- The `lean-spec-tests-verify-signatures` suite (currently 65/225 for zeam) is addressed separately by #880, which wires XMSS into `runVerifySignatures`. This PR leaves that endpoint untouched.

## Test plan

- [x] `zig build` succeeds
- [x] `zig fmt --check .` clean
- [x] `zig build test` — all 291 unit tests pass
- [x] Local hive `lean-spec-tests-fork-choice` 85/85 pass
- [x] Local hive `lean-spec-tests-state-transition` 51/51 pass
- [ ] CI green on PR
- [ ] Apply `run-hive` label to confirm against upstream hive runner