### PR TITLE
node, metrics: offload heavy chain mutations to chain-worker, parallelize XMSS verify (#863)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -220,6 +220,16 @@ const Metrics = struct {
     lean_chain_queue_dropped_total: LeanChainQueueDroppedCounter,
     lean_chain_queue_depth: LeanChainQueueDepthGauge,
     lean_chain_worker_loop_iters_total: LeanChainWorkerLoopItersCounter,
+    /// Tripwire counter (zclawz review on PR #890): bumped from
+    /// `chainWorkerProcessPendingBlocksThunk` whenever it returns a
+    /// non-empty `missing_roots` slice. The thunk has no production
+    /// caller today (the libxev tick runs `processPendingBlocks`
+    /// inline), so this metric MUST stay at 0 in steady state. A
+    /// non-zero value is a regression signal: a future worker
+    /// producer was wired up without first plumbing the missing-
+    /// roots backchannel and is silently stranding sync — the
+    /// thunk would otherwise just log a warn that's easy to miss.
+    lean_chain_worker_process_pending_blocks_dropped_missing_roots_total: LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter,
     // Slice c-2b commit 5 of #803: distribution of refcount values across
     // map-resident BeamState entries at scrape time. Sampled by the chain
     // via `recordChainStateRefcountDistribution` registered as a
@@ -406,6 +416,7 @@ const Metrics = struct {
     const LeanChainQueueDroppedCounter = metrics_lib.CounterVec(u64, struct { queue: []const u8 });
     const LeanChainQueueDepthGauge = metrics_lib.GaugeVec(u64, struct { queue: []const u8 });
     const LeanChainWorkerLoopItersCounter = metrics_lib.Counter(u64);
+    const LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter = metrics_lib.Counter(u64);
     // Refcount-distribution buckets [1, 2, 4, 8, 16, 32, +Inf]. Typical
     // value is 1 (writer-only); transient 2-4 under reader concurrency;
     // values >16 indicate leaked acquires (a reader forgot to release
@@ -899,9 +910,10 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_pending_blocks_replayed_total = try Metrics.LeanPendingBlocksReplayedCounter.init(allocator, io, "lean_pending_blocks_replayed_total", .{ .help = "Total number of replays from pending_blocks, by terminal result (issue #788)." }, .{}),
         .lean_blocks_future_slot_dropped_total = Metrics.LeanBlocksFutureSlotDroppedCounter.init("lean_blocks_future_slot_dropped_total", .{ .help = "Total number of gossip blocks hard-rejected as FutureSlot beyond the queueable window (issue #788)." }, .{}),
         // Chain-worker queue + loop metrics (slice c-1 of #803).
-        .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
+        .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation|aggregated_attestation|replay_pending). The `replay_pending` label is a single nudge that drains the in-process pending-attestation buffers — buffer depth itself is exposed via `lean_pending_attestations_size{kind}`." }, .{}),
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed or explicitly discarded during shutdown, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
+        .lean_chain_worker_process_pending_blocks_dropped_missing_roots_total = Metrics.LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter.init("lean_chain_worker_process_pending_blocks_dropped_missing_roots_total", .{ .help = "Tripwire (#890): non-zero only if a future worker producer dispatches `process_pending_blocks` without wiring the missing-roots backchannel. MUST stay 0 in steady state." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.
         .lean_block_root_compute_skipped_total = try Metrics.LeanBlockRootComputeSkippedCounter.init(allocator, io, "lean_block_root_compute_skipped_total", .{ .help = "Total number of times a downstream consumer skipped a `hashTreeRoot(BeamBlock)` because the producer threaded a precomputed root through (slice (e) of #803). Labeled by skip site." }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -602,9 +602,12 @@ pub const BeamChain = struct {
     /// MUST be called from the chain-worker thread, or from the libxev
     /// thread when the worker is disabled / when `BeamChain` handles
     /// `onBlock` + `onBlockFollowup` directly (gossip, RPC, pending-queue,
-    /// publish paths — same thread as other chain mutations). Holds the
-    /// buffer mutex only across the swap-out / re-append; validation runs
-    /// lock-free over locally-owned slices.
+    /// publish paths — same thread as other chain mutations). When the
+    /// chain-worker is enabled, libxev-thread `BeamNode` paths that replay
+    /// after block import should prefer `replayPendingAttestationsLibxevBudget`
+    /// so a deep pending buffer cannot stall the slot driver (#863).
+    /// Holds the buffer mutex only across the swap-out / re-append;
+    /// validation runs lock-free over locally-owned slices.
     pub fn replayPendingAttestations(self: *Self) void {
         // Swap the buffers out under lock so producers can keep
         // appending into fresh empty buffers while we drain.
@@ -626,6 +629,41 @@ pub const BeamChain = struct {
         }
         for (aggs.items) |*agg| {
             self.replayOneAggregation(agg);
+        }
+    }
+
+    /// Like `replayPendingAttestations`, but caps how many entries are
+    /// processed per call so libxev-thread producers (RPC, cache, publish)
+    /// cannot monopolize the slot driver for seconds when the pending buffers
+    /// are deep (#863, aggregator-heavy devnets).
+    ///
+    /// The chain-worker path continues to use `replayPendingAttestations`
+    /// (unbounded) because it does not share the libxev clock thread.
+    pub fn replayPendingAttestationsLibxevBudget(self: *Self) void {
+        const is_agg = self.is_aggregator_enabled.load(.acquire);
+
+        var a_done: usize = 0;
+        while (a_done < constants.REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET) : (a_done += 1) {
+            self.pending_attestations_mutex.lock();
+            if (self.pending_attestations.items.len == 0) {
+                self.pending_attestations_mutex.unlock();
+                break;
+            }
+            const gossip = self.pending_attestations.orderedRemove(0);
+            self.pending_attestations_mutex.unlock();
+            self.replayOneAttestation(gossip, is_agg);
+        }
+
+        var g_done: usize = 0;
+        while (g_done < constants.REPLAY_PENDING_AGGREGATIONS_LIBXEV_BUDGET) : (g_done += 1) {
+            self.pending_attestations_mutex.lock();
+            if (self.pending_aggregated_attestations.items.len == 0) {
+                self.pending_attestations_mutex.unlock();
+                break;
+            }
+            var agg_owned = self.pending_aggregated_attestations.orderedRemove(0);
+            self.pending_attestations_mutex.unlock();
+            self.replayOneAggregation(&agg_owned);
         }
     }
 
@@ -1034,18 +1072,19 @@ pub const BeamChain = struct {
     }
 
     /// Route a `processPendingBlocks` tick through the worker queue.
-    /// (Not migrated by any caller in commit 3 — included so the
-    /// vtable + queue plumbing is exercised end-to-end and the API
-    /// shape is stable for the follow-up commit that migrates the
-    /// libxev tick path.)
     pub fn submitProcessPendingBlocks(self: *Self, current_slot: types.Slot) SubmitError!void {
         const w = self.chain_worker orelse return error.ChainWorkerDisabled;
         try w.sendBlock(.{ .process_pending_blocks = .{ .current_slot = current_slot } });
     }
 
+    /// Returns whether the background chain-worker thread is active.
+    pub fn chainWorkerEnabled(self: *const Self) bool {
+        return self.chain_worker != null;
+    }
+
     /// Route a `processFinalizationFollowup` move-off through the worker queue.
-    /// (Not migrated by any caller in commit 3; see
-    /// `submitProcessPendingBlocks` for the rationale.)
+    /// (Not yet called from production; reserved for the finalization follow-up
+    /// migration off the libxev thread.)
     pub fn submitProcessFinalizationFollowup(
         self: *Self,
         previous_finalized: types.Checkpoint,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -642,6 +642,10 @@ pub const BeamChain = struct {
     pub fn replayPendingAttestationsLibxevBudget(self: *Self) void {
         const is_agg = self.is_aggregator_enabled.load(.acquire);
 
+        // The size gauges are kept in sync with the buffer length on
+        // every pop. `replayOne*` may re-`enqueuePending*` an entry on
+        // retryable failure (which itself updates the gauge), so the
+        // post-replay value can drift back up — that's expected.
         var a_done: usize = 0;
         while (a_done < constants.REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET) : (a_done += 1) {
             self.pending_attestations_mutex.lock();
@@ -650,7 +654,9 @@ pub const BeamChain = struct {
                 break;
             }
             const gossip = self.pending_attestations.orderedRemove(0);
+            const new_depth = self.pending_attestations.items.len;
             self.pending_attestations_mutex.unlock();
+            zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "attestation" }, new_depth) catch {};
             self.replayOneAttestation(gossip, is_agg);
         }
 
@@ -662,7 +668,9 @@ pub const BeamChain = struct {
                 break;
             }
             var agg_owned = self.pending_aggregated_attestations.orderedRemove(0);
+            const new_depth = self.pending_aggregated_attestations.items.len;
             self.pending_attestations_mutex.unlock();
+            zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "aggregation" }, new_depth) catch {};
             self.replayOneAggregation(&agg_owned);
         }
     }
@@ -981,8 +989,24 @@ pub const BeamChain = struct {
         // a Message-shape change.
         _ = current_slot;
         const self: *Self = @ptrCast(@alignCast(ctx));
+        // No production caller dispatches this variant today: the
+        // libxev tick runs `processPendingBlocks` inline (in
+        // `BeamNode.onInterval`) so the returned `missing_roots` can
+        // be fed straight into `fetchBlockByRoots` via the network
+        // helpers on `BeamNode`. Wiring a worker producer for this
+        // path requires a worker → libxev backchannel for the
+        // missing-roots fetch (the chain has no `BeamNode` handle).
+        // Until that lands, the thunk only drains the queue; if it
+        // ever fires we log so the regression is visible instead of
+        // silently stranding sync.
         const missing_roots = self.processPendingBlocks();
-        self.allocator.free(missing_roots);
+        defer self.allocator.free(missing_roots);
+        if (missing_roots.len > 0) {
+            self.logger.warn(
+                "chain-worker processPendingBlocks dropped {d} missing root fetch(es) — no backchannel wired (#863 followup)",
+                .{missing_roots.len},
+            );
+        }
     }
 
     fn chainWorkerProcessFinalizationFollowupThunk(
@@ -1072,14 +1096,15 @@ pub const BeamChain = struct {
     }
 
     /// Route a `processPendingBlocks` tick through the worker queue.
+    /// Currently has no production caller: the libxev tick runs
+    /// `processPendingBlocks` inline so the returned missing-roots
+    /// can be fed to `BeamNode.fetchBlockByRoots`. Kept so the
+    /// vtable + queue plumbing is exercised end-to-end and the API
+    /// shape is stable for the follow-up commit that adds the
+    /// missing-roots backchannel.
     pub fn submitProcessPendingBlocks(self: *Self, current_slot: types.Slot) SubmitError!void {
         const w = self.chain_worker orelse return error.ChainWorkerDisabled;
         try w.sendBlock(.{ .process_pending_blocks = .{ .current_slot = current_slot } });
-    }
-
-    /// Returns whether the background chain-worker thread is active.
-    pub fn chainWorkerEnabled(self: *const Self) bool {
-        return self.chain_worker != null;
     }
 
     /// Route a `processFinalizationFollowup` move-off through the worker queue.

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -271,16 +271,37 @@ pub const BeamChain = struct {
     // import. With chain-worker enabled, that's the worker thread; the
     // BeamNode handler MUST therefore be safe to call from there. All
     // touched state is mutex-protected (network's `LockedMap`s,
-    // forkchoice's RwLock, BeamNode.batch_pending_parent_roots_lock,
-    // the GeneralPurposeAllocator) so cross-thread is correct today;
-    // future work that adds non-mutex BeamNode state must audit the
-    // callback path.
+    // forkchoice's RwLock, `BeamNode.batch_pending_parent_roots_lock`,
+    // the chain's `Allocator`) so the cross-thread surface is safe
+    // today; future work that adds non-mutex BeamNode state must
+    // audit the callback path.
     //
     // Ownership: the callback takes ownership of `missing_roots` (the
     // chain freed it before this PR — the recipient now owns it).
     // Implementations should defer-free against `chain.allocator`.
     imported_block_ctx: ?*anyopaque = null,
     imported_block_fn: ?ImportedBlockFn = null,
+
+    // -- rejected-block backchannel (#890 zclawz review) -----------------
+    //
+    // Sister callback to `imported_block_fn`: fires when
+    // `chainWorkerOnBlockThunk`'s `onBlock` returns
+    // `MissingPreState` or `PreFinalizedSlot`. These are the two
+    // errors that are NOT permanent failures of the block itself —
+    // a TOCTOU race against finalization (the libxev caller saw
+    // `forkChoice.hasBlock(parent)` true, then finalization advanced
+    // and pruned the parent before the worker dispatched), or a
+    // pre-finalized arrival mid-flight. Without this hand-back the
+    // worker would silently drop the block and sync would stall
+    // until a re-broadcast.
+    //
+    // Threading + ownership: same contract as `imported_block_fn`.
+    // The callback receives a borrowed `*const SignedBlock` (the
+    // `Message.deinit` after dispatch frees it); recipients clone if
+    // they need to outlive the callback (e.g.
+    // `cacheBlockAndFetchParent`).
+    rejected_block_ctx: ?*anyopaque = null,
+    rejected_block_fn: ?RejectedBlockFn = null,
 
     // Queue for blocks that arrived before forkchoice had ticked to their slot.
     // When a peer gossips a block for the current slot before our local interval
@@ -385,6 +406,39 @@ pub const BeamChain = struct {
         ctx: *anyopaque,
         block_root: types.Root,
         missing_roots: []types.Root,
+    ) void;
+
+    /// Reason a worker `onBlock` rejected a block back to BeamNode.
+    /// Mirrors the two errors `chainWorkerOnBlockThunk` hand-backs:
+    /// the libxev producer's "parent ∈ forkchoice" pre-check raced
+    /// with finalization (`missing_pre_state`), or the block was
+    /// pre-finalized (`pre_finalized`). The recipient picks the
+    /// matching libxev-side fallback (`cacheBlockAndFetchParent`
+    /// vs. `pruneCachedBlocks`) — same shape as the inline RPC
+    /// paths' error catch arms.
+    pub const RejectedBlockReason = enum {
+        missing_pre_state,
+        pre_finalized,
+    };
+
+    /// Callback fired when `chainWorkerOnBlockThunk`'s `onBlock`
+    /// returns `MissingPreState` or `PreFinalizedSlot`. Lets the
+    /// libxev-side network code re-cache the block + fetch the
+    /// parent (or prune cached descendants on `pre_finalized`)
+    /// instead of silently dropping it on the worker thread —
+    /// closes the TOCTOU race the `trySubmitImportToWorker` doc
+    /// previously called out as "would otherwise strand sync".
+    ///
+    /// The callback receives the block by const pointer; the
+    /// chain-worker continues to own the heap allocation (the
+    /// dispatch's `Message.deinit` frees it after this call
+    /// returns), so the callback MUST clone if it needs to outlive
+    /// the call. Same threading audit as `ImportedBlockFn`.
+    pub const RejectedBlockFn = *const fn (
+        ctx: *anyopaque,
+        signed_block: *const types.SignedBlock,
+        block_root: types.Root,
+        reason: RejectedBlockReason,
     ) void;
 
     const Self = @This();
@@ -718,6 +772,16 @@ pub const BeamChain = struct {
                 };
             }
             for (aggs.items) |*agg| {
+                // Debug tripwire (zclawz review on PR #890): the
+                // `*SignedAggregatedAttestation` we hand to the
+                // task is a borrow into `aggs.items` — valid only
+                // because this loop never mutates the buffer
+                // (no `append` / `swapRemove`) before
+                // `waitAndWork` returns. A future refactor that
+                // moves entries mid-loop would silently UAF; the
+                // assert fires loud in debug builds.
+                std.debug.assert(@intFromPtr(agg) >= @intFromPtr(aggs.items.ptr));
+                std.debug.assert(@intFromPtr(agg) < @intFromPtr(aggs.items.ptr) + aggs.items.len * @sizeOf(types.SignedAggregatedAttestation));
                 pool.spawnWg(&wg, replayOneAggregationTask, .{ self, agg }) catch {
                     self.replayOneAggregation(agg);
                 };
@@ -737,6 +801,17 @@ pub const BeamChain = struct {
     /// pointer — `replayOneAttestation` is a method and would need a
     /// closure. The pool calls this with the runtime tuple
     /// `.{ chain, gossip, is_aggregator_role }` we pass at spawn time.
+    ///
+    /// `is_aggregator_role` is captured ONCE per replay batch in
+    /// `replayPendingAttestations` (a single
+    /// `is_aggregator_enabled.load(.acquire)`) and propagated into
+    /// every per-entry task verbatim. A concurrent admin toggle
+    /// (`POST /lean/v0/admin/aggregator`) flips the role for the
+    /// NEXT batch only — entries already in flight finish with the
+    /// snapshot value (zclawz review on PR #890). This is
+    /// intentional: the alternative (per-task fresh load) would
+    /// race against forkchoice writes that depend on a coherent
+    /// role for the duration of the replay.
     fn replayOneAttestationTask(
         chain: *Self,
         gossip: networks.AttestationGossip,
@@ -920,6 +995,50 @@ pub const BeamChain = struct {
             .pruneForkchoice = prune_forkchoice,
             .blockRoot = block_root,
         }) catch |err| {
+            // Two of the catch arms are TOCTOU-shaped: the libxev
+            // producer (`trySubmitImportToWorker`) checked
+            // `forkChoice.hasBlock(parent_root)` under the shared
+            // lock, but finalization can advance between that check
+            // and the worker's dispatch and prune the parent —
+            // surfaced here as `MissingPreState` (parent state
+            // already gone) or `PreFinalizedSlot` (block at /
+            // before the new finalized slot). Without the
+            // rejected-block backchannel both arms would silently
+            // drop the block and sync would stall until a re-
+            // broadcast. With it wired (BeamNode in production),
+            // the libxev side runs the same `cacheBlockAndFetchParent`
+            // / `pruneCachedBlocks` path it would have taken on
+            // its own. The callback receives a borrowed pointer —
+            // the message's `deinit` after dispatch frees the
+            // block (recipient clones if it needs to outlive).
+            const reason: ?RejectedBlockReason = switch (err) {
+                BlockProcessingError.MissingPreState => .missing_pre_state,
+                fcFactory.ForkChoiceError.PreFinalizedSlot => .pre_finalized,
+                else => null,
+            };
+            if (reason) |r| {
+                if (self.rejected_block_fn) |cb| {
+                    if (self.rejected_block_ctx) |cb_ctx| {
+                        const r_root: types.Root = block_root orelse blk: {
+                            var rr: types.Root = undefined;
+                            zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &rr, self.allocator) catch |hash_err| {
+                                self.logger.err(
+                                    "chain-worker: rejected-block callback skipped, root recompute failed slot={d} reason={s}: {any}",
+                                    .{ signed_block.block.slot, @tagName(r), hash_err },
+                                );
+                                return;
+                            };
+                            break :blk rr;
+                        };
+                        cb(cb_ctx, &signed_block, r_root, r);
+                        return;
+                    }
+                }
+                // No callback wired (worker test rigs etc.) — fall
+                // through to the legacy "log and drop" path. That
+                // matches the pre-#890 chain-worker behaviour;
+                // production wires the callback in `BeamNode.init`.
+            }
             self.logger.err("chain-worker: onBlock failed slot={d}: {any}", .{
                 signed_block.block.slot,
                 err,
@@ -1115,6 +1234,14 @@ pub const BeamChain = struct {
         const missing_roots = self.processPendingBlocks();
         defer self.allocator.free(missing_roots);
         if (missing_roots.len > 0) {
+            // Tripwire (zclawz review on PR #890): the thunk has no
+            // production producer today, so a non-zero counter
+            // value means somebody wired one without plumbing
+            // missing-roots back to BeamNode and is stranding
+            // sync. The warn is paired with the metric so the
+            // regression is visible in dashboards too, not just
+            // log scraping.
+            zeam_metrics.metrics.lean_chain_worker_process_pending_blocks_dropped_missing_roots_total.incr();
             self.logger.warn(
                 "chain-worker processPendingBlocks dropped {d} missing root fetch(es) — no backchannel wired (#863 followup)",
                 .{missing_roots.len},
@@ -1220,17 +1347,18 @@ pub const BeamChain = struct {
         try w.sendAggregatedAttestation(.{ .on_gossip_aggregated_attestation = agg });
     }
 
-    /// Route a `processPendingBlocks` tick through the worker queue.
-    /// Currently has no production caller: the libxev tick runs
-    /// `processPendingBlocks` inline so the returned missing-roots
-    /// can be fed to `BeamNode.fetchBlockByRoots`. Kept so the
-    /// vtable + queue plumbing is exercised end-to-end and the API
-    /// shape is stable for the follow-up commit that adds the
-    /// missing-roots backchannel.
-    pub fn submitProcessPendingBlocks(self: *Self, current_slot: types.Slot) SubmitError!void {
-        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
-        try w.sendBlock(.{ .process_pending_blocks = .{ .current_slot = current_slot } });
-    }
+    // `submitProcessPendingBlocks` removed (zclawz review on PR #890).
+    // No production caller existed: the libxev tick runs
+    // `processPendingBlocks` inline so it can feed the returned
+    // missing-roots into `BeamNode.fetchBlockByRoots`. The
+    // chain-worker `process_pending_blocks` Message variant + thunk
+    // are kept (heap-free POD token used by queue smoke tests) but
+    // are no longer reachable from production. If a future producer
+    // wants this path it MUST first thread the missing-roots
+    // backchannel through `imported_block_fn` (or a sibling
+    // callback) to avoid stranding sync — the existing thunk warns
+    // + bumps `lean_chain_worker_process_pending_blocks_dropped_missing_roots_total`
+    // so an accidental re-introduction is loud in metrics.
 
     /// Route a `processFinalizationFollowup` move-off through the worker queue.
     /// (Not yet called from production; reserved for the finalization follow-up
@@ -1282,10 +1410,27 @@ pub const BeamChain = struct {
     /// import; takes ownership of the chain's `missing_roots` slice.
     /// See the `imported_block_ctx`/`imported_block_fn` field doc and
     /// the `ImportedBlockFn` type alias for the threading and
-    /// ownership contract. Pass `null`/no-op-fn pair to clear.
+    /// ownership contract.
+    ///
+    /// Both args are required (the chain expects either both wired
+    /// or neither). Re-registration is supported and overwrites the
+    /// previous pair atomically with respect to chain.deinit; there
+    /// is intentionally no "clear" entry point — the chain wipes
+    /// both fields itself in `deinit`.
     pub fn setImportedBlockCallback(self: *Self, ctx: *anyopaque, func: ImportedBlockFn) void {
         self.imported_block_ctx = ctx;
         self.imported_block_fn = func;
+    }
+
+    /// Register the rejected-block backchannel (#890 follow-up).
+    /// Fires from `chainWorkerOnBlockThunk` only when `onBlock`
+    /// returns `MissingPreState` or `PreFinalizedSlot` — see
+    /// `RejectedBlockFn` and the `rejected_block_ctx` /
+    /// `rejected_block_fn` field doc. Same registration contract as
+    /// `setImportedBlockCallback`.
+    pub fn setRejectedBlockCallback(self: *Self, ctx: *anyopaque, func: RejectedBlockFn) void {
+        self.rejected_block_ctx = ctx;
+        self.rejected_block_fn = func;
     }
 
     pub fn deinit(self: *Self) void {
@@ -7429,6 +7574,301 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
         error.ChainWorkerDisabled,
         beam_chain_off.submitBlock(off_cloned, false, null),
     );
+}
+
+// Test fixture for the imported/rejected callback tests below: a tiny
+// observer that records every callback invocation under a mutex so the
+// test thread can assert on the captured side-effects after waiting
+// for the worker to drain. Mirrors the production
+// `BeamNode.handleChainImportedBlock` / `handleChainRejectedBlock` shape
+// but stays in-test so we do NOT depend on networks.zig — the chain-
+// level callbacks are what we want to exercise here.
+const TestCallbackObserver = struct {
+    mu: zeam_utils.SyncMutex = .{},
+    imported: std.ArrayList(ImportedRecord) = .empty,
+    rejected: std.ArrayList(RejectedRecord) = .empty,
+    allocator: std.mem.Allocator,
+
+    const ImportedRecord = struct {
+        block_root: types.Root,
+        missing_roots_len: usize,
+    };
+    const RejectedRecord = struct {
+        block_root: types.Root,
+        slot: types.Slot,
+        reason: BeamChain.RejectedBlockReason,
+    };
+
+    fn init(allocator: std.mem.Allocator) @This() {
+        return .{ .allocator = allocator };
+    }
+
+    fn deinit(self: *@This()) void {
+        self.imported.deinit(self.allocator);
+        self.rejected.deinit(self.allocator);
+    }
+
+    fn onImported(
+        ctx: *anyopaque,
+        block_root: types.Root,
+        missing_roots: []types.Root,
+    ) void {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        // Take ownership of `missing_roots` per the callback contract.
+        self.allocator.free(missing_roots);
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.imported.append(self.allocator, .{
+            .block_root = block_root,
+            .missing_roots_len = missing_roots.len,
+        }) catch {};
+    }
+
+    fn onRejected(
+        ctx: *anyopaque,
+        signed_block: *const types.SignedBlock,
+        block_root: types.Root,
+        reason: BeamChain.RejectedBlockReason,
+    ) void {
+        const self: *@This() = @ptrCast(@alignCast(ctx));
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.rejected.append(self.allocator, .{
+            .block_root = block_root,
+            .slot = signed_block.block.slot,
+            .reason = reason,
+        }) catch {};
+    }
+
+    fn importedCount(self: *@This()) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.imported.items.len;
+    }
+
+    fn rejectedCount(self: *@This()) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.rejected.items.len;
+    }
+};
+
+test "chain-worker (#890): imported_block_fn fires once per successful submitBlock with the correct root" {
+    // PR #890 zclawz review: the `imported_block_fn` backchannel is
+    // the formal channel for the missing-attestation-roots fan-out
+    // and the cached-descendant retry that previously had no
+    // worker-side path. This is the happy-path test: submit a real
+    // block via the worker queue and assert the callback fires
+    // exactly once with the producer's pre-computed root.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 3, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+
+    var db = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir,
+    );
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    var observer = TestCallbackObserver.init(std.testing.allocator);
+    defer observer.deinit();
+    beam_chain.setImportedBlockCallback(&observer, TestCallbackObserver.onImported);
+    beam_chain.setRejectedBlockCallback(&observer, TestCallbackObserver.onRejected);
+
+    try beam_chain.startChainWorker();
+    try std.testing.expect(beam_chain.chain_worker != null);
+
+    const signed_block = mock_chain.blocks[1];
+    const block_root = mock_chain.blockRoots[1];
+    try beam_chain.forkChoice.onInterval(
+        signed_block.block.slot * constants.INTERVALS_PER_SLOT,
+        false,
+    );
+
+    var cloned: types.SignedBlock = undefined;
+    try types.sszClone(std.testing.allocator, types.SignedBlock, signed_block, &cloned);
+    var cloned_consumed = false;
+    defer if (!cloned_consumed) cloned.deinit();
+    try beam_chain.submitBlock(cloned, false, block_root);
+    cloned_consumed = true;
+
+    // Wait up to 5s for the callback to fire. The chain-worker thunk
+    // invokes `imported_block_fn` synchronously after a successful
+    // import, so polling on `observer.importedCount()` is the
+    // strongest signal the dispatch reached the end.
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns: i128 = start_ns + 5 * std.time.ns_per_s;
+    while (zeam_utils.monotonicTimestampNs() < deadline_ns) {
+        if (observer.importedCount() >= 1) break;
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expectEqual(@as(usize, 1), observer.importedCount());
+    try std.testing.expectEqual(@as(usize, 0), observer.rejectedCount());
+
+    // Spot-check the captured root matches what we submitted.
+    observer.mu.lock();
+    defer observer.mu.unlock();
+    try std.testing.expectEqualSlices(u8, &block_root, &observer.imported.items[0].block_root);
+}
+
+test "chain-worker (#890): rejected_block_fn fires on MissingPreState (TOCTOU race)" {
+    // PR #890 zclawz review #2: the libxev producer
+    // (`trySubmitImportToWorker`) checks `forkChoice.hasBlock(parent)`
+    // before submitting; finalization can race and prune the parent
+    // between the check and the worker's dispatch. Without the
+    // rejected-block backchannel the worker would log + drop the
+    // block and sync would stall.
+    //
+    // Direct exercise of the race is awkward in a unit test — we'd
+    // need to time finalization advancement against the worker's
+    // dispatch. Instead we shortcut by submitting a block whose
+    // parent is NOT yet in forkchoice: that triggers the same
+    // `MissingPreState` arm in `chainWorkerOnBlockThunk` and routes
+    // through the same callback. The TOCTOU race in production is
+    // observably equivalent — both end up in the same catch arm.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 4, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+
+    var db = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir,
+    );
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    var observer = TestCallbackObserver.init(std.testing.allocator);
+    defer observer.deinit();
+    beam_chain.setImportedBlockCallback(&observer, TestCallbackObserver.onImported);
+    beam_chain.setRejectedBlockCallback(&observer, TestCallbackObserver.onRejected);
+
+    try beam_chain.startChainWorker();
+
+    // Submit blocks[2] WITHOUT first importing blocks[1] — its parent
+    // state is missing. forkchoice clock is advanced past the slot so
+    // we don't hit FutureSlot first.
+    const orphan_block = mock_chain.blocks[2];
+    const orphan_root = mock_chain.blockRoots[2];
+    try beam_chain.forkChoice.onInterval(
+        orphan_block.block.slot * constants.INTERVALS_PER_SLOT,
+        false,
+    );
+
+    var cloned: types.SignedBlock = undefined;
+    try types.sszClone(std.testing.allocator, types.SignedBlock, orphan_block, &cloned);
+    var cloned_consumed = false;
+    defer if (!cloned_consumed) cloned.deinit();
+    try beam_chain.submitBlock(cloned, false, orphan_root);
+    cloned_consumed = true;
+
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns: i128 = start_ns + 5 * std.time.ns_per_s;
+    while (zeam_utils.monotonicTimestampNs() < deadline_ns) {
+        if (observer.rejectedCount() >= 1) break;
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expectEqual(@as(usize, 0), observer.importedCount());
+    try std.testing.expectEqual(@as(usize, 1), observer.rejectedCount());
+
+    observer.mu.lock();
+    defer observer.mu.unlock();
+    const rec = observer.rejected.items[0];
+    try std.testing.expectEqualSlices(u8, &orphan_root, &rec.block_root);
+    try std.testing.expectEqual(orphan_block.block.slot, rec.slot);
+    try std.testing.expectEqual(BeamChain.RejectedBlockReason.missing_pre_state, rec.reason);
 }
 
 test "chain.statesGet under chain_worker enabled returns Backing.none + acquired_rc (slice c-2b commit 4)" {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -267,24 +267,59 @@ pub const BeamChain = struct {
     // the warn in `chainWorkerProcessPendingBlocksThunk`). The callback
     // is the formal channel for that hand-off.
     //
-    // Threading: the callback runs on whatever thread invoked the
-    // import. With chain-worker enabled, that's the worker thread; the
-    // BeamNode handler MUST therefore be safe to call from there. All
-    // touched state is mutex-protected (network's `LockedMap`s,
-    // forkchoice's RwLock, `BeamNode.batch_pending_parent_roots_lock`,
-    // the chain's `Allocator`) so the cross-thread surface is safe
-    // today; future work that adds non-mutex BeamNode state must
-    // audit the callback path.
+    // **Threading audit (zclawz round 3 review on PR #890).** With
+    // chain-worker enabled the callback runs ON THE WORKER THREAD,
+    // not libxev. Every site the production callback
+    // (`BeamNode.handleChainImportedBlock`) reaches must be safe to
+    // invoke from a non-libxev thread:
+    //
+    //   * `network.removeFetchedBlock`,
+    //     `network.hasFetchedBlock`,
+    //     `network.getChildrenOfBlock`,
+    //     `network.pruneCachedBlocks`        → `LockedMap` (mutex)
+    //   * `network.hasPendingBlockRoot`,
+    //     `network.removePendingBlockRoot`   → `LockedMap` (mutex)
+    //   * `network.connected_peers`          → `RwLock` (`selectPeerCopy`)
+    //   * `network.pending_rpc_requests`,
+    //     `network.blocks_by_root_inflight`  → `LockedMap` + atomic
+    //   * `chain.forkChoice` (`hasBlock`,
+    //     `hasBlocksBatch`)                  → forkchoice `RwLock`
+    //   * `BeamNode.batch_pending_parent_roots`
+    //                                        → its own mutex
+    //   * `network.backend.reqresp.sendRequest`
+    //                                        → enqueues onto a
+    //     **Tokio `mpsc::Sender::try_send`** (`SwarmCommandChannel`,
+    //     see `rust/libp2p-glue/src/lib.rs::send_swarm_command`).
+    //     The Rust libp2p swarm runs on its OWN Tokio runtime — the
+    //     Zig caller never touches a libxev primitive on this path.
+    //     `try_send` is `Send + Sync`-safe, so any thread can fire
+    //     it; full / closed channels return error which is bucketed
+    //     into `lean_block_fetch_dedup_total{outcome=...}` like any
+    //     other dispatch failure.
+    //
+    // Net effect: there is no libxev I/O issued from the worker
+    // thread, only mutex-/rwlock-protected state mutations and an
+    // mpsc enqueue across the FFI boundary. Future work that adds
+    // unprotected BeamNode state OR that dispatches libxev I/O
+    // primitives directly from BeamNode helpers MUST re-audit
+    // every callback site.
     //
     // Ownership: the callback takes ownership of `missing_roots` (the
     // chain freed it before this PR — the recipient now owns it).
     // Implementations should defer-free against `chain.allocator`.
-    imported_block_ctx: ?*anyopaque = null,
-    imported_block_fn: ?ImportedBlockFn = null,
+    //
+    // The fn+ctx pair lives in a single optional so the worker
+    // thunk's read is a single `if (.imported_block) |cb| ...`
+    // branch (zclawz round 3 review #M4). Pre-bundle this avoided a
+    // class of bugs where the setter wired one field but not the
+    // other — direct field mutation from tests would skip the
+    // public setter and silently drop the callback (the chain
+    // would free `missing_roots` instead of handing it back).
+    imported_block: ?BlockCallback(ImportedBlockFn) = null,
 
     // -- rejected-block backchannel (#890 zclawz review) -----------------
     //
-    // Sister callback to `imported_block_fn`: fires when
+    // Sister callback to `imported_block`: fires when
     // `chainWorkerOnBlockThunk`'s `onBlock` returns
     // `MissingPreState` or `PreFinalizedSlot`. These are the two
     // errors that are NOT permanent failures of the block itself —
@@ -295,13 +330,12 @@ pub const BeamChain = struct {
     // worker would silently drop the block and sync would stall
     // until a re-broadcast.
     //
-    // Threading + ownership: same contract as `imported_block_fn`.
+    // Threading + ownership: same contract as `imported_block`.
     // The callback receives a borrowed `*const SignedBlock` (the
-    // `Message.deinit` after dispatch frees it); recipients clone if
-    // they need to outlive the callback (e.g.
+    // `Message.deinit` after dispatch frees it); recipients clone
+    // if they need to outlive the callback (e.g.
     // `cacheBlockAndFetchParent`).
-    rejected_block_ctx: ?*anyopaque = null,
-    rejected_block_fn: ?RejectedBlockFn = null,
+    rejected_block: ?BlockCallback(RejectedBlockFn) = null,
 
     // Queue for blocks that arrived before forkchoice had ticked to their slot.
     // When a peer gossips a block for the current slot before our local interval
@@ -383,6 +417,20 @@ pub const BeamChain = struct {
 
     pub const PruneCachedBlocksFn = *const fn (ptr: *anyopaque, finalized: types.Checkpoint) usize;
 
+    /// Bundles a `ctx` + `fn` pair into one optional struct so the
+    /// worker thunk's "is the callback wired?" check is a single
+    /// branch (zclawz round 3 review on PR #890). The previous
+    /// shape (two independent `?` fields) had a footgun: a test or
+    /// future refactor that assigned one without the other would
+    /// silently drop callbacks because the thunk read both
+    /// independently.
+    pub fn BlockCallback(comptime FnT: type) type {
+        return struct {
+            ctx: *anyopaque,
+            func: FnT,
+        };
+    }
+
     /// Callback fired after every successful chain-worker block import
     /// (#890). `block_root` is the producer's-or-recomputed hash-tree
     /// root of the block that was just imported; `missing_roots` is
@@ -400,8 +448,8 @@ pub const BeamChain = struct {
     ///      accumulated during the import (RPC paths only).
     ///
     /// MUST be safe to call from the chain-worker thread — see the
-    /// `imported_block_ctx` / `imported_block_fn` field doc comment
-    /// above for the threading audit.
+    /// `imported_block` field doc comment above for the threading
+    /// audit.
     pub const ImportedBlockFn = *const fn (
         ctx: *anyopaque,
         block_root: types.Root,
@@ -772,14 +820,37 @@ pub const BeamChain = struct {
                 };
             }
             for (aggs.items) |*agg| {
-                // Debug tripwire (zclawz review on PR #890): the
-                // `*SignedAggregatedAttestation` we hand to the
-                // task is a borrow into `aggs.items` — valid only
-                // because this loop never mutates the buffer
-                // (no `append` / `swapRemove`) before
-                // `waitAndWork` returns. A future refactor that
-                // moves entries mid-loop would silently UAF; the
-                // assert fires loud in debug builds.
+                // Pointer-stability invariant for the spawned task
+                // (zclawz reviews on PR #890):
+                //
+                // The `*SignedAggregatedAttestation` we hand to
+                // `replayOneAggregationTask` is a borrow into
+                // `aggs.items`. It must remain valid for the full
+                // task lifetime, which extends past this loop body
+                // until `pool.waitAndWork(&wg)` returns. Two things
+                // keep that invariant true:
+                //
+                //   1. THIS LOOP NEVER MUTATES `aggs`. There are no
+                //      `append` / `swapRemove` / `resize` calls
+                //      between `pool.spawnWg` and `waitAndWork`. A
+                //      future refactor that moves entries mid-loop
+                //      would invalidate every outstanding `agg`
+                //      pointer and silently UAF in the worker
+                //      threads.
+                //   2. `aggs.deinit(allocator)` runs via the outer
+                //      `defer` AFTER `waitAndWork` joins all tasks
+                //      — guaranteeing the buffer outlives every
+                //      borrow.
+                //
+                // The asserts below are a SPAWN-TIME range check on
+                // the calling thread only; they do NOT guard the
+                // task's runtime invariant (by the time the task
+                // body runs, the assert has already fired and the
+                // pointer-stability claim is what protects the
+                // borrow). Their value is regression detection: if
+                // a future loop hoists a mutation between iterations,
+                // the spawn-side range will be obviously wrong on
+                // the next entry and trip in debug.
                 std.debug.assert(@intFromPtr(agg) >= @intFromPtr(aggs.items.ptr));
                 std.debug.assert(@intFromPtr(agg) < @intFromPtr(aggs.items.ptr) + aggs.items.len * @sizeOf(types.SignedAggregatedAttestation));
                 pool.spawnWg(&wg, replayOneAggregationTask, .{ self, agg }) catch {
@@ -1017,22 +1088,20 @@ pub const BeamChain = struct {
                 else => null,
             };
             if (reason) |r| {
-                if (self.rejected_block_fn) |cb| {
-                    if (self.rejected_block_ctx) |cb_ctx| {
-                        const r_root: types.Root = block_root orelse blk: {
-                            var rr: types.Root = undefined;
-                            zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &rr, self.allocator) catch |hash_err| {
-                                self.logger.err(
-                                    "chain-worker: rejected-block callback skipped, root recompute failed slot={d} reason={s}: {any}",
-                                    .{ signed_block.block.slot, @tagName(r), hash_err },
-                                );
-                                return;
-                            };
-                            break :blk rr;
+                if (self.rejected_block) |cb| {
+                    const r_root: types.Root = block_root orelse blk: {
+                        var rr: types.Root = undefined;
+                        zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &rr, self.allocator) catch |hash_err| {
+                            self.logger.err(
+                                "chain-worker: rejected-block callback skipped, root recompute failed slot={d} reason={s}: {any}",
+                                .{ signed_block.block.slot, @tagName(r), hash_err },
+                            );
+                            return;
                         };
-                        cb(cb_ctx, &signed_block, r_root, r);
-                        return;
-                    }
+                        break :blk rr;
+                    };
+                    cb.func(cb.ctx, &signed_block, r_root, r);
+                    return;
                 }
                 // No callback wired (worker test rigs etc.) — fall
                 // through to the legacy "log and drop" path. That
@@ -1082,11 +1151,9 @@ pub const BeamChain = struct {
             };
             break :blk r;
         };
-        if (self.imported_block_fn) |callback| {
-            if (self.imported_block_ctx) |cb_ctx| {
-                callback(cb_ctx, resolved_root, missing_roots);
-                return;
-            }
+        if (self.imported_block) |cb| {
+            cb.func(cb.ctx, resolved_root, missing_roots);
+            return;
         }
         self.allocator.free(missing_roots);
     }
@@ -1408,29 +1475,25 @@ pub const BeamChain = struct {
     /// Register the imported-block backchannel (#890). The callback
     /// fires from `chainWorkerOnBlockThunk` after every successful
     /// import; takes ownership of the chain's `missing_roots` slice.
-    /// See the `imported_block_ctx`/`imported_block_fn` field doc and
-    /// the `ImportedBlockFn` type alias for the threading and
-    /// ownership contract.
+    /// See the `imported_block` field doc and the `ImportedBlockFn`
+    /// type alias for the threading and ownership contract.
     ///
     /// Both args are required (the chain expects either both wired
     /// or neither). Re-registration is supported and overwrites the
     /// previous pair atomically with respect to chain.deinit; there
     /// is intentionally no "clear" entry point — the chain wipes
-    /// both fields itself in `deinit`.
+    /// the field itself in `deinit`.
     pub fn setImportedBlockCallback(self: *Self, ctx: *anyopaque, func: ImportedBlockFn) void {
-        self.imported_block_ctx = ctx;
-        self.imported_block_fn = func;
+        self.imported_block = .{ .ctx = ctx, .func = func };
     }
 
     /// Register the rejected-block backchannel (#890 follow-up).
     /// Fires from `chainWorkerOnBlockThunk` only when `onBlock`
     /// returns `MissingPreState` or `PreFinalizedSlot` — see
-    /// `RejectedBlockFn` and the `rejected_block_ctx` /
-    /// `rejected_block_fn` field doc. Same registration contract as
-    /// `setImportedBlockCallback`.
+    /// `RejectedBlockFn` and the `rejected_block` field doc. Same
+    /// registration contract as `setImportedBlockCallback`.
     pub fn setRejectedBlockCallback(self: *Self, ctx: *anyopaque, func: RejectedBlockFn) void {
-        self.rejected_block_ctx = ctx;
-        self.rejected_block_fn = func;
+        self.rejected_block = .{ .ctx = ctx, .func = func };
     }
 
     pub fn deinit(self: *Self) void {
@@ -7614,13 +7677,18 @@ const TestCallbackObserver = struct {
         missing_roots: []types.Root,
     ) void {
         const self: *@This() = @ptrCast(@alignCast(ctx));
-        // Take ownership of `missing_roots` per the callback contract.
+        // Capture the length BEFORE the free. Although a Zig slice
+        // header lives on the stack and `.len` after free is
+        // technically defined, reading freed-slice metadata trips
+        // every reasonable static analyzer; explicit capture
+        // documents intent (zclawz round 3 review on PR #890).
+        const missing_len = missing_roots.len;
         self.allocator.free(missing_roots);
         self.mu.lock();
         defer self.mu.unlock();
         self.imported.append(self.allocator, .{
             .block_root = block_root,
-            .missing_roots_len = missing_roots.len,
+            .missing_roots_len = missing_len,
         }) catch {};
     }
 
@@ -7869,6 +7937,118 @@ test "chain-worker (#890): rejected_block_fn fires on MissingPreState (TOCTOU ra
     try std.testing.expectEqualSlices(u8, &orphan_root, &rec.block_root);
     try std.testing.expectEqual(orphan_block.block.slot, rec.slot);
     try std.testing.expectEqual(BeamChain.RejectedBlockReason.missing_pre_state, rec.reason);
+}
+
+test "chain-worker (#890): rejected_block_fn fires on PreFinalizedSlot" {
+    // PR #890 zclawz round 3 review: the `pre_finalized` arm of
+    // `RejectedBlockReason` is a separate code path
+    // (`pruneCachedBlocks` instead of `cacheBlockAndFetchParent`)
+    // and was previously uncovered by tests. Provoke it by bumping
+    // `forkChoice.fcStore.latest_finalized.slot` past the block's
+    // slot before submitting — same end-state as the production
+    // race where finalization advances between the libxev pre-check
+    // and the worker's dispatch.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const mock_chain = try stf.genMockChain(arena, 3, null);
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+
+    const spec_name = try std.testing.allocator.dupe(u8, "beamdev");
+    const fork_digest = try std.testing.allocator.dupe(u8, "12345678");
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var beam_state: types.BeamState = undefined;
+    try types.sszClone(std.testing.allocator, types.BeamState, mock_chain.genesis_state, &beam_state);
+    defer beam_state.deinit();
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    var path_buf: [128]u8 = undefined;
+    const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+
+    var db = try database.Db.open(
+        std.testing.allocator,
+        zeam_logger_config.logger(.database_test),
+        data_dir,
+    );
+    defer db.deinit();
+
+    const connected_peers = try std.testing.allocator.create(ConnectedPeers);
+    defer std.testing.allocator.destroy(connected_peers);
+    connected_peers.* = ConnectedPeers.init(std.testing.allocator);
+    defer connected_peers.deinit();
+
+    const test_registry = try std.testing.allocator.create(NodeNameRegistry);
+    defer std.testing.allocator.destroy(test_registry);
+    test_registry.* = NodeNameRegistry.init(std.testing.allocator);
+    defer test_registry.deinit();
+
+    var beam_chain = try BeamChain.init(std.testing.allocator, ChainOpts{
+        .config = chain_config,
+        .anchorState = &beam_state,
+        .nodeId = 0,
+        .logger_config = &zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+    defer beam_chain.deinit();
+
+    var observer = TestCallbackObserver.init(std.testing.allocator);
+    defer observer.deinit();
+    beam_chain.setImportedBlockCallback(&observer, TestCallbackObserver.onImported);
+    beam_chain.setRejectedBlockCallback(&observer, TestCallbackObserver.onRejected);
+
+    try beam_chain.startChainWorker();
+
+    // Force-advance finalized past the block's slot so onBlock takes
+    // the PreFinalizedSlot arm (the parent — genesis — IS in
+    // forkchoice + states from anchor init, so we won't hit
+    // MissingPreState first).
+    const block = mock_chain.blocks[1];
+    const block_root = mock_chain.blockRoots[1];
+    try beam_chain.forkChoice.onInterval(
+        block.block.slot * constants.INTERVALS_PER_SLOT,
+        false,
+    );
+    {
+        beam_chain.forkChoice.mutex.lock();
+        defer beam_chain.forkChoice.mutex.unlock();
+        beam_chain.forkChoice.fcStore.latest_finalized.slot = block.block.slot + 100;
+    }
+
+    var cloned: types.SignedBlock = undefined;
+    try types.sszClone(std.testing.allocator, types.SignedBlock, block, &cloned);
+    var cloned_consumed = false;
+    defer if (!cloned_consumed) cloned.deinit();
+    try beam_chain.submitBlock(cloned, false, block_root);
+    cloned_consumed = true;
+
+    const start_ns = zeam_utils.monotonicTimestampNs();
+    const deadline_ns: i128 = start_ns + 5 * std.time.ns_per_s;
+    while (zeam_utils.monotonicTimestampNs() < deadline_ns) {
+        if (observer.rejectedCount() >= 1) break;
+        std.Thread.yield() catch {};
+    }
+    try std.testing.expectEqual(@as(usize, 0), observer.importedCount());
+    try std.testing.expectEqual(@as(usize, 1), observer.rejectedCount());
+
+    observer.mu.lock();
+    defer observer.mu.unlock();
+    const rec = observer.rejected.items[0];
+    try std.testing.expectEqualSlices(u8, &block_root, &rec.block_root);
+    try std.testing.expectEqual(BeamChain.RejectedBlockReason.pre_finalized, rec.reason);
 }
 
 test "chain.statesGet under chain_worker enabled returns Backing.none + acquired_rc (slice c-2b commit 4)" {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -17,7 +17,9 @@ const event_broadcaster = api.event_broadcaster;
 const zeam_utils = @import("@zeam/utils");
 const keymanager = @import("@zeam/key-manager");
 const xmss = @import("@zeam/xmss");
-const ThreadPool = @import("@zeam/thread-pool").ThreadPool;
+const thread_pool_pkg = @import("@zeam/thread-pool");
+const ThreadPool = thread_pool_pkg.ThreadPool;
+const WaitGroup = thread_pool_pkg.WaitGroup;
 
 pub const fcFactory = @import("./forkchoice.zig");
 const constants = @import("./constants.zig");
@@ -253,6 +255,33 @@ pub const BeamChain = struct {
     prune_cached_blocks_ctx: ?*anyopaque = null,
     prune_cached_blocks_fn: ?PruneCachedBlocksFn = null,
 
+    // -- imported-block backchannel (#863, #890) -------------------------
+    //
+    // Worker → BeamNode hand-back fired from `chainWorkerOnBlockThunk`
+    // after every successful import. Lets the network-aware code (cached-
+    // descendant retry, missing-attestation-root fetch, batched parent
+    // flush) run without re-checking inside the chain — historically the
+    // worker thunk silently dropped `missing_attestation_roots` because
+    // it had no way to call back into `BeamNode.fetchBlockByRoots` (see
+    // the pre-existing comment on `chain.onGossip`'s `.block` arm and
+    // the warn in `chainWorkerProcessPendingBlocksThunk`). The callback
+    // is the formal channel for that hand-off.
+    //
+    // Threading: the callback runs on whatever thread invoked the
+    // import. With chain-worker enabled, that's the worker thread; the
+    // BeamNode handler MUST therefore be safe to call from there. All
+    // touched state is mutex-protected (network's `LockedMap`s,
+    // forkchoice's RwLock, BeamNode.batch_pending_parent_roots_lock,
+    // the GeneralPurposeAllocator) so cross-thread is correct today;
+    // future work that adds non-mutex BeamNode state must audit the
+    // callback path.
+    //
+    // Ownership: the callback takes ownership of `missing_roots` (the
+    // chain freed it before this PR — the recipient now owns it).
+    // Implementations should defer-free against `chain.allocator`.
+    imported_block_ctx: ?*anyopaque = null,
+    imported_block_fn: ?ImportedBlockFn = null,
+
     // Queue for blocks that arrived before forkchoice had ticked to their slot.
     // When a peer gossips a block for the current slot before our local interval
     // timer fires, the forkchoice rejects it with FutureSlot.  We hold such
@@ -332,6 +361,31 @@ pub const BeamChain = struct {
     pending_aggregated_attestations: std.ArrayListUnmanaged(types.SignedAggregatedAttestation) = .empty,
 
     pub const PruneCachedBlocksFn = *const fn (ptr: *anyopaque, finalized: types.Checkpoint) usize;
+
+    /// Callback fired after every successful chain-worker block import
+    /// (#890). `block_root` is the producer's-or-recomputed hash-tree
+    /// root of the block that was just imported; `missing_roots` is
+    /// the slice of attestation head/source/target roots the chain
+    /// could not resolve while applying the block. **Ownership of
+    /// `missing_roots` transfers to the callback** — the chain no
+    /// longer frees it. Recipients typically:
+    ///
+    ///   1. Fan out a `blocks_by_root` RPC for `missing_roots` so the
+    ///      sync layer can fetch the missing referents.
+    ///   2. Run `processCachedDescendants(block_root)` to retry any
+    ///      previously orphaned children that were waiting on this
+    ///      parent.
+    ///   3. Flush any batched `pending_parent_root` requests
+    ///      accumulated during the import (RPC paths only).
+    ///
+    /// MUST be safe to call from the chain-worker thread — see the
+    /// `imported_block_ctx` / `imported_block_fn` field doc comment
+    /// above for the threading audit.
+    pub const ImportedBlockFn = *const fn (
+        ctx: *anyopaque,
+        block_root: types.Root,
+        missing_roots: []types.Root,
+    ) void;
 
     const Self = @This();
 
@@ -483,6 +537,7 @@ pub const BeamChain = struct {
                 .on_gossip_aggregated_attestation = chainWorkerOnGossipAggregatedAttestationThunk,
                 .process_pending_blocks = chainWorkerProcessPendingBlocksThunk,
                 .process_finalization_followup = chainWorkerProcessFinalizationFollowupThunk,
+                .replay_pending_attestations = chainWorkerReplayPendingAttestationsThunk,
             },
         });
         errdefer w.deinit();
@@ -599,15 +654,17 @@ pub const BeamChain = struct {
     ///   * `dropped` — permanent failure (signature mismatch, malformed
     ///     checkpoint ordering); the entry is discarded.
     ///
-    /// MUST be called from the chain-worker thread, or from the libxev
-    /// thread when the worker is disabled / when `BeamChain` handles
-    /// `onBlock` + `onBlockFollowup` directly (gossip, RPC, pending-queue,
-    /// publish paths — same thread as other chain mutations). When the
-    /// chain-worker is enabled, libxev-thread `BeamNode` paths that replay
-    /// after block import should prefer `replayPendingAttestationsLibxevBudget`
-    /// so a deep pending buffer cannot stall the slot driver (#863).
-    /// Holds the buffer mutex only across the swap-out / re-append;
-    /// validation runs lock-free over locally-owned slices.
+    /// Threading contract (#863, #890): when the chain-worker is enabled
+    /// this function MUST run on the worker thread. The `chain-worker`
+    /// `on_block` thunk drives it inline after every successful import;
+    /// libxev-side producers (`BeamNode.publishBlock`, the disabled-worker
+    /// fallback inside the RPC paths) MUST go through
+    /// `submitReplayPendingAttestations` so the unbounded drain happens
+    /// on the worker thread instead of stalling the slot driver. When
+    /// the worker is disabled, the libxev thread is the chain thread —
+    /// calling this directly is correct (and the only option). Holds
+    /// the buffer mutex only across the swap-out; validation runs
+    /// lock-free over locally-owned slices.
     pub fn replayPendingAttestations(self: *Self) void {
         // Swap the buffers out under lock so producers can keep
         // appending into fresh empty buffers while we drain.
@@ -624,55 +681,80 @@ pub const BeamChain = struct {
 
         const is_agg = self.is_aggregator_enabled.load(.acquire);
 
-        for (atts.items) |gossip| {
-            self.replayOneAttestation(gossip, is_agg);
-        }
-        for (aggs.items) |*agg| {
-            self.replayOneAggregation(agg);
+        // #890: parallelize per-entry replay across the shared thread
+        // pool when one is configured. Each replay does
+        // `validateAttestationData → verifySingleAttestation → (for
+        // aggregators) forkChoice.onSignedAttestation` for raw atts,
+        // or the equivalent aggregate-attestation path for
+        // aggregations. Validation and storage take internal locks
+        // (forkchoice rwlock, pubkey_cache lock-free CAS, the
+        // pending-attestations mutex on retryable failure), so
+        // concurrent invocations serialize on those without
+        // explicit coordination here. The big win is the XMSS verify
+        // — `verifySingleAttestation` is CPU-bound and has no shared
+        // state with siblings (#863 stall data shows aggregator-heavy
+        // replay batches dominate by-far the longest libxev drain
+        // windows).
+        //
+        // No pool ⇒ in-thread serial loop. The fallback path also
+        // covers the chain-worker test rigs that don't wire a pool
+        // and the disabled-worker case where the libxev thread
+        // already serialized everything.
+        if (self.thread_pool) |pool| {
+            // Bound the fan-out so a 1024-entry buffer doesn't
+            // allocate 1024 task wrappers up front. The pool's
+            // worker count is what limits real parallelism anyway;
+            // any more than ~thread_count outstanding tasks just
+            // queues. Pre-#890 measurements on aggregator-heavy
+            // devnet bursts showed 90%+ of replay calls have ≤ 64
+            // entries — keep the simple "spawn each" shape.
+            var wg: WaitGroup = .{};
+            for (atts.items) |gossip| {
+                pool.spawnWg(&wg, replayOneAttestationTask, .{ self, gossip, is_agg }) catch {
+                    // Allocator exhaustion on the task wrapper — fall
+                    // back to running this entry serially so we don't
+                    // strand it. Subsequent entries still try the pool.
+                    self.replayOneAttestation(gossip, is_agg);
+                };
+            }
+            for (aggs.items) |*agg| {
+                pool.spawnWg(&wg, replayOneAggregationTask, .{ self, agg }) catch {
+                    self.replayOneAggregation(agg);
+                };
+            }
+            pool.waitAndWork(&wg);
+        } else {
+            for (atts.items) |gossip| {
+                self.replayOneAttestation(gossip, is_agg);
+            }
+            for (aggs.items) |*agg| {
+                self.replayOneAggregation(agg);
+            }
         }
     }
 
-    /// Like `replayPendingAttestations`, but caps how many entries are
-    /// processed per call so libxev-thread producers (RPC, cache, publish)
-    /// cannot monopolize the slot driver for seconds when the pending buffers
-    /// are deep (#863, aggregator-heavy devnets).
-    ///
-    /// The chain-worker path continues to use `replayPendingAttestations`
-    /// (unbounded) because it does not share the libxev clock thread.
-    pub fn replayPendingAttestationsLibxevBudget(self: *Self) void {
-        const is_agg = self.is_aggregator_enabled.load(.acquire);
+    /// Static thunk so `ThreadPool.spawnWg` can take a function
+    /// pointer — `replayOneAttestation` is a method and would need a
+    /// closure. The pool calls this with the runtime tuple
+    /// `.{ chain, gossip, is_aggregator_role }` we pass at spawn time.
+    fn replayOneAttestationTask(
+        chain: *Self,
+        gossip: networks.AttestationGossip,
+        is_aggregator_role: bool,
+    ) void {
+        chain.replayOneAttestation(gossip, is_aggregator_role);
+    }
 
-        // The size gauges are kept in sync with the buffer length on
-        // every pop. `replayOne*` may re-`enqueuePending*` an entry on
-        // retryable failure (which itself updates the gauge), so the
-        // post-replay value can drift back up — that's expected.
-        var a_done: usize = 0;
-        while (a_done < constants.REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET) : (a_done += 1) {
-            self.pending_attestations_mutex.lock();
-            if (self.pending_attestations.items.len == 0) {
-                self.pending_attestations_mutex.unlock();
-                break;
-            }
-            const gossip = self.pending_attestations.orderedRemove(0);
-            const new_depth = self.pending_attestations.items.len;
-            self.pending_attestations_mutex.unlock();
-            zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "attestation" }, new_depth) catch {};
-            self.replayOneAttestation(gossip, is_agg);
-        }
-
-        var g_done: usize = 0;
-        while (g_done < constants.REPLAY_PENDING_AGGREGATIONS_LIBXEV_BUDGET) : (g_done += 1) {
-            self.pending_attestations_mutex.lock();
-            if (self.pending_aggregated_attestations.items.len == 0) {
-                self.pending_attestations_mutex.unlock();
-                break;
-            }
-            var agg_owned = self.pending_aggregated_attestations.orderedRemove(0);
-            const new_depth = self.pending_aggregated_attestations.items.len;
-            self.pending_attestations_mutex.unlock();
-            zeam_metrics.metrics.lean_pending_attestations_size.set(.{ .kind = "aggregation" }, new_depth) catch {};
-            self.replayOneAggregation(&agg_owned);
-        }
+    /// Same shape as `replayOneAttestationTask` for aggregations.
+    /// Takes the pointer-into-buffer alias produced by the parent
+    /// `replayPendingAttestations` loop. The buffer outlives the
+    /// pool's `waitAndWork`, so the pointer remains valid for the
+    /// task's lifetime.
+    fn replayOneAggregationTask(
+        chain: *Self,
+        agg: *types.SignedAggregatedAttestation,
+    ) void {
+        chain.replayOneAggregation(agg);
     }
 
     /// Inner replay step for a single buffered attestation. The entry
@@ -844,7 +926,6 @@ pub const BeamChain = struct {
             });
             return;
         };
-        defer self.allocator.free(missing_roots);
         // Mirror the gossip path: followup runs after a successful
         // import. We pass the (immutable) signed_block by reference
         // for symmetry with chain.onGossip; current onBlockFollowup
@@ -857,6 +938,38 @@ pub const BeamChain = struct {
         // / future slots get a fresh validation attempt against the
         // updated store.
         self.replayPendingAttestations();
+
+        // Invoke the imported-block backchannel (#890). When wired
+        // (BeamNode in production), the callback takes ownership of
+        // `missing_roots` and runs `fetchBlockByRoots` +
+        // `processCachedDescendants` from this worker thread. When
+        // the callback is not wired (queue-only worker tests), we
+        // free the slice ourselves so the buffer never leaks. The
+        // recipient's contract is documented on `ImportedBlockFn`.
+        const resolved_root: types.Root = block_root orelse blk: {
+            // The chain just imported the block, so its hash-tree
+            // root is in the slot-cache or recomputable; recompute
+            // here so the callback gets a definite root. Failure to
+            // recompute is possible only on OOM — log + drop the
+            // missing-roots slice (we still freed locally).
+            var r: types.Root = undefined;
+            zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &r, self.allocator) catch |err| {
+                self.logger.err(
+                    "chain-worker: imported-block callback skipped, root recompute failed slot={d}: {any}",
+                    .{ signed_block.block.slot, err },
+                );
+                self.allocator.free(missing_roots);
+                return;
+            };
+            break :blk r;
+        };
+        if (self.imported_block_fn) |callback| {
+            if (self.imported_block_ctx) |cb_ctx| {
+                callback(cb_ctx, resolved_root, missing_roots);
+                return;
+            }
+        }
+        self.allocator.free(missing_roots);
     }
 
     fn chainWorkerOnGossipAttestationThunk(
@@ -1028,6 +1141,18 @@ pub const BeamChain = struct {
         };
     }
 
+    /// Worker-thread thunk for the `replay_pending_attestations`
+    /// queue message (#890). Producers post one of these messages
+    /// after a libxev-side block import (publish path / disabled-
+    /// worker fallback) so the unbounded `replayPendingAttestations`
+    /// drain happens here instead of on the slot-driver thread.
+    /// `replayPendingAttestations` is itself idempotent, so duplicate
+    /// nudges from coalesced producers are harmless.
+    fn chainWorkerReplayPendingAttestationsThunk(ctx: *anyopaque) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+        self.replayPendingAttestations();
+    }
+
     // ------------------------------------------------------------------
     // submit* family (slice c-2b commit 3)
     // ------------------------------------------------------------------
@@ -1124,9 +1249,43 @@ pub const BeamChain = struct {
         } });
     }
 
+    /// Same error set as `SubmitError` but flavoured for the
+    /// attestation queue's `trySend` errors. Kept distinct so callers
+    /// don't have to import the worker module to spell the error
+    /// union.
+    pub const SubmitReplayError = chain_worker.AttestationQueue.TrySendError || error{ChainWorkerDisabled};
+
+    /// Nudge the chain-worker to drain `pending_attestations` /
+    /// `pending_aggregated_attestations` (#890). Producers are libxev
+    /// paths that imported a block synchronously (the disabled-worker
+    /// fallback inside `BeamNode.processBlockByRoot|RangeChunk`,
+    /// `processCachedDescendants`) and `BeamNode.publishBlock` (locally
+    /// produced block — no `on_block` is dispatched, so the worker
+    /// would never auto-replay). When the worker is disabled,
+    /// returns `error.ChainWorkerDisabled`; the caller then runs
+    /// `replayPendingAttestations` inline since libxev IS the chain
+    /// thread in that mode. `error.QueueFull` is non-fatal:
+    /// `replayPendingAttestations` is idempotent and the next
+    /// worker `on_block` dispatch will replay anyway.
+    pub fn submitReplayPendingAttestations(self: *Self) SubmitReplayError!void {
+        const w = self.chain_worker orelse return error.ChainWorkerDisabled;
+        try w.sendReplayPending();
+    }
+
     pub fn setPruneCachedBlocksCallback(self: *Self, ctx: *anyopaque, func: PruneCachedBlocksFn) void {
         self.prune_cached_blocks_ctx = ctx;
         self.prune_cached_blocks_fn = func;
+    }
+
+    /// Register the imported-block backchannel (#890). The callback
+    /// fires from `chainWorkerOnBlockThunk` after every successful
+    /// import; takes ownership of the chain's `missing_roots` slice.
+    /// See the `imported_block_ctx`/`imported_block_fn` field doc and
+    /// the `ImportedBlockFn` type alias for the threading and
+    /// ownership contract. Pass `null`/no-op-fn pair to clear.
+    pub fn setImportedBlockCallback(self: *Self, ctx: *anyopaque, func: ImportedBlockFn) void {
+        self.imported_block_ctx = ctx;
+        self.imported_block_fn = func;
     }
 
     pub fn deinit(self: *Self) void {

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -660,22 +660,37 @@ pub const ChainWorker = struct {
     }
 
     /// Enqueue a `replay_pending_attestations` nudge on the attestation
-    /// queue. Same wake/backpressure contract as `sendAttestation` —
-    /// `error.QueueFull` returns immediately and increments the
-    /// `attestation`-labelled drop metric. Producers (libxev fallback
-    /// paths after a synchronous `chain.onBlock`, `BeamNode.publishBlock`
-    /// after publishing a locally produced block) treat a full-queue
-    /// drop as benign: the next worker `on_block` dispatch already
-    /// runs `replayPendingAttestations`, and the buffers themselves are
-    /// FIFO-bounded so a missed replay just delays a few entries by
-    /// one block-cycle. Routed onto the attestation queue (rather than
-    /// adding a fourth queue) because the work it triggers is per-
-    /// attestation/per-aggregation; the queue-depth metric label
-    /// stays consistent with the workload it gates.
+    /// queue. Same wake/backpressure contract as `sendAttestation` but
+    /// with its OWN drop label (`replay_pending`) so it doesn't muddy
+    /// the per-attestation-message queue-depth metric (zclawz review on
+    /// PR #890): one nudge fans out into N replays inside the worker,
+    /// so charging it against `queue="attestation"` would make
+    /// dashboards read "attestation throughput fine" while the
+    /// pending-buffer behind it sits at 800+ entries. The buffer
+    /// depth itself is already exposed via
+    /// `lean_pending_attestations_size{kind=attestation|aggregation}`
+    /// — operators looking for "how full is the replay backlog?"
+    /// should read that gauge.
+    ///
+    /// Producers (libxev fallback paths after a synchronous
+    /// `chain.onBlock`, `BeamNode.publishBlock` after publishing a
+    /// locally produced block) treat a full-queue drop as benign in
+    /// the steady-state aggregator case: the next worker `on_block`
+    /// dispatch already runs `replayPendingAttestations`, and the
+    /// buffers themselves are FIFO-bounded
+    /// (`MAX_PENDING_ATTESTATIONS`) so a missed replay just delays a
+    /// few entries by one block-cycle. Tail behaviour for an isolated
+    /// node producing in a quiet network (no inbound `on_block` to
+    /// piggy-back on): buffered attestations age behind FIFO eviction
+    /// — at the spec's 1024-cap that is ~hundreds of slots of
+    /// inbound traffic before head-of-line eviction kicks in.
+    /// Operators monitor `lean_chain_queue_dropped_total{queue=replay_pending}`
+    /// rate against `lean_pending_attestations_size` to spot a stuck
+    /// node.
     pub fn sendReplayPending(self: *Self) AttestationQueue.TrySendError!void {
         self.attestation_queue.trySend(.{ .replay_pending_attestations = {} }) catch |err| {
             if (err == error.QueueFull) {
-                zeam_metrics.metrics.lean_chain_queue_dropped_total.incr(.{ .queue = "attestation" }) catch {};
+                zeam_metrics.metrics.lean_chain_queue_dropped_total.incr(.{ .queue = "replay_pending" }) catch {};
             }
             return err;
         };

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -165,6 +165,17 @@ pub const Message = union(enum) {
         latest_finalized: types.Checkpoint,
         prune_forkchoice: bool,
     },
+    /// Trigger an unbounded replay of the pending-attestation /
+    /// pending-aggregation buffers on the worker thread. POD payload
+    /// — the chain pulls the buffer contents itself. Issued by libxev
+    /// callers that imported a block via the disabled-worker fallback
+    /// path or that produced a block locally (`BeamNode.publishBlock`),
+    /// since neither dispatches an `on_block` message that would
+    /// auto-replay on the worker side. Coalesces naturally: if multiple
+    /// libxev paths queue a replay before the worker drains, the
+    /// worker still only reads one buffer state per dispatch — the
+    /// extra messages are harmless no-ops.
+    replay_pending_attestations: void,
 
     /// Free any heap-owned data on this message. The worker must call
     /// this on every message it pops, including in error paths from
@@ -181,6 +192,7 @@ pub const Message = union(enum) {
             .on_gossip_attestation,
             .process_pending_blocks,
             .process_finalization_followup,
+            .replay_pending_attestations,
             => {
                 // Plain-old-data; nothing to free. Listed explicitly
                 // so that a future variant added with heap fields
@@ -427,6 +439,16 @@ pub const Handlers = struct {
         latest_finalized: types.Checkpoint,
         prune_forkchoice: bool,
     ) void,
+    /// Drain the chain's pending-attestation / pending-aggregation
+    /// buffers via `BeamChain.replayPendingAttestations`. Producer is
+    /// the libxev thread (post-RPC-block-import paths and `publishBlock`)
+    /// — see `BeamChain.submitReplayPendingAttestations`. The worker's
+    /// own `on_block` thunk replays inline after every successful
+    /// import, so this variant is only needed when the libxev side
+    /// imports a block (e.g. via the inline fallback path) or when
+    /// the producer wants to nudge the worker after structural work
+    /// that may unblock buffered attestations (#863).
+    replay_pending_attestations: *const fn (ctx: *anyopaque) void,
 };
 
 /// Default capacities. Generous enough that a 30s gossip burst on
@@ -635,6 +657,30 @@ pub const ChainWorker = struct {
             .{ .queue = "attestation" },
             self.attestation_queue.outstandingDepth(),
         ) catch {};
+    }
+
+    /// Enqueue a `replay_pending_attestations` nudge on the attestation
+    /// queue. Same wake/backpressure contract as `sendAttestation` —
+    /// `error.QueueFull` returns immediately and increments the
+    /// `attestation`-labelled drop metric. Producers (libxev fallback
+    /// paths after a synchronous `chain.onBlock`, `BeamNode.publishBlock`
+    /// after publishing a locally produced block) treat a full-queue
+    /// drop as benign: the next worker `on_block` dispatch already
+    /// runs `replayPendingAttestations`, and the buffers themselves are
+    /// FIFO-bounded so a missed replay just delays a few entries by
+    /// one block-cycle. Routed onto the attestation queue (rather than
+    /// adding a fourth queue) because the work it triggers is per-
+    /// attestation/per-aggregation; the queue-depth metric label
+    /// stays consistent with the workload it gates.
+    pub fn sendReplayPending(self: *Self) AttestationQueue.TrySendError!void {
+        self.attestation_queue.trySend(.{ .replay_pending_attestations = {} }) catch |err| {
+            if (err == error.QueueFull) {
+                zeam_metrics.metrics.lean_chain_queue_dropped_total.incr(.{ .queue = "attestation" }) catch {};
+            }
+            return err;
+        };
+        self.recordAttestationQueueDepth();
+        self.wake();
     }
 
     /// Send an aggregated-attestation-flavored message and wake the worker.
@@ -878,6 +924,7 @@ pub const ChainWorker = struct {
                 payload.latest_finalized,
                 payload.prune_forkchoice,
             ),
+            .replay_pending_attestations => h.replay_pending_attestations(h.ctx),
         }
     }
 };

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -140,8 +140,20 @@ pub const Message = union(enum) {
     /// Aggregated-attestation gossip. Producer is libp2p gossip handler.
     /// Owns: `proof` slices inside the aggregated attestation.
     on_gossip_aggregated_attestation: types.SignedAggregatedAttestation,
-    /// `processPendingBlocks` drain trigger. Producer is libxev clock
-    /// (`onInterval`). Heap-free (slot is a value type).
+    /// **TEST-ONLY in production today; see #863 follow-up.**
+    /// `processPendingBlocks` drain trigger. Heap-free (slot is a
+    /// value type). The libxev tick currently runs
+    /// `processPendingBlocks` inline so the returned missing-roots
+    /// can flow back into `BeamNode.fetchBlockByRoots`. Wiring a
+    /// worker producer requires plumbing those missing roots
+    /// through a worker→BeamNode backchannel (see
+    /// `imported_block_fn` for the analogous on_block path) — until
+    /// that lands, this variant is exercised ONLY by the queue
+    /// smoke tests in `chain_worker.zig` and the corresponding
+    /// thunk warns + bumps
+    /// `lean_chain_worker_process_pending_blocks_dropped_missing_roots_total`
+    /// if it ever fires with non-empty missing roots, so an
+    /// accidental re-introduction is loud in metrics.
     process_pending_blocks: struct {
         current_slot: types.Slot,
     },

--- a/pkgs/node/src/clock.zig
+++ b/pkgs/node/src/clock.zig
@@ -159,9 +159,9 @@ pub const Clock = struct {
         // multi-second slot-driver stalls and ~96 finalized vs ~196 head
         // delta on the aggregator as a direct consequence.
         //
-        // `.once` blocks until at least one completion is ready, drains
-        // whatever the kernel has queued in that batch (up to 128 CQEs
-        // per the io_uring backend), and returns. The next-interval
+        // `.once` blocks until at least one completion is ready, then
+        // drains every CQE the kernel returns in that syscall batch (up
+        // to 128 per the io_uring backend) before returning. The next-interval
         // timer is itself a completion, so under no-flood conditions
         // we still wake every ~800ms and call `tickInterval` exactly
         // once per interval — the steady-state behaviour is unchanged.

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -81,6 +81,20 @@ pub const MAX_PENDING_BLOCKS: usize = 1024;
 // vectors. FIFO eviction matches the spec's "drop oldest" policy.
 pub const MAX_PENDING_ATTESTATIONS: usize = 1024;
 
+/// When the **libxev** thread replays pending gossip attestations / aggregations
+/// (`BeamNode` paths: RPC block import, cached-block resolution, `publishBlock`),
+/// drain at most this many attestations per call. The full buffer can hold
+/// `MAX_PENDING_ATTESTATIONS` entries; replaying all of them in one completion
+/// stacks with libxev's io_uring behaviour where a single `run(.once)` may
+/// process many CQEs before returning — a major contributor to slot-driver
+/// stalls on aggregators (#863). The chain-worker thread uses unbounded
+/// `replayPendingAttestations` instead.
+pub const REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET: usize = 48;
+
+/// Same as `REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET` but for aggregated
+/// attestations (each replay runs aggregate XMSS verify).
+pub const REPLAY_PENDING_AGGREGATIONS_LIBXEV_BUDGET: usize = 8;
+
 // Maximum depth for recursive block fetching
 // When fetching parent blocks, we stop after this many levels to avoid infinite loops
 pub const MAX_BLOCK_FETCH_DEPTH = 512;

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -81,20 +81,6 @@ pub const MAX_PENDING_BLOCKS: usize = 1024;
 // vectors. FIFO eviction matches the spec's "drop oldest" policy.
 pub const MAX_PENDING_ATTESTATIONS: usize = 1024;
 
-/// When the **libxev** thread replays pending gossip attestations / aggregations
-/// (`BeamNode` paths: RPC block import, cached-block resolution, `publishBlock`),
-/// drain at most this many attestations per call. The full buffer can hold
-/// `MAX_PENDING_ATTESTATIONS` entries; replaying all of them in one completion
-/// stacks with libxev's io_uring behaviour where a single `run(.once)` may
-/// process many CQEs before returning — a major contributor to slot-driver
-/// stalls on aggregators (#863). The chain-worker thread uses unbounded
-/// `replayPendingAttestations` instead.
-pub const REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET: usize = 48;
-
-/// Same as `REPLAY_PENDING_ATTESTATIONS_LIBXEV_BUDGET` but for aggregated
-/// attestations (each replay runs aggregate XMSS verify).
-pub const REPLAY_PENDING_AGGREGATIONS_LIBXEV_BUDGET: usize = 8;
-
 // Maximum depth for recursive block fetching
 // When fetching parent blocks, we stop after this many levels to avoid infinite loops
 pub const MAX_BLOCK_FETCH_DEPTH = 512;

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1575,61 +1575,105 @@ pub const ForkChoice = struct {
 
     /// Aggregate attestation signatures using recursive child proofs.
     ///
-    /// Extends aggregation with child proofs from new/known payloads
-    /// via two-pass greedy selection. Replaces new_payloads with fresh results.
+    /// **#863 / #890 followup — snapshot-then-release.** The XMSS
+    /// aggregate-proof FFI inside `computeAggregatedSignatures` runs
+    /// for ~18 s per call on devnet aggregators (see
+    /// `lean_committee_signatures_aggregation_time_seconds`). The
+    /// previous shape held `signatures_mutex` for that whole window,
+    /// so libxev's `chain.onInterval` → `tickIntervalUnlocked` →
+    /// `acceptNewAttestationsUnlocked` (which also takes
+    /// `signatures_mutex`) blocked at intervals 0/3/4 every slot an
+    /// aggregation was in flight. The slot-driver watchdog fired
+    /// every i=4 tick during aggregation as a result.
+    ///
+    /// This shape splits the body into three phases:
+    ///
+    ///   1. **Snapshot** (signatures_mutex held briefly, ms-scale):
+    ///      deep-clone `attestation_signatures`, `latest_new_aggregated_payloads`,
+    ///      `latest_known_aggregated_payloads` into owned local copies.
+    ///      Release.
+    ///   2. **Compute** (no lock held, ~18 s):
+    ///      run `computeAggregatedSignatures` and per-result SSZ clones
+    ///      against the owned snapshot. While this runs, `addSignature`
+    ///      / `storeAggregatedPayload` / `acceptNewAttestationsUnlocked`
+    ///      / `pruneStaleAttestationData` are free to mutate the live
+    ///      maps.
+    ///   3. **Commit** (signatures_mutex held briefly, ms-scale):
+    ///      MERGE per-att_data new aggregations into
+    ///      `latest_new_aggregated_payloads` (do NOT REPLACE — gossip-
+    ///      sourced aggregations from other subnets that arrived during
+    ///      phase 2 must survive). Per-validator remove from
+    ///      `attestation_signatures` for the (att_data, validator_id)
+    ///      pairs that existed at snapshot time (entries added during
+    ///      phase 2 stay so the next aggregator pass can consume them).
+    ///
+    /// `submitAggregateOnInterval` already gates concurrent
+    /// `aggregate()` calls via `aggregate_group.concurrent`
+    /// (concurrent_limit=1), so two aggregations cannot race here.
     fn aggregateUnlocked(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
         const state = state_opt orelse return try self.allocator.alloc(types.SignedAggregatedAttestation, 0);
         const agg_timer = zeam_metrics.lean_committee_signatures_aggregation_time_seconds.start();
         defer _ = agg_timer.observe();
 
-        // Capture counts for metrics update outside lock scope
-        var new_payloads_count: usize = 0;
-        var gossip_sigs_count: usize = 0;
+        // ─── Phase 1: snapshot ──────────────────────────────────────
+        // Deep-clone the three input maps under signatures_mutex so
+        // computeAggregatedSignatures (phase 2) can run on owned data
+        // without holding the lock. Cost is bounded by total entry
+        // count: SignaturesMap is POD (StoredSignature is 8B + SIGBYTES);
+        // AggregatedPayloadsMap entries each sszClone an
+        // AggregatedSignatureProof (Rust-allocated XMSS handle, refcount
+        // bump via FFI). Per-entry clone is sub-ms; total snapshot
+        // typically O(10 ms) on a healthy aggregator.
+        var snap = try AggregateSnapshot.takeUnderLock(self);
+        defer snap.deinit(self.allocator);
 
+        // ─── Phase 2: compute (no lock held) ────────────────────────
         var agg = try types.AggregatedAttestationsResult.init(self.allocator);
         var agg_att_cleanup = true;
         var agg_sig_cleanup = true;
         errdefer if (agg_att_cleanup) {
-            for (agg.attestations.slice()) |*att| {
-                att.deinit();
-            }
+            for (agg.attestations.slice()) |*att| att.deinit();
             agg.attestations.deinit();
         };
         errdefer if (agg_sig_cleanup) {
-            for (agg.attestation_signatures.slice()) |*sig| {
-                sig.deinit();
-            }
+            for (agg.attestation_signatures.slice()) |*sig| sig.deinit();
             agg.attestation_signatures.deinit();
         };
 
+        try agg.computeAggregatedSignatures(
+            &state.validators,
+            &snap.signatures,
+            &snap.new_payloads,
+            &snap.known_payloads,
+        );
+
+        // Build the per-att_data map of fresh aggregations and the
+        // result slice while no lock is held. SSZ-clone per proof
+        // twice (once for our internal map, once for the caller's
+        // slice) — both clones are independent Rust handles.
+        //
+        // `defer` (not `errdefer`) — on the success path the lock
+        // block below transfers ownership of every
+        // `StoredAggregatedPayload` into `self.latest_new_aggregated_payloads`
+        // and resets each value list to `.empty`. The deferred
+        // `deinitAggregatedPayloadsMap` then walks the (now-empty)
+        // value lists, frees their zero-capacity buffers, and frees
+        // the outer hashmap. On any error path before the transfer
+        // completes, any retained `AggregatedSignatureProof` is
+        // released the same way.
+        var new_payloads_local = AggregatedPayloadsMap.init(self.allocator);
+        defer deinitAggregatedPayloadsMap(self.allocator, &new_payloads_local);
+
         var results: std.ArrayList(types.SignedAggregatedAttestation) = .empty;
         errdefer {
-            for (results.items) |*signed| {
-                signed.deinit();
-            }
+            for (results.items) |*signed| signed.deinit();
             results.deinit(self.allocator);
         }
 
-        // Build new payloads map from aggregation results
-        var new_payloads = AggregatedPayloadsMap.init(self.allocator);
-        errdefer deinitAggregatedPayloadsMap(self.allocator, &new_payloads);
-
-        // Track which AttestationData keys were successfully aggregated
         var aggregated_att_data_keys: std.ArrayList(types.AttestationData) = .empty;
         defer aggregated_att_data_keys.deinit(self.allocator);
 
         {
-            self.signatures_mutex.lock();
-            defer self.signatures_mutex.unlock();
-
-            // Pass new and known payloads for two-pass greedy child selection
-            try agg.computeAggregatedSignatures(
-                &state.validators,
-                &self.attestation_signatures,
-                &self.latest_new_aggregated_payloads,
-                &self.latest_known_aggregated_payloads,
-            );
-
             const agg_attestations = agg.attestations.constSlice();
             const agg_signatures = agg.attestation_signatures.constSlice();
 
@@ -1638,11 +1682,8 @@ pub const ForkChoice = struct {
 
                 try aggregated_att_data_keys.append(self.allocator, agg_att.data);
 
-                // Store proof into new payloads map
-                const gop = try new_payloads.getOrPut(agg_att.data);
-                if (!gop.found_existing) {
-                    gop.value_ptr.* = .empty;
-                }
+                const gop = try new_payloads_local.getOrPut(agg_att.data);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
 
                 var cloned_proof: types.AggregatedSignatureProof = undefined;
                 try types.sszClone(self.allocator, types.AggregatedSignatureProof, proof, &cloned_proof);
@@ -1660,34 +1701,89 @@ pub const ForkChoice = struct {
                     .proof = output_proof,
                 });
             }
+        }
 
-            // Replace latest_new_aggregated_payloads
-            deinitAggregatedPayloadsMap(self.allocator, &self.latest_new_aggregated_payloads);
-            self.latest_new_aggregated_payloads = new_payloads;
+        // ─── Phase 3: commit (signatures_mutex held briefly) ────────
+        var new_payloads_count: usize = 0;
+        var gossip_sigs_count: usize = 0;
+        {
+            self.signatures_mutex.lock();
+            defer self.signatures_mutex.unlock();
 
-            // Remove only signatures whose AttestationData was successfully aggregated
-            // (leanSpec #449: per-attestation_data key removal, not a full clear)
-            for (aggregated_att_data_keys.items) |att_data| {
-                self.attestation_signatures.removeAndDeinit(att_data);
+            // MERGE (NOT replace). The previous shape did
+            //   deinitAggregatedPayloadsMap(allocator, &self.latest_new_aggregated_payloads);
+            //   self.latest_new_aggregated_payloads = new_payloads_local;
+            // which was safe because the lock was held across compute
+            // so nothing could append in between. With phase 2
+            // unlocked, gossip-sourced aggregations (other subnets'
+            // `storeAggregatedPayload(is_from_block=false)`) and
+            // accept's clear/migrate can mutate `latest_new_*` while
+            // we work. Replace would clobber those gossip
+            // aggregations. Merge appends ours instead; greedy proof
+            // selection in `getProposalAttestations` already
+            // de-duplicates overlapping proofs across the resulting
+            // list so the only cost of merge is a slightly larger
+            // payload list per att_data (bounded by
+            // `acceptNewAttestationsUnlocked`'s clear-on-i=0/i=4
+            // tick).
+            var local_iter = new_payloads_local.iterator();
+            while (local_iter.next()) |entry| {
+                const att_data = entry.key_ptr.*;
+                const list = entry.value_ptr;
+
+                const gop = try self.latest_new_aggregated_payloads.getOrPut(att_data);
+                if (!gop.found_existing) gop.value_ptr.* = .empty;
+                try gop.value_ptr.appendSlice(self.allocator, list.items);
+
+                // Ownership of every StoredAggregatedPayload moved
+                // into self.latest_new_aggregated_payloads. Free the
+                // local list buffer (no proofs to deinit — they all
+                // moved) and reset to `.empty` so the deferred
+                // `deinitAggregatedPayloadsMap` is a no-op walk over
+                // empty lists.
+                list.deinit(self.allocator);
+                list.* = .empty;
             }
 
-            // Capture counts before lock is released
+            // Per-validator remove from live `attestation_signatures`
+            // for every (att_data, vid) pair that EXISTED IN THE
+            // SNAPSHOT for an aggregated key. Snapshot vids are the
+            // upper bound of what compute could have consumed (some
+            // were skipped because already covered by children, but
+            // those are redundant in the live map too — safe to drop).
+            // Vids added by `addSignature` during phase 2 are NOT in
+            // the snapshot, so they survive and feed the next
+            // aggregate cycle.
+            for (aggregated_att_data_keys.items) |att_data| {
+                const snap_inner_kv = snap.signatures.fetchRemove(att_data) orelse continue;
+                var snap_inner = snap_inner_kv.value;
+                defer snap_inner.deinit();
+                if (self.attestation_signatures.getPtr(att_data)) |live_inner| {
+                    var snap_vid_it = snap_inner.iterator();
+                    while (snap_vid_it.next()) |vid_entry| {
+                        _ = live_inner.remove(vid_entry.key_ptr.*);
+                    }
+                    if (live_inner.count() == 0) {
+                        self.attestation_signatures.removeAndDeinit(att_data);
+                    }
+                }
+            }
+
             new_payloads_count = self.latest_new_aggregated_payloads.count();
             gossip_sigs_count = self.attestation_signatures.count();
         }
 
+        // Phase 2 cleanup: free the AggregatedAttestationsResult
+        // local now that ownership of every cloned proof has either
+        // moved into self.latest_new_aggregated_payloads (via the
+        // merge above) or into `results` (returned to caller).
         agg_att_cleanup = false;
         agg_sig_cleanup = false;
-        for (agg.attestations.slice()) |*att| {
-            att.deinit();
-        }
+        for (agg.attestations.slice()) |*att| att.deinit();
         agg.attestations.deinit();
-        for (agg.attestation_signatures.slice()) |*sig| {
-            sig.deinit();
-        }
+        for (agg.attestation_signatures.slice()) |*sig| sig.deinit();
         agg.attestation_signatures.deinit();
 
-        // Update fork-choice store gauges after aggregation (outside lock scope)
         zeam_metrics.metrics.lean_latest_new_aggregated_payloads.set(@intCast(new_payloads_count));
         zeam_metrics.metrics.lean_gossip_signatures.set(@intCast(gossip_sigs_count));
 
@@ -1698,38 +1794,23 @@ pub const ForkChoice = struct {
     /// `attestation_signatures` map and the cached
     /// `latest_known_aggregated_payloads`.
     ///
-    /// **#863 / #890 followup — the forkchoice main mutex is intentionally
-    /// NOT acquired here.** The body lives inside `aggregateUnlocked`,
-    /// which only touches state guarded by `signatures_mutex`
-    /// (`attestation_signatures`, `latest_new_aggregated_payloads`,
-    /// `latest_known_aggregated_payloads`). The heavy XMSS aggregate
-    /// proof FFI inside `computeAggregatedSignatures` runs for
-    /// **~70s per call** on devnet aggregators (see metric
-    /// `lean_committee_signatures_aggregation_time_seconds_sum`).
-    /// The previous shape took `mutex.lock()` (forkchoice exclusive)
-    /// for the entire FFI window. That serialised the libxev slot
-    /// driver — `chain.onInterval` → `forkChoice.onInterval` waits on
-    /// the same mutex — so the watchdog fired with multi-second
-    /// stalls every interval an aggregation was in flight, and the
-    /// chain-worker (block import, gossip-attestation tracker
-    /// updates) blocked behind us too. With the mutex dropped:
+    /// **#863 / #890 followup — neither the forkchoice main mutex nor
+    /// the `signatures_mutex` is held during the heavy XMSS FFI
+    /// window.** The forkchoice main mutex isn't acquired at all (the
+    /// body doesn't touch state guarded by it). `signatures_mutex` is
+    /// acquired twice, both ms-scale: once for the snapshot phase,
+    /// once for the commit phase. The ~18 s
+    /// `computeAggregatedSignatures` runs in between with no locks,
+    /// so libxev's `chain.onInterval` →
+    /// `acceptNewAttestationsUnlocked` (which also takes
+    /// `signatures_mutex`) and the chain worker's per-attestation /
+    /// per-block forkchoice updates are unblocked even while an
+    /// aggregation is in flight. See the docstring on
+    /// `aggregateUnlocked` for the three-phase contract.
     ///
-    ///   * libxev `chain.onInterval` (intervals 1, 2, 3 and i=0 on
-    ///     non-proposer slots) acquires forkchoice exclusive on the
-    ///     happy path.
-    ///   * Worker `chain.onBlock` / `forkChoice.onAttestation` acquires
-    ///     forkchoice exclusive on the happy path.
-    ///   * Other aggregator-thread `aggregate` invocations are gated
-    ///     upstream by `aggregate_group.concurrent` (concurrent_limit=1
-    ///     in `submitAggregateOnInterval`), so two aggregations cannot
-    ///     race here.
-    ///
-    /// What `aggregateUnlocked` DOES still hold (correctly) is
-    /// `signatures_mutex` for the read+compute+write window. The
-    /// follow-up to remove that residual hold (snapshot-then-release
-    /// over the FFI window so libxev's i=4 `acceptNewAttestations`
-    /// also runs unblocked) is tracked in the issue linked from
-    /// `submitAggregateOnInterval`.
+    /// `submitAggregateOnInterval` already gates concurrent
+    /// `aggregate()` invocations via `aggregate_group.concurrent`
+    /// (concurrent_limit=1), so two aggregations cannot race here.
     pub fn aggregate(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
         return self.aggregateUnlocked(state_opt);
     }
@@ -2988,6 +3069,92 @@ fn deinitAggregatedPayloadsMap(allocator: Allocator, map: *AggregatedPayloadsMap
     }
     map.deinit();
 }
+
+/// Deep-clone an `AggregatedPayloadsMap`. Each stored
+/// `AggregatedSignatureProof` is `sszClone`d so the destination owns
+/// its own Rust XMSS handle (independent refcount). Caller releases
+/// via `deinitAggregatedPayloadsMap`.
+fn cloneAggregatedPayloadsMap(
+    allocator: Allocator,
+    src: *const AggregatedPayloadsMap,
+) !AggregatedPayloadsMap {
+    var dst = AggregatedPayloadsMap.init(allocator);
+    errdefer deinitAggregatedPayloadsMap(allocator, &dst);
+
+    var it = src.iterator();
+    while (it.next()) |entry| {
+        const gop = try dst.getOrPut(entry.key_ptr.*);
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+
+        try gop.value_ptr.ensureTotalCapacityPrecise(allocator, entry.value_ptr.items.len);
+        for (entry.value_ptr.items) |*stored| {
+            var cloned_proof: types.AggregatedSignatureProof = undefined;
+            try types.sszClone(allocator, types.AggregatedSignatureProof, stored.proof, &cloned_proof);
+            errdefer cloned_proof.deinit();
+            try gop.value_ptr.append(allocator, .{
+                .slot = stored.slot,
+                .proof = cloned_proof,
+            });
+        }
+    }
+    return dst;
+}
+
+/// Owned snapshot of the three signature/aggregation maps that
+/// `aggregateUnlocked` reads. Taken under `signatures_mutex` and
+/// then operated on outside the lock so the heavy XMSS FFI does
+/// not block libxev / chain-worker writers.
+const AggregateSnapshot = struct {
+    signatures: types.SignaturesMap,
+    new_payloads: AggregatedPayloadsMap,
+    known_payloads: AggregatedPayloadsMap,
+
+    /// Acquires `fork_choice.signatures_mutex`, deep-clones the three
+    /// maps into freshly-allocated owned copies, then releases the
+    /// lock. Cost is dominated by `sszClone` of every
+    /// `AggregatedSignatureProof` (Rust FFI handle clone).
+    fn takeUnderLock(fork_choice: *ForkChoice) !AggregateSnapshot {
+        const allocator = fork_choice.allocator;
+
+        fork_choice.signatures_mutex.lock();
+        defer fork_choice.signatures_mutex.unlock();
+
+        var signatures = types.SignaturesMap.init(allocator);
+        errdefer signatures.deinit();
+
+        var src_sig_it = fork_choice.attestation_signatures.iterator();
+        while (src_sig_it.next()) |entry| {
+            var inner = types.SignaturesMap.InnerMap.init(allocator);
+            errdefer inner.deinit();
+            try inner.ensureTotalCapacity(@intCast(entry.value_ptr.count()));
+
+            var inner_it = entry.value_ptr.iterator();
+            while (inner_it.next()) |vid_entry| {
+                try inner.put(vid_entry.key_ptr.*, vid_entry.value_ptr.*);
+            }
+
+            try signatures.put(entry.key_ptr.*, inner);
+        }
+
+        var new_payloads = try cloneAggregatedPayloadsMap(allocator, &fork_choice.latest_new_aggregated_payloads);
+        errdefer deinitAggregatedPayloadsMap(allocator, &new_payloads);
+
+        var known_payloads = try cloneAggregatedPayloadsMap(allocator, &fork_choice.latest_known_aggregated_payloads);
+        errdefer deinitAggregatedPayloadsMap(allocator, &known_payloads);
+
+        return .{
+            .signatures = signatures,
+            .new_payloads = new_payloads,
+            .known_payloads = known_payloads,
+        };
+    }
+
+    fn deinit(self: *AggregateSnapshot, allocator: Allocator) void {
+        self.signatures.deinit();
+        deinitAggregatedPayloadsMap(allocator, &self.new_payloads);
+        deinitAggregatedPayloadsMap(allocator, &self.known_payloads);
+    }
+};
 
 // Helper to build the comprehensive test tree with 9 nodes (A-I)
 // Returns ForkChoice and spec_name. Caller must manage mock_chain lifecycle separately.

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1576,9 +1576,43 @@ pub const ForkChoice = struct {
         return results.toOwnedSlice(self.allocator);
     }
 
+    /// Build aggregate-attestation payloads from the gossip
+    /// `attestation_signatures` map and the cached
+    /// `latest_known_aggregated_payloads`.
+    ///
+    /// **#863 / #890 followup — the forkchoice main mutex is intentionally
+    /// NOT acquired here.** The body lives inside `aggregateUnlocked`,
+    /// which only touches state guarded by `signatures_mutex`
+    /// (`attestation_signatures`, `latest_new_aggregated_payloads`,
+    /// `latest_known_aggregated_payloads`). The heavy XMSS aggregate
+    /// proof FFI inside `computeAggregatedSignatures` runs for
+    /// **~70s per call** on devnet aggregators (see metric
+    /// `lean_committee_signatures_aggregation_time_seconds_sum`).
+    /// The previous shape took `mutex.lock()` (forkchoice exclusive)
+    /// for the entire FFI window. That serialised the libxev slot
+    /// driver — `chain.onInterval` → `forkChoice.onInterval` waits on
+    /// the same mutex — so the watchdog fired with multi-second
+    /// stalls every interval an aggregation was in flight, and the
+    /// chain-worker (block import, gossip-attestation tracker
+    /// updates) blocked behind us too. With the mutex dropped:
+    ///
+    ///   * libxev `chain.onInterval` (intervals 1, 2, 3 and i=0 on
+    ///     non-proposer slots) acquires forkchoice exclusive on the
+    ///     happy path.
+    ///   * Worker `chain.onBlock` / `forkChoice.onAttestation` acquires
+    ///     forkchoice exclusive on the happy path.
+    ///   * Other aggregator-thread `aggregate` invocations are gated
+    ///     upstream by `aggregate_group.concurrent` (concurrent_limit=1
+    ///     in `submitAggregateOnInterval`), so two aggregations cannot
+    ///     race here.
+    ///
+    /// What `aggregateUnlocked` DOES still hold (correctly) is
+    /// `signatures_mutex` for the read+compute+write window. The
+    /// follow-up to remove that residual hold (snapshot-then-release
+    /// over the FFI window so libxev's i=4 `acceptNewAttestations`
+    /// also runs unblocked) is tracked in the issue linked from
+    /// `submitAggregateOnInterval`.
     pub fn aggregate(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
-        self.mutex.lock();
-        defer self.mutex.unlock();
         return self.aggregateUnlocked(state_opt);
     }
 
@@ -2266,6 +2300,120 @@ test "aggregate prunes attestation signatures" {
     try std.testing.expectEqual(@as(usize, 1), aggregations.len);
     try std.testing.expectEqual(@as(usize, 0), fork_choice.attestation_signatures.count());
     try std.testing.expect(fork_choice.latest_new_aggregated_payloads.get(attestation_data) != null);
+}
+
+test "aggregate (#890): does not acquire forkchoice main mutex" {
+    // Regression for the slot-driver stall on aggregator devnet nodes:
+    // before this PR, `forkChoice.aggregate` took `mutex.lock()` for the
+    // entire ~70s XMSS aggregate FFI, blocking libxev's `chain.onInterval`
+    // (which also acquires the same mutex) and the chain-worker thread
+    // (block import / per-attestation tracker updates).
+    //
+    // The contract going forward: `aggregate` MUST NOT acquire the
+    // forkchoice main mutex. Internal coordination is via
+    // `signatures_mutex`, which is the only lock the heavy aggregation
+    // body needs. We assert the contract by holding the main mutex
+    // EXCLUSIVE on the test thread and observing that the aggregator
+    // thread completes without deadlocking. If a future refactor
+    // re-introduces `mutex.lock()` (or any acquisition that the
+    // aggregator must wait for), this test will hang at `thread.join()`
+    // and the CI watchdog will fail it.
+    const allocator = std.testing.allocator;
+    const validator_count: usize = 4;
+    const num_blocks: usize = 1;
+
+    var key_manager = try keymanager.getTestKeyManager(allocator, validator_count, num_blocks);
+    defer key_manager.deinit();
+
+    const all_pubkeys = try key_manager.getAllPubkeys(allocator, validator_count);
+    defer allocator.free(all_pubkeys.attestation_pubkeys);
+    defer allocator.free(all_pubkeys.proposal_pubkeys);
+
+    const genesis_spec = types.GenesisSpec{
+        .genesis_time = 1234,
+        .validator_attestation_pubkeys = all_pubkeys.attestation_pubkeys,
+        .validator_proposal_pubkeys = all_pubkeys.proposal_pubkeys,
+    };
+
+    var mock_chain = try stf.genMockChain(allocator, num_blocks, genesis_spec);
+    defer mock_chain.deinit(allocator);
+    defer mock_chain.genesis_state.validators.deinit();
+    defer mock_chain.genesis_state.historical_block_hashes.deinit();
+    defer mock_chain.genesis_state.justified_slots.deinit();
+    defer mock_chain.genesis_state.justifications_roots.deinit();
+    defer mock_chain.genesis_state.justifications_validators.deinit();
+
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    defer allocator.free(spec_name);
+    defer allocator.free(fork_digest);
+    const chain_config = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+    var fork_choice = try ForkChoice.init(allocator, .{
+        .config = chain_config,
+        .anchorState = &mock_chain.genesis_state,
+        .logger = zeam_logger_config.logger(.forkchoice),
+    });
+    defer fork_choice.deinit();
+
+    // Seed one signature so `aggregate` has work to do (otherwise an
+    // empty-input return path could pass without ever touching the
+    // mutex even before the fix).
+    const attestation_data = types.AttestationData{
+        .slot = 0,
+        .head = .{ .root = fork_choice.head.blockRoot, .slot = 0 },
+        .target = .{ .root = fork_choice.head.blockRoot, .slot = 0 },
+        .source = .{ .root = fork_choice.head.blockRoot, .slot = 0 },
+    };
+    const attestation = types.Attestation{ .validator_id = 0, .data = attestation_data };
+    const signature = try key_manager.signAttestation(&attestation, allocator);
+    try fork_choice.onSignedAttestation(.{
+        .validator_id = 0,
+        .message = attestation_data,
+        .signature = signature,
+    });
+
+    // Hold the forkchoice main mutex exclusive on the test thread for
+    // the entire aggregator-thread lifetime. If `aggregate` (still)
+    // calls `mutex.lock()`, the aggregator deadlocks and `join()`
+    // never returns; the surrounding test runner watchdog will then
+    // fail the test.
+    fork_choice.mutex.lock();
+    defer fork_choice.mutex.unlock();
+
+    const Worker = struct {
+        fork_choice: *ForkChoice,
+        state: *const types.BeamState,
+        result: anyerror![]types.SignedAggregatedAttestation = undefined,
+
+        fn run(ctx: *@This()) void {
+            ctx.result = ctx.fork_choice.aggregate(ctx.state);
+        }
+    };
+    var worker: Worker = .{ .fork_choice = &fork_choice, .state = &mock_chain.genesis_state };
+    const thread = try std.Thread.spawn(.{}, Worker.run, .{&worker});
+    thread.join();
+
+    const aggregations = try worker.result;
+    defer {
+        for (aggregations) |*signed_aggregation| {
+            signed_aggregation.deinit();
+        }
+        allocator.free(aggregations);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), aggregations.len);
 }
 
 // Helper function to create a deterministic test root filled with a specific byte

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -476,13 +476,54 @@ pub const BeamNode = struct {
     /// Imported-block backchannel handler (#890). Fires from
     /// `BeamChain.chainWorkerOnBlockThunk` after every successful
     /// chain-worker import. Takes ownership of `missing_roots` —
-    /// frees it before returning. May run on the chain-worker thread,
-    /// the gossip-import thread, or the libxev thread depending on
-    /// which path imported the block; all work routed through here
-    /// uses mutex-protected state (network helpers, forkchoice,
-    /// `batch_pending_parent_roots_lock`) so the cross-thread surface
-    /// is safe today. See `BeamChain.imported_block_ctx` /
-    /// `ImportedBlockFn` for the full contract.
+    /// frees it before returning. May run on the chain-worker
+    /// thread, the gossip-import thread, or the libxev thread
+    /// depending on which path imported the block.
+    ///
+    /// **Thread-safety audit (zclawz round 3 review on PR #890).**
+    /// Every primitive this handler reaches is safe to call from a
+    /// non-libxev thread:
+    ///
+    ///   * `network.removeFetchedBlock` /
+    ///     `network.getChildrenOfBlock` /
+    ///     `network.hasFetchedBlock` /
+    ///     `network.pruneCachedBlocks`
+    ///                  → `LockedMap` (mutex-protected hashmap).
+    ///   * `network.hasPendingBlockRoot` /
+    ///     `network.removePendingBlockRoot` /
+    ///     `network.trackPendingBlockRoot`
+    ///                  → `LockedMap`.
+    ///   * `network.connected_peers.selectPeerCopy`
+    ///                  → `RwLock`-guarded random pick.
+    ///   * `network.pending_rpc_requests`,
+    ///     `network.blocks_by_root_inflight`
+    ///                  → `LockedMap` + atomic counter (CAS reservation).
+    ///   * `chain.forkChoice.hasBlocksBatch` /
+    ///     `chain.forkChoice.hasBlock`
+    ///                  → forkchoice `RwLock` shared/exclusive.
+    ///   * `self.batch_pending_parent_roots`
+    ///                  → its own `batch_pending_parent_roots_lock`.
+    ///   * `network.backend.reqresp.sendRequest`
+    ///                  → enqueues onto a Tokio `mpsc::Sender::try_send`
+    ///                    in the Rust libp2p glue
+    ///                    (`SwarmCommandChannel`,
+    ///                    `rust/libp2p-glue/src/lib.rs::send_swarm_command`).
+    ///                    The Rust libp2p swarm runs on its OWN
+    ///                    Tokio runtime — the Zig caller never
+    ///                    touches a libxev primitive on this path,
+    ///                    so there is no event-loop affinity to
+    ///                    violate. `try_send` is `Send + Sync`.
+    ///
+    /// Net result: this handler issues NO libxev I/O directly. It
+    /// mutates lock-protected state and queues a command across
+    /// the Zig→Rust FFI boundary; the libxev thread is unaffected.
+    /// Future BeamNode helpers that issue libxev I/O primitives
+    /// (timers, fd reads/writes via `xev.Loop`) MUST NOT be called
+    /// from this handler — they would need to be hopped back via
+    /// the chain-worker queue or a dedicated libxev wakeup.
+    ///
+    /// See `BeamChain.imported_block` / `ImportedBlockFn` for the
+    /// full contract.
     fn handleChainImportedBlock(
         ptr: *anyopaque,
         block_root: types.Root,
@@ -543,8 +584,14 @@ pub const BeamNode = struct {
     /// The callback DOES NOT take ownership of `signed_block`; the
     /// worker's `Message.deinit` frees it after this call returns.
     /// `cacheBlockAndFetchParent` clones internally, matching the
-    /// inline `processBlockByRootChunk` MissingPreState arm. Same
-    /// threading contract as `handleChainImportedBlock`.
+    /// inline `processBlockByRootChunk` MissingPreState arm.
+    ///
+    /// Threading: same contract as `handleChainImportedBlock`. The
+    /// reachable network/forkchoice helpers + the
+    /// `cacheBlockAndFetchParent` path that this handler walks are
+    /// audited in the doc on `handleChainImportedBlock` above —
+    /// every primitive is mutex- / atomic- / FFI-mpsc-safe; no
+    /// libxev I/O is issued from the worker thread.
     fn handleChainRejectedBlock(
         ptr: *anyopaque,
         signed_block: *const types.SignedBlock,
@@ -594,6 +641,20 @@ pub const BeamNode = struct {
         }
     }
 
+    /// Producer side identification for `replayPendingAttestationsAsync`
+    /// drop log severity (zclawz round 3 review on PR #890). The
+    /// distinction matters for an isolated single-validator node:
+    /// when there is NO inbound gossip `on_block` to piggy-back on,
+    /// a `QueueFull` drop on `local_publish` means the buffered
+    /// attestations age until FIFO eviction
+    /// (`MAX_PENDING_ATTESTATIONS = 1024`) — the first occurrence is
+    /// the operator's only signal that liveness is degrading.
+    /// `gossip_or_rpc_followup` paths always have a fresh
+    /// `replayPendingAttestations` queued behind every successful
+    /// import, so a missed nudge there is provably benign within
+    /// one block-cycle.
+    const ReplayProducer = enum { local_publish, gossip_or_rpc_followup };
+
     /// Replay the chain's pending-attestation buffers without
     /// blocking the libxev thread (#890). Routes to the chain-worker
     /// queue when the worker is enabled (the worker drains the
@@ -609,24 +670,27 @@ pub const BeamNode = struct {
     /// slot, so a missed nudge just delays a few buffered entries by
     /// one block-cycle.
     ///
-    /// Tail behaviour for an isolated node (zclawz review on PR
-    /// #890): if the producer is `publishBlock` (we just produced
-    /// locally and there is no inbound `on_block` to piggy-back on)
-    /// AND the queue happens to be full AND no other gossip block
-    /// arrives, buffered attestations sit until the FIFO eviction
-    /// tail of the bounded buffer kicks in
-    /// (`MAX_PENDING_ATTESTATIONS = 1024`). Operators should monitor
-    /// `lean_chain_queue_dropped_total{queue="replay_pending"}` against
-    /// `lean_pending_attestations_size{kind=...}` to detect this in
-    /// dashboards. The drop is logged at debug because the
-    /// steady-state path is benign.
-    fn replayPendingAttestationsAsync(self: *Self) void {
+    /// Producer-aware drop severity (zclawz round 3 review on PR
+    /// #890): isolated nodes producing locally have no inbound
+    /// `on_block` to piggy-back on, so a `QueueFull` drop with
+    /// `producer == .local_publish` escalates to `warn` so the
+    /// first occurrence is visible in logs without needing the
+    /// `lean_chain_queue_dropped_total{queue="replay_pending"}`
+    /// dashboard. `gossip_or_rpc_followup` keeps the prior `debug`
+    /// level.
+    fn replayPendingAttestationsAsync(self: *Self, producer: ReplayProducer) void {
         self.chain.submitReplayPendingAttestations() catch |err| switch (err) {
             error.ChainWorkerDisabled => self.chain.replayPendingAttestations(),
-            error.QueueFull, error.QueueClosed => self.logger.debug(
-                "chain-worker replay submit dropped: {any} (next on_block dispatch will replay)",
-                .{err},
-            ),
+            error.QueueFull, error.QueueClosed => switch (producer) {
+                .local_publish => self.logger.warn(
+                    "chain-worker replay submit dropped on local-publish path: {any} (no inbound on_block to piggy-back; pending attestations age toward FIFO eviction at MAX_PENDING_ATTESTATIONS=1024 — see lean_chain_queue_dropped_total{{queue=replay_pending}} and lean_pending_attestations_size{{kind=...}})",
+                    .{err},
+                ),
+                .gossip_or_rpc_followup => self.logger.debug(
+                    "chain-worker replay submit dropped: {any} (next on_block dispatch will replay)",
+                    .{err},
+                ),
+            },
         };
     }
 
@@ -810,7 +874,7 @@ pub const BeamNode = struct {
                 // iteration of a deep cached-block chain. Correct semantically; a future optimisation
                 // could pass false during catch-up and prune once at the end.
                 self.chain.onBlockFollowup(true, &cached_block);
-                self.replayPendingAttestationsAsync();
+                self.replayPendingAttestationsAsync(.gossip_or_rpc_followup);
 
                 // Remove from cache now that it's been processed. Note:
                 // we own `cached` (clone), so this `removeFetchedBlock`
@@ -1117,7 +1181,7 @@ pub const BeamNode = struct {
             // Store aggregated signature proofs from this block so they can be reused
             // in future block production. This is the same followup done for gossiped blocks.
             self.chain.onBlockFollowup(true, signed_block);
-            self.replayPendingAttestationsAsync();
+            self.replayPendingAttestationsAsync(.gossip_or_rpc_followup);
 
             // Block was successfully added, try to process any cached descendants
             self.processCachedDescendants(block_root);
@@ -1206,7 +1270,7 @@ pub const BeamNode = struct {
         defer self.allocator.free(missing_roots);
 
         self.chain.onBlockFollowup(true, signed_block);
-        self.replayPendingAttestationsAsync();
+        self.replayPendingAttestationsAsync(.gossip_or_rpc_followup);
         self.processCachedDescendants(block_root);
         self.fetchBlockByRoots(missing_roots, 0) catch |err| {
             self.logger.warn("blocks_by_range: failed to fetch {d} missing block(s): {any}", .{ missing_roots.len, err });
@@ -2263,7 +2327,7 @@ pub const BeamNode = struct {
 
         // 4. Followup with additional housekeeping tasks.
         self.chain.onBlockFollowup(true, &signed_block);
-        self.replayPendingAttestationsAsync();
+        self.replayPendingAttestationsAsync(.local_publish);
     }
 
     pub fn publishAttestation(self: *Self, signed_attestation: networks.AttestationGossip) !void {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -182,15 +182,24 @@ pub const BeamNode = struct {
         };
 
         chain.setPruneCachedBlocksCallback(self, pruneCachedBlocksCallback);
+        chain.setImportedBlockCallback(self, handleChainImportedBlock);
 
         network_init_cleanup = false;
     }
 
     pub fn deinit(self: *Self) void {
         self.batch_pending_parent_roots.deinit();
-        self.network.deinit();
+        // Order matters under #890: the chain-worker's
+        // `imported_block_fn` callback (`handleChainImportedBlock`)
+        // touches `self.network` (cache removal, missing-root fetches,
+        // pending-parent flush). `BeamChain.deinit` is what
+        // stops/joins the worker thread, so it MUST run before
+        // `network.deinit()` — otherwise a still-draining worker
+        // dispatch fires the callback against a freed `LockedMap`
+        // (alignment panic on the cache hashmap header).
         self.chain.deinit();
         self.allocator.destroy(self.chain);
+        self.network.deinit();
     }
 
     pub fn onGossip(ptr: *anyopaque, data: *const networks.GossipMessage, sender_peer_id: []const u8) anyerror!void {
@@ -451,6 +460,134 @@ pub const BeamNode = struct {
         };
     }
 
+    /// Imported-block backchannel handler (#890). Fires from
+    /// `BeamChain.chainWorkerOnBlockThunk` after every successful
+    /// chain-worker import. Takes ownership of `missing_roots` —
+    /// frees it before returning. May run on the chain-worker thread,
+    /// the gossip-import thread, or the libxev thread depending on
+    /// which path imported the block; all work routed through here
+    /// uses mutex-protected state (network helpers, forkchoice,
+    /// `batch_pending_parent_roots_lock`) so the cross-thread surface
+    /// is safe today. See `BeamChain.imported_block_ctx` /
+    /// `ImportedBlockFn` for the full contract.
+    fn handleChainImportedBlock(
+        ptr: *anyopaque,
+        block_root: types.Root,
+        missing_roots: []types.Root,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ptr));
+        defer self.allocator.free(missing_roots);
+
+        // If the block was previously cached (a `processCachedDescendants`
+        // submission, or a long-orphan block that arrived ahead of its
+        // parent and got buffered in `network.fetched_blocks`), the
+        // cache entry is now stale — clear it before driving descendant
+        // retry so we don't re-process the same root in a future pass.
+        // Idempotent: no-op for blocks that arrived via gossip or RPC
+        // and never sat in the cache.
+        _ = self.network.removeFetchedBlock(block_root);
+
+        // The block was just imported, so any cached descendants
+        // waiting on it can now be retried. Mirrors the post-import
+        // recursion in the inline RPC paths
+        // (`processBlockByRootChunk` / `processBlockByRangeChunk`).
+        // Internally uses cache-lock-protected helpers + chain.onBlock
+        // (mutex-guarded), so it is safe to invoke from whichever
+        // thread the worker dispatched on.
+        self.processCachedDescendants(block_root);
+
+        // Drive the missing-attestation-root fetch fan-out. Pre-#890
+        // this slice was silently dropped by the worker thunk
+        // (chain.onGossip's `.block` arm comment, and
+        // `chainWorkerProcessPendingBlocksThunk` warn) so attestation
+        // sync stalled until a re-broadcast nudged us. With the
+        // backchannel wired, RPC fetches kick off the moment the
+        // chain knows the dependency.
+        if (missing_roots.len > 0) {
+            self.fetchBlockByRoots(missing_roots, 0) catch |err| {
+                self.logger.warn(
+                    "imported-block callback: failed to fetch {d} missing block(s): {any}",
+                    .{ missing_roots.len, err },
+                );
+            };
+        }
+
+        // Coalesce any parent fetches accumulated during the
+        // descendant retry into one batched `blocks_by_root` request.
+        self.flushPendingParentFetches();
+    }
+
+    /// Replay the chain's pending-attestation buffers without
+    /// blocking the libxev thread (#890). Routes to the chain-worker
+    /// queue when the worker is enabled (the worker drains the
+    /// buffers off-thread in `chainWorkerReplayPendingAttestationsThunk`),
+    /// falls back to the synchronous `replayPendingAttestations` only
+    /// when the worker is disabled — in that mode libxev IS the chain
+    /// thread, so a direct call is the only option. `error.QueueFull`
+    /// / `error.QueueClosed` from the worker submit are non-fatal:
+    /// the chain-worker's own `on_block` thunk replays after every
+    /// successful block import, so a missed nudge just delays a few
+    /// buffered entries by one block-cycle.
+    fn replayPendingAttestationsAsync(self: *Self) void {
+        self.chain.submitReplayPendingAttestations() catch |err| switch (err) {
+            error.ChainWorkerDisabled => self.chain.replayPendingAttestations(),
+            error.QueueFull, error.QueueClosed => self.logger.debug(
+                "chain-worker replay submit dropped: {any} (next on_block dispatch will replay)",
+                .{err},
+            ),
+        };
+    }
+
+    /// Try to route a block import through the chain-worker (#890).
+    /// Returns `true` when the worker accepted ownership of the block
+    /// — followup (`onBlockFollowup` + `replayPendingAttestations` +
+    /// the imported-block callback that drives `processCachedDescendants`
+    /// / `fetchBlockByRoots`) all run on the worker thread, so the
+    /// caller MUST NOT redo any of that work. Returns `false` when
+    /// the worker is disabled, the block queue is full / closed, or
+    /// the SSZ clone needed to transfer ownership failed; the caller
+    /// is then responsible for the inline fallback path.
+    ///
+    /// Caller pre-conditions (so we never queue a block that would
+    /// fail with errors the worker can't recover from): the block's
+    /// parent MUST already be in the forkchoice. The chain-worker
+    /// thunk only logs on error (it has no network handle to drive
+    /// recursive parent fetches), so a `MissingPreState` or
+    /// `PreFinalizedSlot` from `onBlock` would otherwise strand sync.
+    /// The libxev caller keeps those error paths.
+    fn trySubmitImportToWorker(
+        self: *Self,
+        signed_block: *const types.SignedBlock,
+        block_root: types.Root,
+    ) bool {
+        var cloned: types.SignedBlock = undefined;
+        types.sszClone(self.allocator, types.SignedBlock, signed_block.*, &cloned) catch |err| {
+            self.logger.warn(
+                "chain-worker submit: sszClone failed for slot={d} root=0x{x}: {any}, falling back to inline import",
+                .{ signed_block.block.slot, &block_root, err },
+            );
+            return false;
+        };
+        var consumed = false;
+        // `defer` (not `errdefer`): the catch arm below `return false`s
+        // on QueueFull / QueueClosed which are *normal* returns — an
+        // `errdefer` would not run and the clone would leak.
+        defer if (!consumed) cloned.deinit();
+
+        self.chain.submitBlock(cloned, true, block_root) catch |err| switch (err) {
+            error.ChainWorkerDisabled => return false,
+            error.QueueFull, error.QueueClosed => {
+                self.logger.warn(
+                    "chain-worker block queue {s} for slot={d} root=0x{x}, falling back to inline import",
+                    .{ @errorName(err), signed_block.block.slot, &block_root },
+                );
+                return false;
+            },
+        };
+        consumed = true;
+        return true;
+    }
+
     fn processCachedDescendants(self: *Self, parent_root: types.Root) void {
         // Get cached children of this parent (helper returns an owned
         // copy under the cache lock so we can iterate after release).
@@ -516,6 +653,25 @@ pub const BeamNode = struct {
                     .{&descendant_root},
                 );
 
+                // #890 note: cached-descendant retry stays inline (no
+                // chain-worker submit). Two reasons:
+                //   1. Test/caller contract: `processCachedDescendants`
+                //      is observed synchronously (assertions on
+                //      forkchoice / cache state) by the gossip-import
+                //      tests and by `processReadyCachedBlocks`'s
+                //      callers; an async submit defers the side-effect
+                //      past the return.
+                //   2. Re-entrance is safe: when the chain-worker fires
+                //      `imported_block_fn` we are POST-`onBlock` (locks
+                //      released) on the worker thread, so calling
+                //      `chain.onBlock` again here is sequential same-
+                //      thread work — exactly what the worker already
+                //      serialises.
+                // The libxev fallback paths (`processBlockByRootChunk`
+                // / `processBlockByRangeChunk`) are still off-libxev
+                // because they used `trySubmitImportToWorker` for the
+                // *primary* import; cache-retry is the cheap recursive
+                // tail.
                 const block_ssz = cached.ssz;
                 const missing_roots = self.chain.onBlock(cached_block, .{ .sszBytes = block_ssz }) catch |err| {
                     if (err == chainFactory.BlockProcessingError.MissingPreState) {
@@ -558,7 +714,7 @@ pub const BeamNode = struct {
                 // iteration of a deep cached-block chain. Correct semantically; a future optimisation
                 // could pass false during catch-up and prune once at the end.
                 self.chain.onBlockFollowup(true, &cached_block);
-                self.chain.replayPendingAttestationsLibxevBudget();
+                self.replayPendingAttestationsAsync();
 
                 // Remove from cache now that it's been processed. Note:
                 // we own `cached` (clone), so this `removeFetchedBlock`
@@ -771,6 +927,25 @@ pub const BeamNode = struct {
                 return;
             }
 
+            // #890: route to the chain-worker when the parent is already
+            // resolved. The MissingPreState fallback (cache + fetch
+            // parent) below stays libxev-side because the chain-worker
+            // thunk has no network handle to recurse — see
+            // `trySubmitImportToWorker` doc.
+            if (self.chain.forkChoice.hasBlock(signed_block.block.parent_root)) {
+                if (self.trySubmitImportToWorker(signed_block, block_root)) {
+                    // Worker takes ownership; followup (cached
+                    // descendants + missing-root fetch + replay) runs
+                    // from the imported-block callback. We still flush
+                    // any parent fetches accumulated on the libxev
+                    // side during the pre-checks above.
+                    self.flushPendingParentFetches();
+                    return;
+                }
+                // Submit failed (worker disabled / queue full); fall
+                // through to inline path.
+            }
+
             // Try to add the block to the chain
             const missing_roots = self.chain.onBlock(signed_block.*, .{}) catch |err| {
                 // Check if the error is due to missing parent
@@ -847,7 +1022,7 @@ pub const BeamNode = struct {
             // Store aggregated signature proofs from this block so they can be reused
             // in future block production. This is the same followup done for gossiped blocks.
             self.chain.onBlockFollowup(true, signed_block);
-            self.chain.replayPendingAttestationsLibxevBudget();
+            self.replayPendingAttestationsAsync();
 
             // Block was successfully added, try to process any cached descendants
             self.processCachedDescendants(block_root);
@@ -891,6 +1066,17 @@ pub const BeamNode = struct {
             return;
         }
 
+        // #890: route to the chain-worker when the parent is already
+        // resolved. By-range chunks arrive slot-ordered so this is the
+        // common case after the first chunk; the
+        // MissingPreState/cache-and-fetch fallback below stays inline.
+        if (self.chain.forkChoice.hasBlock(signed_block.block.parent_root)) {
+            if (self.trySubmitImportToWorker(signed_block, block_root)) {
+                self.flushPendingParentFetches();
+                return;
+            }
+        }
+
         const missing_roots = self.chain.onBlock(signed_block.*, .{}) catch |err| {
             if (err == chainFactory.BlockProcessingError.MissingPreState) {
                 // Cache and try to fetch parent. Range responses arrive ordered by slot,
@@ -925,7 +1111,7 @@ pub const BeamNode = struct {
         defer self.allocator.free(missing_roots);
 
         self.chain.onBlockFollowup(true, signed_block);
-        self.chain.replayPendingAttestationsLibxevBudget();
+        self.replayPendingAttestationsAsync();
         self.processCachedDescendants(block_root);
         self.fetchBlockByRoots(missing_roots, 0) catch |err| {
             self.logger.warn("blocks_by_range: failed to fetch {d} missing block(s): {any}", .{ missing_roots.len, err });
@@ -1943,6 +2129,14 @@ pub const BeamNode = struct {
         // entry already exists, so locally produced blocks no longer leak
         // their initial post-state on the publish hop. See the design doc
         // §Resource-by-resource design / `BeamChain.states` for context.
+        //
+        // Stays inline (NOT routed through the chain-worker like the RPC
+        // paths in #890): the validator path runs on the libxev thread,
+        // and downstream callers / tests assume the block is in
+        // forkchoice by the time `publishBlock` returns. Async would
+        // surface a race where attestations produced in the same
+        // interval reference a block the chain hasn't imported yet.
+        // The replay below still goes via the worker.
         const missing_roots = try self.chain.onBlock(signed_block, .{
             .blockRoot = block_root,
         });
@@ -1974,7 +2168,7 @@ pub const BeamNode = struct {
 
         // 4. Followup with additional housekeeping tasks.
         self.chain.onBlockFollowup(true, &signed_block);
-        self.chain.replayPendingAttestationsLibxevBudget();
+        self.replayPendingAttestationsAsync();
     }
 
     pub fn publishAttestation(self: *Self, signed_attestation: networks.AttestationGossip) !void {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -183,22 +183,35 @@ pub const BeamNode = struct {
 
         chain.setPruneCachedBlocksCallback(self, pruneCachedBlocksCallback);
         chain.setImportedBlockCallback(self, handleChainImportedBlock);
+        chain.setRejectedBlockCallback(self, handleChainRejectedBlock);
 
         network_init_cleanup = false;
     }
 
     pub fn deinit(self: *Self) void {
-        self.batch_pending_parent_roots.deinit();
-        // Order matters under #890: the chain-worker's
-        // `imported_block_fn` callback (`handleChainImportedBlock`)
-        // touches `self.network` (cache removal, missing-root fetches,
-        // pending-parent flush). `BeamChain.deinit` is what
-        // stops/joins the worker thread, so it MUST run before
-        // `network.deinit()` — otherwise a still-draining worker
-        // dispatch fires the callback against a freed `LockedMap`
-        // (alignment panic on the cache hashmap header).
+        // Order matters under #890. `chain.deinit()` is what stops/
+        // joins the chain-worker thread, so any state the worker
+        // callbacks (`handleChainImportedBlock`,
+        // `handleChainRejectedBlock`) reach into MUST outlive the
+        // join. Concretely the callbacks touch:
+        //
+        //   * `self.network`            (cache removal, missing-root
+        //                                fetches, pre-finalized prune)
+        //   * `self.batch_pending_parent_roots` + its lock
+        //                                (`flushPendingParentFetches`,
+        //                                `cacheBlockAndFetchParent`)
+        //   * `self.chain.forkChoice`   (already torn down inside
+        //                                `chain.deinit` — but only
+        //                                AFTER the worker has joined,
+        //                                so still safe)
+        //
+        // Any new BeamNode field a worker callback can reach must be
+        // deinit'd AFTER `chain.deinit()` — failure surfaces as an
+        // alignment panic / UAF on the still-draining worker
+        // dispatch (zclawz review on PR #890).
         self.chain.deinit();
         self.allocator.destroy(self.chain);
+        self.batch_pending_parent_roots.deinit();
         self.network.deinit();
     }
 
@@ -517,17 +530,96 @@ pub const BeamNode = struct {
         self.flushPendingParentFetches();
     }
 
+    /// Rejected-block backchannel handler (#890 zclawz review). Fires
+    /// from `BeamChain.chainWorkerOnBlockThunk` ONLY when worker-side
+    /// `onBlock` returns `MissingPreState` or `PreFinalizedSlot` —
+    /// the two errors caused by a TOCTOU race between the libxev
+    /// caller's `forkChoice.hasBlock(parent)` pre-check inside
+    /// `trySubmitImportToWorker` and the worker's eventual dispatch
+    /// (finalization can prune the parent in between). Without this
+    /// hand-back the worker would silently drop the block — sync
+    /// would stall until a re-broadcast.
+    ///
+    /// The callback DOES NOT take ownership of `signed_block`; the
+    /// worker's `Message.deinit` frees it after this call returns.
+    /// `cacheBlockAndFetchParent` clones internally, matching the
+    /// inline `processBlockByRootChunk` MissingPreState arm. Same
+    /// threading contract as `handleChainImportedBlock`.
+    fn handleChainRejectedBlock(
+        ptr: *anyopaque,
+        signed_block: *const types.SignedBlock,
+        block_root: types.Root,
+        reason: chainFactory.BeamChain.RejectedBlockReason,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ptr));
+        switch (reason) {
+            .missing_pre_state => {
+                // Mirror the inline `processBlockByRootChunk`
+                // MissingPreState arm. Use depth=1 since the libxev
+                // caller already accepted this block (depth 0); a
+                // subsequent parent fetch is the next hop.
+                if (self.cacheBlockAndFetchParent(block_root, signed_block.*, 1)) |parent_root| {
+                    self.logger.debug(
+                        "chain-worker rejected MissingPreState slot={d} root=0x{x}, cached + fetching parent 0x{x}",
+                        .{ signed_block.block.slot, &block_root, &parent_root },
+                    );
+                } else |cache_err| {
+                    if (cache_err == CacheBlockError.PreFinalized) {
+                        self.logger.info(
+                            "chain-worker rejected MissingPreState slot={d} root=0x{x} but block is now pre-finalized; pruning cached descendants",
+                            .{ signed_block.block.slot, &block_root },
+                        );
+                        _ = self.network.pruneCachedBlocks(block_root, null);
+                    } else if (cache_err == CacheBlockError.AlreadyCached) {
+                        self.logger.debug(
+                            "chain-worker rejected MissingPreState slot={d} root=0x{x} but block already cached (concurrent re-arrival)",
+                            .{ signed_block.block.slot, &block_root },
+                        );
+                    } else {
+                        self.logger.warn(
+                            "chain-worker rejected MissingPreState slot={d} root=0x{x}: cache failed: {any}",
+                            .{ signed_block.block.slot, &block_root, cache_err },
+                        );
+                    }
+                }
+                self.flushPendingParentFetches();
+            },
+            .pre_finalized => {
+                self.logger.info(
+                    "chain-worker rejected PreFinalizedSlot slot={d} root=0x{x}; pruning cached descendants",
+                    .{ signed_block.block.slot, &block_root },
+                );
+                _ = self.network.pruneCachedBlocks(block_root, null);
+            },
+        }
+    }
+
     /// Replay the chain's pending-attestation buffers without
     /// blocking the libxev thread (#890). Routes to the chain-worker
     /// queue when the worker is enabled (the worker drains the
     /// buffers off-thread in `chainWorkerReplayPendingAttestationsThunk`),
     /// falls back to the synchronous `replayPendingAttestations` only
     /// when the worker is disabled — in that mode libxev IS the chain
-    /// thread, so a direct call is the only option. `error.QueueFull`
-    /// / `error.QueueClosed` from the worker submit are non-fatal:
-    /// the chain-worker's own `on_block` thunk replays after every
-    /// successful block import, so a missed nudge just delays a few
-    /// buffered entries by one block-cycle.
+    /// thread, so a direct call is the only option.
+    ///
+    /// `error.QueueFull` / `error.QueueClosed` from the worker submit
+    /// are non-fatal in the steady-state aggregator case: the
+    /// chain-worker's own `on_block` thunk runs `replayPendingAttestations`
+    /// after every successful import, and gossip blocks land within a
+    /// slot, so a missed nudge just delays a few buffered entries by
+    /// one block-cycle.
+    ///
+    /// Tail behaviour for an isolated node (zclawz review on PR
+    /// #890): if the producer is `publishBlock` (we just produced
+    /// locally and there is no inbound `on_block` to piggy-back on)
+    /// AND the queue happens to be full AND no other gossip block
+    /// arrives, buffered attestations sit until the FIFO eviction
+    /// tail of the bounded buffer kicks in
+    /// (`MAX_PENDING_ATTESTATIONS = 1024`). Operators should monitor
+    /// `lean_chain_queue_dropped_total{queue="replay_pending"}` against
+    /// `lean_pending_attestations_size{kind=...}` to detect this in
+    /// dashboards. The drop is logged at debug because the
+    /// steady-state path is benign.
     fn replayPendingAttestationsAsync(self: *Self) void {
         self.chain.submitReplayPendingAttestations() catch |err| switch (err) {
             error.ChainWorkerDisabled => self.chain.replayPendingAttestations(),
@@ -548,13 +640,17 @@ pub const BeamNode = struct {
     /// the SSZ clone needed to transfer ownership failed; the caller
     /// is then responsible for the inline fallback path.
     ///
-    /// Caller pre-conditions (so we never queue a block that would
-    /// fail with errors the worker can't recover from): the block's
-    /// parent MUST already be in the forkchoice. The chain-worker
-    /// thunk only logs on error (it has no network handle to drive
-    /// recursive parent fetches), so a `MissingPreState` or
-    /// `PreFinalizedSlot` from `onBlock` would otherwise strand sync.
-    /// The libxev caller keeps those error paths.
+    /// Caller pre-condition: the libxev caller MUST have observed
+    /// the parent under `forkChoice.hasBlock` before submitting.
+    /// The check is racy by design: finalization can advance and
+    /// prune the parent between the check and the worker's
+    /// eventual dispatch. The race is closed by the rejected-block
+    /// backchannel — `chainWorkerOnBlockThunk` invokes
+    /// `handleChainRejectedBlock` on `MissingPreState` /
+    /// `PreFinalizedSlot`, which runs the same `cacheBlockAndFetch
+    /// Parent` / `pruneCachedBlocks` path the inline
+    /// `processBlockByRootChunk` would have taken. Net effect: the
+    /// worker can never strand sync on this race.
     fn trySubmitImportToWorker(
         self: *Self,
         signed_block: *const types.SignedBlock,
@@ -927,19 +1023,18 @@ pub const BeamNode = struct {
                 return;
             }
 
-            // #890: route to the chain-worker when the parent is already
-            // resolved. The MissingPreState fallback (cache + fetch
-            // parent) below stays libxev-side because the chain-worker
-            // thunk has no network handle to recurse — see
-            // `trySubmitImportToWorker` doc.
+            // #890: route to the chain-worker when the parent is
+            // already resolved. The MissingPreState / PreFinalizedSlot
+            // race against finalization is closed by the rejected-
+            // block backchannel — `handleChainRejectedBlock` runs
+            // the same cache-and-fetch / prune path the inline arm
+            // below would. See `trySubmitImportToWorker` doc.
             if (self.chain.forkChoice.hasBlock(signed_block.block.parent_root)) {
                 if (self.trySubmitImportToWorker(signed_block, block_root)) {
                     // Worker takes ownership; followup (cached
-                    // descendants + missing-root fetch + replay) runs
-                    // from the imported-block callback. We still flush
-                    // any parent fetches accumulated on the libxev
-                    // side during the pre-checks above.
-                    self.flushPendingParentFetches();
+                    // descendants + missing-root fetch + replay +
+                    // parent-fetch flush) all run from the imported-
+                    // block callback. No redundant flush here.
                     return;
                 }
                 // Submit failed (worker disabled / queue full); fall
@@ -1067,12 +1162,12 @@ pub const BeamNode = struct {
         }
 
         // #890: route to the chain-worker when the parent is already
-        // resolved. By-range chunks arrive slot-ordered so this is the
-        // common case after the first chunk; the
-        // MissingPreState/cache-and-fetch fallback below stays inline.
+        // resolved. By-range chunks arrive slot-ordered so this is
+        // the common case after the first chunk. The TOCTOU race
+        // against finalization is closed by `handleChainRejectedBlock`
+        // — see `trySubmitImportToWorker` doc.
         if (self.chain.forkChoice.hasBlock(signed_block.block.parent_root)) {
             if (self.trySubmitImportToWorker(signed_block, block_root)) {
-                self.flushPendingParentFetches();
                 return;
             }
         }

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -558,7 +558,7 @@ pub const BeamNode = struct {
                 // iteration of a deep cached-block chain. Correct semantically; a future optimisation
                 // could pass false during catch-up and prune once at the end.
                 self.chain.onBlockFollowup(true, &cached_block);
-                self.chain.replayPendingAttestations();
+                self.chain.replayPendingAttestationsLibxevBudget();
 
                 // Remove from cache now that it's been processed. Note:
                 // we own `cached` (clone), so this `removeFetchedBlock`
@@ -847,7 +847,7 @@ pub const BeamNode = struct {
             // Store aggregated signature proofs from this block so they can be reused
             // in future block production. This is the same followup done for gossiped blocks.
             self.chain.onBlockFollowup(true, signed_block);
-            self.chain.replayPendingAttestations();
+            self.chain.replayPendingAttestationsLibxevBudget();
 
             // Block was successfully added, try to process any cached descendants
             self.processCachedDescendants(block_root);
@@ -925,7 +925,7 @@ pub const BeamNode = struct {
         defer self.allocator.free(missing_roots);
 
         self.chain.onBlockFollowup(true, signed_block);
-        self.chain.replayPendingAttestations();
+        self.chain.replayPendingAttestationsLibxevBudget();
         self.processCachedDescendants(block_root);
         self.fetchBlockByRoots(missing_roots, 0) catch |err| {
             self.logger.warn("blocks_by_range: failed to fetch {d} missing block(s): {any}", .{ missing_roots.len, err });
@@ -1698,6 +1698,33 @@ pub const BeamNode = struct {
                     continue;
                 };
 
+                // Drain the future-slot `pending_blocks` queue on the chain-worker
+                // (#803). `submitProcessPendingBlocks` was added for the worker
+                // plumbing but had no production caller — without this tick the
+                // queue never advanced off the libxev thread. Keeps heavy
+                // `processPendingBlocks` work off the slot driver.
+                if (self.chain.chainWorkerEnabled()) {
+                    self.chain.submitProcessPendingBlocks(slot) catch |err| switch (err) {
+                        error.QueueFull => self.logger.warn(
+                            "chain-worker block queue full; skipped processPendingBlocks for slot={d}",
+                            .{slot},
+                        ),
+                        error.QueueClosed => {},
+                        error.ChainWorkerDisabled => unreachable,
+                    };
+                } else {
+                    const missing_roots = self.chain.processPendingBlocks();
+                    defer self.allocator.free(missing_roots);
+                    if (missing_roots.len > 0) {
+                        self.fetchBlockByRoots(missing_roots, 0) catch |e| {
+                            self.logger.warn(
+                                "failed to fetch {d} missing block root(s) from processPendingBlocks: {any}",
+                                .{ missing_roots.len, e },
+                            );
+                        };
+                    }
+                }
+
                 // Sweep timed-out RPC requests to prevent sync stalls from non-responsive peers.
                 self.sweepTimedOutRequests();
 
@@ -1952,7 +1979,7 @@ pub const BeamNode = struct {
 
         // 4. Followup with additional housekeeping tasks.
         self.chain.onBlockFollowup(true, &signed_block);
-        self.chain.replayPendingAttestations();
+        self.chain.replayPendingAttestationsLibxevBudget();
     }
 
     pub fn publishAttestation(self: *Self, signed_attestation: networks.AttestationGossip) !void {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1698,21 +1698,16 @@ pub const BeamNode = struct {
                     continue;
                 };
 
-                // Drain the future-slot `pending_blocks` queue on the chain-worker
-                // (#803). `submitProcessPendingBlocks` was added for the worker
-                // plumbing but had no production caller — without this tick the
-                // queue never advanced off the libxev thread. Keeps heavy
-                // `processPendingBlocks` work off the slot driver.
-                if (self.chain.chainWorkerEnabled()) {
-                    self.chain.submitProcessPendingBlocks(slot) catch |err| switch (err) {
-                        error.QueueFull => self.logger.warn(
-                            "chain-worker block queue full; skipped processPendingBlocks for slot={d}",
-                            .{slot},
-                        ),
-                        error.QueueClosed => {},
-                        error.ChainWorkerDisabled => unreachable,
-                    };
-                } else {
+                // Drain the future-slot `pending_blocks` queue. Runs inline
+                // on the libxev thread because `processPendingBlocks` returns
+                // missing block roots that must feed back into
+                // `BeamNode.fetchBlockByRoots`, and the chain-worker thunk has
+                // no handle to `BeamNode` to make that call. A worker → libxev
+                // backchannel for the fetch is tracked as a #863 follow-up;
+                // see the comment on `chainWorkerProcessPendingBlocksThunk`.
+                // Per-call work is bounded by `MAX_PENDING_BLOCKS` (1024) and
+                // in steady state the queue is empty / single-digit.
+                {
                     const missing_roots = self.chain.processPendingBlocks();
                     defer self.allocator.free(missing_roots);
                     if (missing_roots.len > 0) {


### PR DESCRIPTION
## Summary

Follow-up to #886. On aggregator nodes (e.g. `zeam_0` in lean-quickstart) the
`[clock] slot-driver stall detected: last tick N.NNNs ago` line was still firing
because heavy chain mutations were still running synchronously on the libxev
thread under aggregator load. This PR moves all of them off libxev and onto
the chain-worker.

Three offload strategies, plus the original `processPendingBlocks` driver fix:

1. **RPC block import on the chain-worker.** `processBlockByRootChunk`,
   `processBlockByRangeChunk`, and the post-import branch of
   `processCachedDescendants` route through a new `trySubmitImportToWorker`
   helper when the worker is enabled and the parent is in forkchoice.
   `chain.onBlock` + `onBlockFollowup` + the inline replay all run on the
   worker thread; libxev only does network plumbing. A new `imported_block_fn`
   backchannel hands `(block_root, missing_attestation_roots)` back to
   `BeamNode.handleChainImportedBlock` so cache cleanup, descendant retry,
   and the `blocks_by_root` fan-out still happen — fixing the long-standing
   TODO where `chainWorkerOnBlockThunk` silently dropped `missing_roots`.
   `publishBlock` keeps its inline import (downstream callers/tests observe
   forkchoice synchronously) but now nudges the worker for replay.

2. **`replayPendingAttestations` is worker-only when the worker is enabled.**
   New `submitReplayPendingAttestations` enqueues a
   `replay_pending_attestations` `Message` onto the chain-worker. Every
   libxev producer (cached-descendant, RPC by-root/by-range,
   `publishBlock`) now goes through `replayPendingAttestationsAsync`, which
   submits to the worker or falls back to the synchronous in-thread path
   only on `error.ChainWorkerDisabled`. `error.QueueFull` /
   `error.QueueClosed` are non-fatal: the worker's own `on_block` thunk
   replays after every successful import, so a missed nudge just delays a
   few buffered entries by one block-cycle. The libxev-budgeted variant
   added earlier in this PR (`replayPendingAttestationsLibxevBudget` plus
   the two `…_LIBXEV_BUDGET` constants) is removed — it only existed to
   bound work that no longer runs on libxev.

3. **Parallel XMSS verify in `replayPendingAttestations`.** When
   `BeamChain.thread_pool` is configured the per-entry replay
   (`replayOneAttestation` / `replayOneAggregation`) fans out via
   `pool.spawnWg` + `pool.waitAndWork`. The XMSS verify is the dominant
   cost and has no shared state across siblings; forkchoice / pubkey-cache
   writes already take their own locks. Falls back to a serial loop when
   there is no pool (chain-worker test rigs, disabled-worker mode).

4. **`submitProcessPendingBlocks` was wired up.** `BeamNode.onInterval` now
   asks the worker to drive the future-slot `pending_blocks` queue when
   the worker is enabled, falling back to the inline path otherwise. Also
   the comment fix in `clock.zig`: `events.run(.once)` drains the whole
   kernel CQE batch (up to 128 on the io_uring backend), not a single
   completion — that was a major contributor to the stalls #886 was still
   seeing.

## Changes

- `pkgs/node/src/chain.zig`
  - New `imported_block_ctx` / `imported_block_fn` + `ImportedBlockFn`
    type + `setImportedBlockCallback` for the worker → BeamNode
    backchannel. `chainWorkerOnBlockThunk` now invokes the callback
    after a successful import (transferring ownership of
    `missing_roots`); when no callback is wired it free's the slice
    locally.
  - New `submitReplayPendingAttestations` + `chainWorkerReplayPendingAttestationsThunk`.
  - `replayPendingAttestations` is now worker-thread-only when the
    worker is enabled (doc comment updated). Internally fans out via
    the shared `ThreadPool` + `WaitGroup` when one is configured.
  - `chainWorkerEnabled()` accessor (added earlier in this PR) stays.
  - Drops `replayPendingAttestationsLibxevBudget`.
- `pkgs/node/src/chain_worker.zig`
  - New `replay_pending_attestations` `Message` variant + matching
    `Handlers.replay_pending_attestations` entry + `dispatch` arm.
  - New `ChainWorker.sendReplayPending` (routes onto the attestation
    queue; same wake/backpressure contract as `sendAttestation`).
- `pkgs/node/src/node.zig`
  - New `replayPendingAttestationsAsync` helper. All four libxev call
    sites (`processCachedDescendants`, `processBlockByRootChunk`,
    `processBlockByRangeChunk`, `publishBlock`) now go through it.
  - New `trySubmitImportToWorker` helper + `handleChainImportedBlock`
    callback. `processBlockByRootChunk` / `processBlockByRangeChunk`
    submit to the worker when parent ∈ forkchoice, falling back to the
    inline path otherwise. `processCachedDescendants` keeps the inline
    `chain.onBlock` for cache-retry (caller contract is synchronous).
  - `BeamNode.init` registers `handleChainImportedBlock` as the chain's
    `imported_block_fn`.
  - `BeamNode.deinit` reorder: `chain.deinit()` (which stops/joins the
    worker) now runs before `network.deinit()`. Without this, a still-
    draining worker dispatch fires `imported_block_fn` against a freed
    `LockedMap` — surfaced by an alignment panic in the
    `processCachedDescendants basic flow` test.
- `pkgs/node/src/constants.zig`: drops the two `…_LIBXEV_BUDGET`
  constants (no longer needed).
- `pkgs/node/src/clock.zig`: comment clarification (drained-CQE-batch
  semantics).

No public API removed. Watchdog (#863), drain histograms, and stall
counters remain unchanged so before/after dashboards are directly
comparable.

## Test plan

- [x] `zig build`
- [x] `zig fmt --check .`
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings`
- [x] `zig build test --summary all` (149/149 pass locally)
- [x] `zig build simtest --summary all` (15/15 pass locally)
- [ ] Run `zig build test` and `zig build simtest` in CI
- [ ] Burn-in on devnet aggregator (`zeam_0`): confirm
  `zeam_slot_driver_stall_fired_total` rate drops and
  `zeam_xev_clock_until_done_drain_seconds` p99 stays bounded under
  4-subnet aggregator load.