### PR TITLE
ci(risc0): install nightly Rust toolchain before cargo build

### DIFF
--- a/.github/workflows/risc0.yml
+++ b/.github/workflows/risc0.yml
@@ -41,6 +41,9 @@ jobs:
         toolchain: stable
         components: clippy, rustfmt
 
+    - name: Install Rust nightly toolchain
+      run: rustup toolchain install nightly --no-self-update
+
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:


### PR DESCRIPTION
## Problem

The `risc0` CI job was failing with:

```
error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install nightly-x86_64-unknown-linux-gnu` to install it
```

`build.zig` invokes `rustup run nightly cargo ...` for all Rust glue crate builds (the comment in `build_rust_project` explains why we use `rustup run` instead of `cargo +nightly`). The `risc0.yml` workflow only installed the `stable` toolchain via `setup-rust-toolchain`, so nightly was never available on the runner.

Failing run: https://github.com/blockblaz/zeam/actions/runs/25932545989/job/76229730270

## Fix

Add an explicit step to install the nightly toolchain after stable is set up:

```yaml
- name: Install Rust nightly toolchain
  run: rustup toolchain install nightly --no-self-update
```

Note: `--no-self-update` avoids an unnecessary rustup self-update and matches the pattern used in similar workflows.