### PR TITLE
fix(node): retry unserved blocks_by_root roots on EOS/failure + range-sync in fc_initing

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -5650,12 +5650,12 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
     try std.testing.expect(known_count > 0);
 }
 
-// Shared setup for the three leanSpec #716 produceBlock tests.
+// Shared setup for the justification-aware produceBlock tests.
 // Heap-allocates zeam_logger_config and beam_state via the arena so their
 // addresses are stable across the deep call stacks inside produceBlock
 // (stack locals would be clobbered when the call depth grows; see the
 // FutureSlotTestFixture pattern used elsewhere in this file).
-fn setup716TestChain(allocator: std.mem.Allocator, n_blocks: usize) !struct {
+fn setupJustifiedSourceTestChain(allocator: std.mem.Allocator, n_blocks: usize) !struct {
     mock_chain: stf.MockChainData,
     beam_chain: *BeamChain,
     connected_peers: *ConnectedPeers,
@@ -5719,7 +5719,7 @@ fn setup716TestChain(allocator: std.mem.Allocator, n_blocks: usize) !struct {
     };
 }
 
-test "produceBlock - older-but-justified source is accepted (leanSpec #716)" {
+test "produceBlock - older-but-justified source is accepted" {
     // leanSpec commit 00556d8: build_block must accept any attestation whose
     // source *slot* is in justified_slots, not just the most recent justified
     // checkpoint's root. This test places an attestation whose source is an
@@ -5730,7 +5730,7 @@ test "produceBlock - older-but-justified source is accepted (leanSpec #716)" {
     const allocator = arena_allocator.allocator();
 
     // 8 blocks: enough for at least two justification cycles (pattern repeats every 4).
-    var fx = try setup716TestChain(allocator, 8);
+    var fx = try setupJustifiedSourceTestChain(allocator, 8);
     defer {
         fx.beam_chain.deinit();
         fx.test_registry.deinit();
@@ -5791,7 +5791,7 @@ test "produceBlock - older-but-justified source is accepted (leanSpec #716)" {
     try std.testing.expect(found_older);
 }
 
-test "produceBlock - zero-hash source/target rejected by build_block (leanSpec #716)" {
+test "produceBlock - zero-hash source/target rejected by build_block" {
     // attestationDataMatchesChainExtended must reject attestations whose source or
     // target root is ZERO_HASH even when the slot would otherwise pass the justified check.
     // A valid control attestation is also stored to guarantee the block is non-empty,
@@ -5800,7 +5800,7 @@ test "produceBlock - zero-hash source/target rejected by build_block (leanSpec #
     defer arena_allocator.deinit();
     const allocator = arena_allocator.allocator();
 
-    var fx = try setup716TestChain(allocator, 6);
+    var fx = try setupJustifiedSourceTestChain(allocator, 6);
     defer {
         fx.beam_chain.deinit();
         fx.test_registry.deinit();
@@ -5879,7 +5879,7 @@ test "produceBlock - zero-hash source/target rejected by build_block (leanSpec #
     try std.testing.expect(found_valid);
 }
 
-test "produceBlock - already-justified target skipped, genesis self-vote exemption (leanSpec #716)" {
+test "produceBlock - already-justified target skipped, genesis self-vote exemption" {
     // Two assertions:
     //   (a) NEGATIVE: a non-genesis attestation whose target slot is already justified
     //       must be excluded from the produced block.
@@ -5891,7 +5891,7 @@ test "produceBlock - already-justified target skipped, genesis self-vote exempti
     defer arena_allocator.deinit();
     const allocator = arena_allocator.allocator();
 
-    var fx = try setup716TestChain(allocator, 6);
+    var fx = try setupJustifiedSourceTestChain(allocator, 6);
     defer {
         fx.beam_chain.deinit();
         fx.test_registry.deinit();

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -5649,6 +5649,329 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
     try std.testing.expect(unseen_count == 0);
     try std.testing.expect(known_count > 0);
 }
+
+// Shared setup for the three leanSpec #716 produceBlock tests.
+// Heap-allocates zeam_logger_config and beam_state via the arena so their
+// addresses are stable across the deep call stacks inside produceBlock
+// (stack locals would be clobbered when the call depth grows; see the
+// FutureSlotTestFixture pattern used elsewhere in this file).
+fn setup716TestChain(allocator: std.mem.Allocator, n_blocks: usize) !struct {
+    mock_chain: stf.MockChainData,
+    beam_chain: *BeamChain,
+    connected_peers: *ConnectedPeers,
+    test_registry: *NodeNameRegistry,
+    db: database.Db,
+    tmp_dir: std.testing.TmpDir,
+} {
+    const mock_chain = try stf.genMockChain(allocator, n_blocks, null);
+    const spec_name = try allocator.dupe(u8, "beamdev");
+    const fork_digest = try allocator.dupe(u8, "12345678");
+    // chain_config on heap so that embedded slices aren't on a stack frame
+    // that may be clobbered during produceBlock's deep call chain.
+    const chain_config = try allocator.create(configs.ChainConfig);
+    chain_config.* = configs.ChainConfig{
+        .id = configs.Chain.custom,
+        .genesis = mock_chain.genesis_config,
+        .spec = .{
+            .preset = params.Preset.mainnet,
+            .name = spec_name,
+            .fork_digest = fork_digest,
+            .attestation_committee_count = 1,
+            .max_attestations_data = 16,
+        },
+    };
+    // Heap-allocate beam_state and zeam_logger_config so their addresses are
+    // stable.  BeamChain stores *BeamState and *ZeamLoggerConfig; if those
+    // live on the test stack they get stomped when produceBlock grows the
+    // call stack past them.
+    const beam_state = try allocator.create(types.BeamState);
+    beam_state.* = mock_chain.genesis_state;
+    const zeam_logger_config = try allocator.create(zeam_utils.ZeamLoggerConfig);
+    zeam_logger_config.* = zeam_utils.getTestLoggerConfig();
+
+    const tmp_dir = std.testing.tmpDir(.{});
+    const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
+    defer allocator.free(data_dir);
+    const db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+
+    const connected_peers = try allocator.create(ConnectedPeers);
+    connected_peers.* = ConnectedPeers.init(allocator);
+    const test_registry = try allocator.create(NodeNameRegistry);
+    test_registry.* = NodeNameRegistry.init(allocator);
+
+    const beam_chain = try allocator.create(BeamChain);
+    beam_chain.* = try BeamChain.init(allocator, ChainOpts{
+        .config = chain_config.*,
+        .anchorState = beam_state,
+        .nodeId = 0,
+        .logger_config = zeam_logger_config,
+        .db = db,
+        .node_registry = test_registry,
+    }, connected_peers);
+
+    return .{
+        .mock_chain = mock_chain,
+        .beam_chain = beam_chain,
+        .connected_peers = connected_peers,
+        .test_registry = test_registry,
+        .db = db,
+        .tmp_dir = tmp_dir,
+    };
+}
+
+test "produceBlock - older-but-justified source is accepted (leanSpec #716)" {
+    // leanSpec commit 00556d8: build_block must accept any attestation whose
+    // source *slot* is in justified_slots, not just the most recent justified
+    // checkpoint's root. This test places an attestation whose source is an
+    // older justified slot (not the latest_justified checkpoint) and verifies
+    // it ends up in the produced block.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    // 8 blocks: enough for at least two justification cycles (pattern repeats every 4).
+    var fx = try setup716TestChain(allocator, 8);
+    defer {
+        fx.beam_chain.deinit();
+        fx.test_registry.deinit();
+        fx.db.deinit();
+        fx.tmp_dir.cleanup();
+    }
+    const mock_chain = fx.mock_chain;
+    const beam_chain = fx.beam_chain;
+
+    // Apply 4 blocks so the chain has at least one justified slot.
+    for (1..5) |i| {
+        const signed_block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(signed_block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false });
+        allocator.free(missing_roots);
+    }
+
+    // Use mock_chain.latestJustified which was precomputed by genMockChain
+    // without going through states.get (avoids unsafe raw pointer access).
+    const justified_cp = mock_chain.latestJustified[4];
+    const justified_slot: types.Slot = justified_cp.slot;
+    try std.testing.expect(justified_slot >= 1);
+
+    // Craft an attestation with an *older* justified source slot (not the latest).
+    // Under the old root-equality filter this would be dropped; under the new
+    // slot-based filter it must be included.
+    const older_justified_slot: types.Slot = if (justified_slot > 1) justified_slot - 1 else justified_slot;
+    const older_source_root = mock_chain.blockRoots[older_justified_slot];
+    const proposal_slot: types.Slot = 5;
+    const parent_root = mock_chain.blockRoots[4];
+
+    const att_data_older_source = types.AttestationData{
+        .slot = proposal_slot - 1,
+        .head = .{ .root = parent_root, .slot = 4 },
+        .target = .{ .root = parent_root, .slot = 4 },
+        .source = .{ .root = older_source_root, .slot = older_justified_slot },
+    };
+    const num_validators: u64 = @intCast(mock_chain.genesis_config.numValidators());
+    var proof = try types.AggregatedSignatureProof.init(allocator);
+    for (0..@intCast(num_validators)) |i| try types.aggregationBitsSet(&proof.participants, i, true);
+    try beam_chain.forkChoice.storeAggregatedPayload(&att_data_older_source, proof, true);
+
+    const produced = try beam_chain.produceBlock(.{
+        .slot = proposal_slot,
+        .proposer_index = proposal_slot % num_validators,
+    });
+    defer @constCast(&produced).deinit();
+
+    const atts = produced.block.body.attestations.constSlice();
+    var found_older = false;
+    for (atts) |att| {
+        if (att.data.source.slot == older_justified_slot and
+            std.mem.eql(u8, &att.data.source.root, &older_source_root))
+        {
+            found_older = true;
+        }
+    }
+    try std.testing.expect(found_older);
+}
+
+test "produceBlock - zero-hash source/target rejected by build_block (leanSpec #716)" {
+    // attestationDataMatchesChainExtended must reject attestations whose source or
+    // target root is ZERO_HASH even when the slot would otherwise pass the justified check.
+    // A valid control attestation is also stored to guarantee the block is non-empty,
+    // so the negative assertions cannot pass vacuously.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    var fx = try setup716TestChain(allocator, 6);
+    defer {
+        fx.beam_chain.deinit();
+        fx.test_registry.deinit();
+        fx.db.deinit();
+        fx.tmp_dir.cleanup();
+    }
+    const mock_chain = fx.mock_chain;
+    const beam_chain = fx.beam_chain;
+
+    for (1..5) |i| {
+        const signed_block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(signed_block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false });
+        allocator.free(missing_roots);
+    }
+
+    const justified_cp = mock_chain.latestJustified[4];
+    const justified_slot: types.Slot = justified_cp.slot;
+    const justified_root = justified_cp.root;
+    const proposal_slot: types.Slot = 5;
+    const num_validators: u64 = @intCast(mock_chain.genesis_config.numValidators());
+    const parent_root = mock_chain.blockRoots[4];
+
+    // Attestation with ZERO_HASH source root — must be rejected.
+    const att_zero_source = types.AttestationData{
+        .slot = proposal_slot - 1,
+        .head = .{ .root = parent_root, .slot = 4 },
+        .target = .{ .root = parent_root, .slot = 4 },
+        .source = .{ .root = types.ZERO_HASH, .slot = justified_slot },
+    };
+    var proof_zs = try types.AggregatedSignatureProof.init(allocator);
+    for (0..@intCast(num_validators)) |i| try types.aggregationBitsSet(&proof_zs.participants, i, true);
+    try beam_chain.forkChoice.storeAggregatedPayload(&att_zero_source, proof_zs, true);
+
+    // Attestation with ZERO_HASH target root — must be rejected.
+    const att_zero_target = types.AttestationData{
+        .slot = proposal_slot - 1,
+        .head = .{ .root = parent_root, .slot = 4 },
+        .target = .{ .root = types.ZERO_HASH, .slot = 4 },
+        .source = .{ .root = justified_root, .slot = justified_slot },
+    };
+    var proof_zt = try types.AggregatedSignatureProof.init(allocator);
+    for (0..@intCast(num_validators)) |i| try types.aggregationBitsSet(&proof_zt.participants, i, true);
+    try beam_chain.forkChoice.storeAggregatedPayload(&att_zero_target, proof_zt, true);
+
+    // Control: a valid attestation that must appear in the block, ensuring the
+    // produced block is non-empty so the negative assertions below are not vacuous.
+    const att_valid = types.AttestationData{
+        .slot = proposal_slot - 1,
+        .head = .{ .root = parent_root, .slot = 4 },
+        .target = .{ .root = parent_root, .slot = 4 },
+        .source = .{ .root = justified_root, .slot = justified_slot },
+    };
+    var proof_valid = try types.AggregatedSignatureProof.init(allocator);
+    for (0..@intCast(num_validators)) |i| try types.aggregationBitsSet(&proof_valid.participants, i, true);
+    try beam_chain.forkChoice.storeAggregatedPayload(&att_valid, proof_valid, true);
+
+    const produced = try beam_chain.produceBlock(.{
+        .slot = proposal_slot,
+        .proposer_index = proposal_slot % num_validators,
+    });
+    defer @constCast(&produced).deinit();
+
+    const atts = produced.block.body.attestations.constSlice();
+    // Control attestation must be present — proves block non-empty.
+    var found_valid = false;
+    for (atts) |att| {
+        if (std.mem.eql(u8, &att.data.source.root, &justified_root) and
+            att.data.source.slot == justified_slot)
+        {
+            found_valid = true;
+        }
+        try std.testing.expect(!std.mem.eql(u8, &att.data.source.root, &types.ZERO_HASH));
+        try std.testing.expect(!std.mem.eql(u8, &att.data.target.root, &types.ZERO_HASH));
+    }
+    try std.testing.expect(found_valid);
+}
+
+test "produceBlock - already-justified target skipped, genesis self-vote exemption (leanSpec #716)" {
+    // Two assertions:
+    //   (a) NEGATIVE: a non-genesis attestation whose target slot is already justified
+    //       must be excluded from the produced block.
+    //   (b) POSITIVE: a genesis self-vote (source.slot==0, target.slot==0) must be
+    //       included even though slot 0 is already justified — the exemption in
+    //       isSlotJustifiedForBuild explicitly allows it for fork-choice bootstrapping.
+    // Both attestations are stored; the test asserts (a) is absent and (b) is present.
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    var fx = try setup716TestChain(allocator, 6);
+    defer {
+        fx.beam_chain.deinit();
+        fx.test_registry.deinit();
+        fx.db.deinit();
+        fx.tmp_dir.cleanup();
+    }
+    const mock_chain = fx.mock_chain;
+    const beam_chain = fx.beam_chain;
+
+    for (1..5) |i| {
+        const signed_block = mock_chain.blocks[i];
+        try beam_chain.forkChoice.onInterval(signed_block.block.slot * constants.INTERVALS_PER_SLOT, false);
+        const missing_roots = try beam_chain.onBlock(signed_block, .{ .pruneForkchoice = false });
+        allocator.free(missing_roots);
+    }
+
+    const justified_cp = mock_chain.latestJustified[4];
+    const justified_slot: types.Slot = justified_cp.slot;
+    const justified_root = justified_cp.root;
+    const proposal_slot: types.Slot = 5;
+    const num_validators: u64 = @intCast(mock_chain.genesis_config.numValidators());
+    const parent_root = mock_chain.blockRoots[4];
+
+    // (a) NEGATIVE: attestation targeting an already-justified slot — must be dropped.
+    const already_justified_slot: types.Slot = justified_slot;
+    const att_already_justified = types.AttestationData{
+        .slot = proposal_slot - 1,
+        .head = .{ .root = parent_root, .slot = 4 },
+        .target = .{ .root = justified_root, .slot = already_justified_slot },
+        .source = .{ .root = mock_chain.blockRoots[1], .slot = 1 },
+    };
+    var proof_aj = try types.AggregatedSignatureProof.init(allocator);
+    for (0..@intCast(num_validators)) |i| try types.aggregationBitsSet(&proof_aj.participants, i, true);
+    try beam_chain.forkChoice.storeAggregatedPayload(&att_already_justified, proof_aj, true);
+
+    // (b) POSITIVE: genesis self-vote — source.slot==0, target.slot==0.
+    // Slot 0 is already justified (finalized genesis slot), but the exemption
+    // must let this through the target-already-justified filter.
+    // historical_block_hashes[0] == blockRoots[0] once block 1 is applied,
+    // so the chain-match check passes too.
+    const genesis_root = mock_chain.blockRoots[0];
+    const att_genesis_self_vote = types.AttestationData{
+        .slot = 0,
+        .head = .{ .root = genesis_root, .slot = 0 },
+        .target = .{ .root = genesis_root, .slot = 0 },
+        .source = .{ .root = genesis_root, .slot = 0 },
+    };
+    var proof_gsv = try types.AggregatedSignatureProof.init(allocator);
+    for (0..@intCast(num_validators)) |i| try types.aggregationBitsSet(&proof_gsv.participants, i, true);
+    try beam_chain.forkChoice.storeAggregatedPayload(&att_genesis_self_vote, proof_gsv, true);
+
+    const produced = try beam_chain.produceBlock(.{
+        .slot = proposal_slot,
+        .proposer_index = proposal_slot % num_validators,
+    });
+    defer @constCast(&produced).deinit();
+
+    const atts = produced.block.body.attestations.constSlice();
+
+    // (a) Negative: already-justified non-genesis target must be absent.
+    for (atts) |att| {
+        const is_genesis_sv = att.data.source.slot == 0 and att.data.target.slot == 0;
+        if (!is_genesis_sv and att.data.target.slot == already_justified_slot) {
+            try std.testing.expect(false); // unreachable: must be filtered
+        }
+    }
+
+    // (b) Positive: the genesis self-vote must appear — this exercises the
+    // positive path of the exemption.
+    var found_genesis_sv = false;
+    for (atts) |att| {
+        if (att.data.source.slot == 0 and att.data.target.slot == 0 and
+            std.mem.eql(u8, &att.data.source.root, &genesis_root) and
+            std.mem.eql(u8, &att.data.target.root, &genesis_root))
+        {
+            found_genesis_sv = true;
+        }
+    }
+    try std.testing.expect(found_genesis_sv);
+}
 test "BorrowedState: cloneAndRelease success path against real BeamState" {
     var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_allocator.deinit();

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -967,7 +967,8 @@ pub const ForkChoice = struct {
     };
 
     /// Checks whether `slot` is justified under the given tracking state,
-    /// matching leanSpec `build_block`'s `current_justified_slots.is_slot_justified`.
+    /// matching leanSpec `build_block`'s `current_justified_slots.is_slot_justified`
+    /// (leanSpec commit 00556d8).
     /// Returns `false` (never an error) when `slot` is beyond the current
     /// justified_slots window — those slots are simply not yet justified.
     /// Slots at or before `finalized_slot` are implicitly justified (return `true`).
@@ -983,6 +984,7 @@ pub const ForkChoice = struct {
         return justified_slots.get(idx) catch false;
     }
 
+    /// Mirrors leanSpec `_attestation_data_matches_chain` (leanSpec commit 00556d8).
     /// Checks whether `att_data`'s source and target roots are consistent with
     /// the *extended* historical block hashes view — i.e. `state.historical_block_hashes`
     /// as it would appear after `process_block_header` on the candidate block:

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -983,9 +983,9 @@ pub const ForkChoice = struct {
         return justified_slots.get(idx) catch false;
     }
 
-    /// Mirror of leanSpec `_attestation_data_matches_chain` using the *extended*
-    /// historical block hashes view — i.e. `state.historical_block_hashes` as it
-    /// would appear after `process_block_header` on the candidate block:
+    /// Checks whether `att_data`'s source and target roots are consistent with
+    /// the *extended* historical block hashes view — i.e. `state.historical_block_hashes`
+    /// as it would appear after `process_block_header` on the candidate block:
     ///
     ///   extended = historical_block_hashes + [parent_root] + [ZERO_HASH] * num_empty_slots
     ///

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -966,6 +966,69 @@ pub const ForkChoice = struct {
         signatures: types.AttestationSignatures,
     };
 
+    /// Checks whether `slot` is justified under the given tracking state,
+    /// matching leanSpec `build_block`'s `current_justified_slots.is_slot_justified`.
+    /// Returns `false` (never an error) when `slot` is beyond the current
+    /// justified_slots window — those slots are simply not yet justified.
+    /// Slots at or before `finalized_slot` are implicitly justified (return `true`).
+    fn isSlotJustifiedForBuild(
+        finalized_slot: types.Slot,
+        justified_slots: *const types.JustifiedSlots,
+        slot: types.Slot,
+    ) bool {
+        if (slot <= finalized_slot) return true;
+        // idx = slot - (finalized_slot + 1)
+        const idx: usize = @intCast(slot - finalized_slot - 1);
+        if (idx >= justified_slots.len()) return false;
+        return justified_slots.get(idx) catch false;
+    }
+
+    /// Mirror of leanSpec `_attestation_data_matches_chain` using the *extended*
+    /// historical block hashes view — i.e. `state.historical_block_hashes` as it
+    /// would appear after `process_block_header` on the candidate block:
+    ///
+    ///   extended = historical_block_hashes + [parent_root] + [ZERO_HASH] * num_empty_slots
+    ///
+    /// Receives the pre-state's `historical_block_hashes` and the candidate
+    /// `parent_root` separately to avoid an allocation; `hist_len` is computed
+    /// internally from the slice length.
+    /// Also rejects attestations whose source or target root is the zero hash.
+    fn attestationDataMatchesChainExtended(
+        historical_block_hashes: *const types.HistoricalBlockHashes,
+        parent_root: [32]u8,
+        att_data: types.AttestationData,
+    ) bool {
+        const ZERO_HASH = types.ZERO_HASH;
+        if (std.mem.eql(u8, &att_data.source.root, &ZERO_HASH)) return false;
+        if (std.mem.eql(u8, &att_data.target.root, &ZERO_HASH)) return false;
+
+        const hist_len: u64 = @intCast(historical_block_hashes.len());
+        const hist_slice = historical_block_hashes.constSlice();
+        const source_slot: u64 = att_data.source.slot;
+        const target_slot: u64 = att_data.target.slot;
+
+        // Resolve a slot index against the extended view:
+        //   [0, hist_len)  → historical_block_hashes[i]
+        //   hist_len       → parent_root (the parent block's slot)
+        //   > hist_len     → ZERO_HASH  (empty slots; will fail equality check)
+        const stored_source: [32]u8 = if (source_slot < hist_len)
+            hist_slice[source_slot]
+        else if (source_slot == hist_len)
+            parent_root
+        else
+            ZERO_HASH;
+
+        const stored_target: [32]u8 = if (target_slot < hist_len)
+            hist_slice[target_slot]
+        else if (target_slot == hist_len)
+            parent_root
+        else
+            ZERO_HASH;
+
+        return std.mem.eql(u8, &att_data.source.root, &stored_source) and
+            std.mem.eql(u8, &att_data.target.root, &stored_target);
+    }
+
     fn getProposalAttestationsUnlocked(
         self: *Self,
         pre_state: *const types.BeamState,
@@ -989,26 +1052,45 @@ pub const ForkChoice = struct {
 
         // Fixed-point attestation collection with greedy proof selection.
         //
-        // For the current latest_justified checkpoint, find matching attestation_data
-        // entries in latest_known_aggregated_payloads and greedily select proofs that
-        // maximize new validator coverage. Then apply STF to check if justification
-        // changed. If it did, look for entries matching the new justified checkpoint
-        // and repeat. If no matching entries exist or justification did not change,
-        // block production is done.
-        // When building on top of genesis (slot 0), process_block_header will
-        // update the justified root to parent_root. Apply the same derivation
-        // here so attestation sources match (leanSpec d0c5030).
-        var current_justified_root = if (pre_state.latest_block_header.slot == 0)
-            parent_root
-        else
-            pre_state.latest_justified.root;
+        // leanSpec `build_block` (commit 00556d8): instead of filtering by a single
+        // justified root, we now accept any attestation whose *source slot* is marked
+        // justified in `current_justified_slots`. This allows older-but-still-justified
+        // sources to appear in a block, not just the latest justified checkpoint.
+        //
+        // The extended historical block hashes view (pre_state hashes + parent_root +
+        // zero-hashes for empty slots) is used to validate source/target roots without
+        // running the full STF first.
+        //
+        // The loop restarts whenever justification OR finalization advances so we can
+        // pick up attestations that become valid only after a justification update.
+        var current_finalized_slot: types.Slot = pre_state.latest_finalized.slot;
+        // Spec note (leanSpec d0c5030 / commit 00556d8): when building on top of genesis
+        // (pre_state.latest_block_header.slot == 0), process_block_header would set
+        // latest_justified.root = parent_root. The old code applied that same derivation
+        // eagerly so the source-root filter matched. With the new slot-based filter we no
+        // longer need the root at all — we only test whether the source *slot* is justified.
+        // At genesis, slot 0 <= finalized_slot 0 so isSlotJustifiedForBuild returns true
+        // unconditionally, which is correct. The one observable difference is that the first
+        // STF run will see justified_changed == true (pre_state has ZERO_HASH root; post-state
+        // has parent_root) and do one extra loop iteration. That iteration finds no new
+        // entries (genesis self-votes are already in processed_att_data) and breaks, so the
+        // output is identical — the extra iteration is intentionally accepted in exchange for
+        // simpler code with no genesis special-case.
+        var current_justified: types.Checkpoint = pre_state.latest_justified;
+
+        // Clone pre_state.justified_slots so we can update it across loop iterations
+        // without touching the immutable pre_state.
+        var current_justified_slots: types.JustifiedSlots = undefined;
+        try types.sszClone(self.allocator, types.JustifiedSlots, pre_state.justified_slots, &current_justified_slots);
+        defer current_justified_slots.deinit();
+
         var processed_att_data = std.AutoHashMap(types.AttestationData, void).init(self.allocator);
         defer processed_att_data.deinit();
 
         while (true) {
-            // Find all attestation_data entries whose source matches the current justified checkpoint
-            // and greedily select proofs maximizing new validator coverage for each.
-            // Collect entries and sort by target slot for deterministic processing order.
+            // Find attestation_data entries whose source slot is justified on this chain,
+            // that reference blocks we know about, and whose target is not yet justified.
+            // Collect and sort by target slot for deterministic processing order.
             const MapEntry = struct {
                 att_data: *types.AttestationData,
                 payloads: *types.AggregatedPayloadsList,
@@ -1018,10 +1100,30 @@ pub const ForkChoice = struct {
 
             var payload_it = self.latest_known_aggregated_payloads.iterator();
             while (payload_it.next()) |entry| {
-                if (!std.mem.eql(u8, &current_justified_root, &entry.key_ptr.source.root)) continue;
-                if (!self.protoArray.indices.contains(entry.key_ptr.head.root)) continue;
-                if (processed_att_data.contains(entry.key_ptr.*)) continue;
-                try sorted_entries.append(self.allocator, .{ .att_data = entry.key_ptr, .payloads = entry.value_ptr });
+                const att_data = entry.key_ptr;
+
+                // Source slot must already be justified on this chain (leanSpec build_block).
+                if (!isSlotJustifiedForBuild(current_finalized_slot, &current_justified_slots, att_data.source.slot)) continue;
+
+                // Source and target roots must match our chain's historical block hashes
+                // (extended to include parent_root and empty-slot zeros up to slot-1).
+                // Also rejects zero-hash source or target roots inline.
+                if (!attestationDataMatchesChainExtended(&pre_state.historical_block_hashes, parent_root, att_data.*)) continue;
+
+                // Skip attestations whose target slot is already justified on this chain,
+                // except for genesis self-votes used for fork-choice bootstrapping.
+                const is_genesis_self_vote = att_data.source.slot == 0 and att_data.target.slot == 0;
+                if (!is_genesis_self_vote and isSlotJustifiedForBuild(current_finalized_slot, &current_justified_slots, att_data.target.slot)) continue;
+
+                if (!self.protoArray.indices.contains(att_data.head.root)) continue;
+                // Spec divergence (intentional): leanSpec removed the processed_att_data
+                // dedup in this commit, relying on a final proof_groups compaction pass.
+                // Zeam keeps it because we compact *inside* the loop and each AttestationData
+                // is processed exactly once per outer iteration. Removing the skip here would
+                // re-select the same entry on loop restarts, producing duplicate attestations
+                // in the candidate without changing the final justified checkpoint.
+                if (processed_att_data.contains(att_data.*)) continue;
+                try sorted_entries.append(self.allocator, .{ .att_data = att_data, .payloads = entry.value_ptr });
             }
 
             std.mem.sort(MapEntry, sorted_entries.items, {}, struct {
@@ -1138,13 +1240,27 @@ pub const ForkChoice = struct {
             try candidate_state.process_slots(self.allocator, slot, self.logger);
             try candidate_state.process_block(self.allocator, candidate_block, self.logger, null);
 
-            if (!std.mem.eql(u8, &candidate_state.latest_justified.root, &current_justified_root)) {
-                // Justification changed - look for entries matching the new checkpoint
-                current_justified_root = candidate_state.latest_justified.root;
+            // Restart if justification or finalization advanced (leanSpec build_block).
+            // When either changes, update all tracking state and re-scan for newly
+            // eligible attestations (older sources whose slots are now justified, or
+            // targets that were previously already-justified but aren't after a finality
+            // shift).
+            const justified_changed = !std.mem.eql(u8, &candidate_state.latest_justified.root, &current_justified.root) or
+                candidate_state.latest_justified.slot != current_justified.slot;
+            const finalized_changed = candidate_state.latest_finalized.slot != current_finalized_slot;
+            if (justified_changed or finalized_changed) {
+                current_justified = candidate_state.latest_justified;
+                current_finalized_slot = candidate_state.latest_finalized.slot;
+                // Swap in the updated justified_slots (clone first so candidate_state
+                // can be safely deinitialized at end of this iteration).
+                var new_justified_slots: types.JustifiedSlots = undefined;
+                try types.sszClone(self.allocator, types.JustifiedSlots, candidate_state.justified_slots, &new_justified_slots);
+                current_justified_slots.deinit();
+                current_justified_slots = new_justified_slots;
                 continue;
             }
 
-            // Justification unchanged or no new entries - block production done
+            // Justification and finalization unchanged - block production done.
             break;
         }
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1033,8 +1033,10 @@ pub const BeamNode = struct {
                                 // fc_initing. Without this branch the node deadlocks: it stays in
                                 // fc_initing because no blocks arrive, and no blocks arrive because
                                 // the sync code skips fc_initing.
-                                // Treat this exactly like behind_peers: if the peer's head is ahead
-                                // of our anchor, request their head block to start the parent chain.
+                                //
+                                // Mirror the behind_peers logic: prefer blocks_by_range for large
+                                // gaps (avoids the one-round-trip-per-block parent-chain walk);
+                                // fall back to head-by-root for small gaps or on range failure.
                                 // Snapshot once: forkChoice.head is a
                                 // multi-field ProtoBlock written under
                                 // exclusive. A second raw read in the log
@@ -1042,21 +1044,49 @@ pub const BeamNode = struct {
                                 // different update's blockRoot.
                                 const head_snapshot = self.chain.forkChoice.getHead();
                                 if (status_resp.head_slot > head_snapshot.slot) {
-                                    self.logger.info("peer {s}{f} is ahead during fc init (peer_head={d} > our_head={d}), requesting head block 0x{x}", .{
-                                        status_ctx.peer_id,
-                                        self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
-                                        status_resp.head_slot,
-                                        head_snapshot.slot,
-                                        &status_resp.head_root,
-                                    });
-                                    const roots = [_]types.Root{status_resp.head_root};
-                                    self.fetchBlockByRoots(&roots, 0) catch |err| {
-                                        self.logger.warn("failed to initiate sync from peer {s}{f} during fc init: {any}", .{
+                                    const gap: u64 = status_resp.head_slot - head_snapshot.slot;
+                                    if (gap > constants.BLOCKS_BY_RANGE_SYNC_THRESHOLD) {
+                                        const start_slot: types.Slot = head_snapshot.slot + 1;
+                                        const requested_count: u64 = @min(gap, params.MAX_REQUEST_BLOCKS);
+                                        self.logger.info("peer {s}{f} is ahead during fc init by {d} slots, bulk-syncing via blocks_by_range start_slot={d} count={d}", .{
                                             status_ctx.peer_id,
                                             self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
-                                            err,
+                                            gap,
+                                            start_slot,
+                                            requested_count,
                                         });
-                                    };
+                                        const handler = networks.OnReqRespResponseCbHandler{
+                                            .ptr = self,
+                                            .onReqRespResponseCb = onReqRespResponse,
+                                        };
+                                        _ = self.network.sendBlocksByRangeRequest(status_ctx.peer_id, start_slot, requested_count, handler) catch |err| {
+                                            self.logger.warn("fc_initing: blocks_by_range from peer {s}{f} failed: {any}; falling back to head-by-root", .{
+                                                status_ctx.peer_id,
+                                                self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
+                                                err,
+                                            });
+                                            const roots = [_]types.Root{status_resp.head_root};
+                                            self.fetchBlockByRoots(&roots, 0) catch |fetch_err| {
+                                                self.logger.warn("fc_initing: fallback head-by-root also failed: {any}", .{fetch_err});
+                                            };
+                                        };
+                                    } else {
+                                        self.logger.info("peer {s}{f} is ahead during fc init (peer_head={d} > our_head={d}), requesting head block 0x{x}", .{
+                                            status_ctx.peer_id,
+                                            self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
+                                            status_resp.head_slot,
+                                            head_snapshot.slot,
+                                            &status_resp.head_root,
+                                        });
+                                        const roots = [_]types.Root{status_resp.head_root};
+                                        self.fetchBlockByRoots(&roots, 0) catch |err| {
+                                            self.logger.warn("failed to initiate sync from peer {s}{f} during fc init: {any}", .{
+                                                status_ctx.peer_id,
+                                                self.node_registry.getNodeNameFromPeerId(status_ctx.peer_id),
+                                                err,
+                                            });
+                                        };
+                                    }
                                 }
                             },
                             .synced, .no_peers => {},
@@ -1117,6 +1147,15 @@ pub const BeamNode = struct {
                             err_payload.code,
                             err_payload.message,
                         });
+                        // Failure means the peer did not serve any of the
+                        // requested roots. Collect them for retry BEFORE
+                        // finalizePendingRequest removes them from
+                        // pending_block_roots so a different peer can
+                        // serve them. Without this, a failed request
+                        // permanently stalls the parent-chain walk used
+                        // during fc_initing / behind_peers sync.
+                        self.retryUnservedBlockRoots(request_id, snap.requested_roots_copy, peer_id);
+                        return;
                     },
                     .blocks_by_range => {
                         self.logger.warn("blocks-by-range request to peer {s}{f} failed ({d}): {s}", .{
@@ -1130,6 +1169,17 @@ pub const BeamNode = struct {
                 self.network.finalizePendingRequest(request_id);
             },
             .completed => {
+                // For blocks_by_root requests: detect roots that were not
+                // served by any chunk (still in pending_block_roots after
+                // all chunks arrived) and re-schedule them with a new
+                // peer. Without this, a peer that returns EOS without
+                // fulfilling all requested roots (e.g., a mesh helper
+                // with head_slot=0) permanently stalls the parent-chain
+                // walk used during fc_initing / behind_peers sync.
+                if (snap.request_kind == .blocks_by_root) {
+                    self.retryUnservedBlockRoots(request_id, snap.requested_roots_copy, peer_id);
+                    return;
+                }
                 self.network.finalizePendingRequest(request_id);
             },
         }
@@ -1814,6 +1864,56 @@ pub const BeamNode = struct {
                     self.node_registry.getNodeNameFromPeerId(peer_id),
                     err,
                 });
+            };
+        }
+    }
+
+    /// Collect `blocks_by_root` roots that were NOT served by any chunk
+    /// (still present in `pending_block_roots` when the request ends),
+    /// finalize the request, then re-schedule each unserved root via
+    /// `fetchBlockByRoots` so a new (hopefully different) peer can serve
+    /// it.
+    ///
+    /// Called from the `.completed` and `.failure` arms of
+    /// `handleReqRespResponse` for `blocks_by_root` requests.
+    /// Without this, a peer that returns EOS or a protocol error without
+    /// serving one or more of the requested roots permanently removes
+    /// those roots from `pending_block_roots` (via `finalizePendingRequest`)
+    /// and leaves the parent-chain-walk orphaned — the cached child
+    /// blocks sit in `block_cache` forever waiting for a parent nobody
+    /// fetches again. This manifests as a sync stall during `fc_initing`
+    /// when one of the two connected peers has `head_slot=0` and the
+    /// random peer selector (`selectPeerCopy`) occasionally routes a
+    /// parent-chain fetch to it.
+    fn retryUnservedBlockRoots(
+        self: *Self,
+        request_id: u64,
+        requested_roots: []const types.Root,
+        peer_id: []const u8,
+    ) void {
+        // Collect roots still in pending_block_roots (unserved) BEFORE
+        // finalizePendingRequest removes them.
+        var roots_to_retry: std.ArrayListUnmanaged(struct { root: types.Root, depth: u32 }) = .empty;
+        defer roots_to_retry.deinit(self.allocator);
+        for (requested_roots) |root| {
+            if (self.network.getPendingBlockRootDepth(root)) |depth| {
+                roots_to_retry.append(self.allocator, .{ .root = root, .depth = depth }) catch {};
+            }
+        }
+        if (roots_to_retry.items.len > 0) {
+            self.logger.warn(
+                "blocks-by-root request_id={d} from peer {s}: {d}/{d} root(s) unserved — scheduling retry via new peer",
+                .{ request_id, peer_id, roots_to_retry.items.len, requested_roots.len },
+            );
+        }
+        // Finalize clears pending state + releases in-flight slot.
+        self.network.finalizePendingRequest(request_id);
+        // Re-schedule each unserved root; fetchBlockByRoots will
+        // dedup against forkchoice/cache/pending and pick a new peer.
+        for (roots_to_retry.items) |item| {
+            const single = [_]types.Root{item.root};
+            self.fetchBlockByRoots(&single, item.depth) catch |err| {
+                self.logger.warn("retryUnservedBlockRoots: failed to re-fetch root after unserved EOS/failure: {any}", .{err});
             };
         }
     }


### PR DESCRIPTION
## Root cause

Hive test-285 failure: **sync: checkpoint sync fresh start** (`zeam_devnet4`).

The node checkpoint-synced to slot 17 (`fc_initing`). To exit `fc_initing` it must import blocks beyond the anchor until a new justified checkpoint is observed. With two connected peers — one at `head_slot=23+` (LeanSpec helper) and one at `head_slot=0` (a mesh node with no blocks) — every `blocks_by_root` parent-chain fetch used **random peer selection**.

When the `head_slot=0` peer was selected (50% per hop), it responded with **EOS and zero chunks**. The `.completed` handler called `finalizePendingRequest` which cleared the unserved root from `pending_block_roots` — but **triggered no retry**. The cached child blocks (slots 23, 22, …) sat in `block_cache` forever waiting for a parent nobody would fetch again. The node stayed at `head_slot=17` for all 180 s until hive declared failure.

`sweepTimedOutRequests` (the existing 8-second timeout retry) does **not** help here: EOS triggers `.completed` which immediately removes the request from `pending_rpc_requests`, so the sweep never sees it.

## Fixes

### 1. `retryUnservedBlockRoots` (primary fix)

New helper called from both `.completed` and `.failure` arms of `handleReqRespResponse` for `blocks_by_root` requests.

- Collects roots still in `pending_block_roots` (not served by any prior chunk) **before** `finalizePendingRequest` removes them.
- After finalize, re-schedules each unserved root via `fetchBlockByRoots` so a new (hopefully different) peer can serve it.
- Logs `"N/M root(s) unserved — scheduling retry"` at `warn` so the event is visible in hive logs without dashboard access.

Covers both the `head_slot=0` EOS case (`.completed`) and explicit protocol failures (`.failure`).

### 2. `blocks_by_range` in `fc_initing` status handler

Mirrors the existing `behind_peers` bulk-sync logic. When `peer_head_slot - our_head_slot > BLOCKS_BY_RANGE_SYNC_THRESHOLD` (64), uses `blocks_by_range` instead of the one-round-trip-per-block by-root parent-chain walk. Falls back to head-by-root on range failure.

For test-285 (gap ≈ 6 slots) this path is not taken — fix #1 is what resolves the failure — but it future-proofs large checkpoint gaps.

## Verification

- `zig build` → clean
- `zig build test --summary all` → **152/152 pass**

Related: hive suite `1778885677-b3fb0130e67f50133988c623e23c2ceb`, test-285.