### PR TITLE
Label aggregate coverage metrics by slot and subnet

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -121,10 +121,10 @@ const Metrics = struct {
     // Attestation aggregate coverage gauges. Section labels are the same
     // names printed in the slot/report logs: timely, late, block, combined,
     // agg_start_new, proposal_payloads, proposal_gossip, and proposal_combined.
-    // Slot labels identify the slot the coverage describes, not the scrape slot.
     // `subnet="combined"` is the all-subnet validator total for the section;
     // `subnet="subnet_N"` is that section's validator coverage on one subnet.
     // Direction labels are block_only and timely_only.
+    // Slot is the X-axis (time series progression), not a label dimension.
     zeam_attestation_aggregate_coverage_validators: AttestationAggregateCoverageValidatorsGauge,
     zeam_attestation_aggregate_coverage_subnets: AttestationAggregateCoverageSubnetsGauge,
     zeam_attestation_aggregate_coverage_diff_validators: AttestationAggregateCoverageDiffValidatorsGauge,
@@ -439,9 +439,9 @@ const Metrics = struct {
     const LeanGossipSignaturesGauge = metrics_lib.Gauge(u64);
     const LeanLatestNewAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
     const LeanLatestKnownAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
-    const AttestationAggregateCoverageValidatorsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8, slot: u64, subnet: []const u8 });
-    const AttestationAggregateCoverageSubnetsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8, slot: u64 });
-    const AttestationAggregateCoverageDiffValidatorsGauge = metrics_lib.GaugeVec(u64, struct { slot: u64, direction: []const u8 });
+    const AttestationAggregateCoverageValidatorsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8, subnet: []const u8 });
+    const AttestationAggregateCoverageSubnetsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8 });
+    const AttestationAggregateCoverageDiffValidatorsGauge = metrics_lib.GaugeVec(u64, struct { direction: []const u8 });
     // Committee aggregation histogram type
     // Buckets widened for Devnet-4: was [0.005..1], now [0.05..4]
     const CommitteeSignaturesAggregationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
@@ -880,9 +880,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_gossip_signatures = Metrics.LeanGossipSignaturesGauge.init("lean_gossip_signatures", .{ .help = "Number of gossip signatures in fork-choice store" }, .{}),
         .lean_latest_new_aggregated_payloads = Metrics.LeanLatestNewAggregatedPayloadsGauge.init("lean_latest_new_aggregated_payloads", .{ .help = "Number of new aggregated payload items" }, .{}),
         .lean_latest_known_aggregated_payloads = Metrics.LeanLatestKnownAggregatedPayloadsGauge.init("lean_latest_known_aggregated_payloads", .{ .help = "Number of known aggregated payload items" }, .{}),
-        .zeam_attestation_aggregate_coverage_validators = try Metrics.AttestationAggregateCoverageValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_validators", .{ .help = "Validator coverage in attestation aggregate reports, labeled by section, slot, and subnet. subnet=combined is the section total; subnet=subnet_N is per-subnet coverage." }, .{}),
-        .zeam_attestation_aggregate_coverage_subnets = try Metrics.AttestationAggregateCoverageSubnetsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_subnets", .{ .help = "Number of covered subnets in attestation aggregate reports, labeled by section and slot." }, .{}),
-        .zeam_attestation_aggregate_coverage_diff_validators = try Metrics.AttestationAggregateCoverageDiffValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_diff_validators", .{ .help = "Validator coverage delta between block payloads and timely pre-merge payloads, labeled by slot and direction (block_only|timely_only)." }, .{}),
+        .zeam_attestation_aggregate_coverage_validators = try Metrics.AttestationAggregateCoverageValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_validators", .{ .help = "Validator coverage in attestation aggregate reports, labeled by section and subnet. subnet=combined is the section total; subnet=subnet_N is per-subnet coverage. Updated each slot (slot is the X-axis)." }, .{}),
+        .zeam_attestation_aggregate_coverage_subnets = try Metrics.AttestationAggregateCoverageSubnetsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_subnets", .{ .help = "Number of covered subnets in attestation aggregate reports, labeled by section. Updated each slot (slot is the X-axis)." }, .{}),
+        .zeam_attestation_aggregate_coverage_diff_validators = try Metrics.AttestationAggregateCoverageDiffValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_diff_validators", .{ .help = "Validator coverage delta between block payloads and timely pre-merge payloads, labeled by direction (block_only|timely_only). Updated each slot (slot is the X-axis)." }, .{}),
         // Committee aggregation histogram
         .lean_committee_signatures_aggregation_time_seconds = Metrics.CommitteeSignaturesAggregationHistogram.init("lean_committee_signatures_aggregation_time_seconds", .{ .help = "Time taken to aggregate committee signatures" }, .{}),
         // Validator status gauges
@@ -958,24 +958,24 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics.lean_gossip_signatures.set(0);
     metrics.lean_latest_new_aggregated_payloads.set(0);
     metrics.lean_latest_known_aggregated_payloads.set(0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "timely", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "late", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "block", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "combined", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "agg_start_new", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_payloads", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_gossip", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_combined", .slot = 0, .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "timely", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "late", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "block", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "combined", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "agg_start_new", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_payloads", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_gossip", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_combined", .slot = 0 }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = 0, .direction = "block_only" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = 0, .direction = "timely_only" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "timely", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "late", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "block", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "combined", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "agg_start_new", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_payloads", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_gossip", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_combined", .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "timely" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "late" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "block" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "agg_start_new" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_payloads" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_gossip" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, 0);
 
     // Set context for histogram wrappers (observe functions already assigned at compile time)
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -121,6 +121,9 @@ const Metrics = struct {
     // Attestation aggregate coverage gauges. Section labels are the same
     // names printed in the slot/report logs: timely, late, block, combined,
     // agg_start_new, proposal_payloads, proposal_gossip, and proposal_combined.
+    // Slot labels identify the slot the coverage describes, not the scrape slot.
+    // `subnet="combined"` is the all-subnet validator total for the section;
+    // `subnet="subnet_N"` is that section's validator coverage on one subnet.
     // Direction labels are block_only and timely_only.
     zeam_attestation_aggregate_coverage_validators: AttestationAggregateCoverageValidatorsGauge,
     zeam_attestation_aggregate_coverage_subnets: AttestationAggregateCoverageSubnetsGauge,
@@ -436,9 +439,9 @@ const Metrics = struct {
     const LeanGossipSignaturesGauge = metrics_lib.Gauge(u64);
     const LeanLatestNewAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
     const LeanLatestKnownAggregatedPayloadsGauge = metrics_lib.Gauge(u64);
-    const AttestationAggregateCoverageValidatorsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8 });
-    const AttestationAggregateCoverageSubnetsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8 });
-    const AttestationAggregateCoverageDiffValidatorsGauge = metrics_lib.GaugeVec(u64, struct { direction: []const u8 });
+    const AttestationAggregateCoverageValidatorsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8, slot: u64, subnet: []const u8 });
+    const AttestationAggregateCoverageSubnetsGauge = metrics_lib.GaugeVec(u64, struct { section: []const u8, slot: u64 });
+    const AttestationAggregateCoverageDiffValidatorsGauge = metrics_lib.GaugeVec(u64, struct { slot: u64, direction: []const u8 });
     // Committee aggregation histogram type
     // Buckets widened for Devnet-4: was [0.005..1], now [0.05..4]
     const CommitteeSignaturesAggregationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
@@ -877,9 +880,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_gossip_signatures = Metrics.LeanGossipSignaturesGauge.init("lean_gossip_signatures", .{ .help = "Number of gossip signatures in fork-choice store" }, .{}),
         .lean_latest_new_aggregated_payloads = Metrics.LeanLatestNewAggregatedPayloadsGauge.init("lean_latest_new_aggregated_payloads", .{ .help = "Number of new aggregated payload items" }, .{}),
         .lean_latest_known_aggregated_payloads = Metrics.LeanLatestKnownAggregatedPayloadsGauge.init("lean_latest_known_aggregated_payloads", .{ .help = "Number of known aggregated payload items" }, .{}),
-        .zeam_attestation_aggregate_coverage_validators = try Metrics.AttestationAggregateCoverageValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_validators", .{ .help = "Validator coverage in attestation aggregate reports, labeled by section (timely|late|block|combined|agg_start_new|proposal_payloads|proposal_gossip|proposal_combined)." }, .{}),
-        .zeam_attestation_aggregate_coverage_subnets = try Metrics.AttestationAggregateCoverageSubnetsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_subnets", .{ .help = "Subnet coverage in attestation aggregate reports, labeled by section (timely|late|block|combined|agg_start_new|proposal_payloads|proposal_gossip|proposal_combined)." }, .{}),
-        .zeam_attestation_aggregate_coverage_diff_validators = try Metrics.AttestationAggregateCoverageDiffValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_diff_validators", .{ .help = "Validator coverage delta between block payloads and timely pre-merge payloads, labeled by direction (block_only|timely_only)." }, .{}),
+        .zeam_attestation_aggregate_coverage_validators = try Metrics.AttestationAggregateCoverageValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_validators", .{ .help = "Validator coverage in attestation aggregate reports, labeled by section, slot, and subnet. subnet=combined is the section total; subnet=subnet_N is per-subnet coverage." }, .{}),
+        .zeam_attestation_aggregate_coverage_subnets = try Metrics.AttestationAggregateCoverageSubnetsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_subnets", .{ .help = "Number of covered subnets in attestation aggregate reports, labeled by section and slot." }, .{}),
+        .zeam_attestation_aggregate_coverage_diff_validators = try Metrics.AttestationAggregateCoverageDiffValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_diff_validators", .{ .help = "Validator coverage delta between block payloads and timely pre-merge payloads, labeled by slot and direction (block_only|timely_only)." }, .{}),
         // Committee aggregation histogram
         .lean_committee_signatures_aggregation_time_seconds = Metrics.CommitteeSignaturesAggregationHistogram.init("lean_committee_signatures_aggregation_time_seconds", .{ .help = "Time taken to aggregate committee signatures" }, .{}),
         // Validator status gauges
@@ -955,24 +958,24 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics.lean_gossip_signatures.set(0);
     metrics.lean_latest_new_aggregated_payloads.set(0);
     metrics.lean_latest_known_aggregated_payloads.set(0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "timely" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "late" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "block" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "agg_start_new" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_payloads" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_gossip" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "timely" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "late" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "block" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "agg_start_new" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_payloads" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_gossip" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "timely", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "late", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "block", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "combined", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "agg_start_new", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_payloads", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_gossip", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_combined", .slot = 0, .subnet = "combined" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "timely", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "late", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "block", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "combined", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "agg_start_new", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_payloads", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_gossip", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_combined", .slot = 0 }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = 0, .direction = "block_only" }, 0);
+    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = 0, .direction = "timely_only" }, 0);
 
     // Set context for histogram wrappers (observe functions already assigned at compile time)
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -130,9 +130,9 @@ const Metrics = struct {
     // `subnet="subnet_N"` is that section's validator coverage on one subnet.
     // Direction labels are block_only and timely_only.
     // Slot is the X-axis (time series progression), not a label dimension.
-    zeam_attestation_aggregate_coverage_validators: AttestationAggregateCoverageValidatorsGauge,
-    zeam_attestation_aggregate_coverage_subnets: AttestationAggregateCoverageSubnetsGauge,
-    zeam_attestation_aggregate_coverage_diff_validators: AttestationAggregateCoverageDiffValidatorsGauge,
+    lean_attestation_aggregate_coverage_validators: AttestationAggregateCoverageValidatorsGauge,
+    lean_attestation_aggregate_coverage_subnets: AttestationAggregateCoverageSubnetsGauge,
+    lean_attestation_aggregate_coverage_diff_validators: AttestationAggregateCoverageDiffValidatorsGauge,
     // Committee aggregation histogram
     lean_committee_signatures_aggregation_time_seconds: CommitteeSignaturesAggregationHistogram,
     // Validator status gauges
@@ -890,9 +890,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_gossip_signatures = Metrics.LeanGossipSignaturesGauge.init("lean_gossip_signatures", .{ .help = "Number of gossip signatures in fork-choice store" }, .{}),
         .lean_latest_new_aggregated_payloads = Metrics.LeanLatestNewAggregatedPayloadsGauge.init("lean_latest_new_aggregated_payloads", .{ .help = "Number of new aggregated payload items" }, .{}),
         .lean_latest_known_aggregated_payloads = Metrics.LeanLatestKnownAggregatedPayloadsGauge.init("lean_latest_known_aggregated_payloads", .{ .help = "Number of known aggregated payload items" }, .{}),
-        .zeam_attestation_aggregate_coverage_validators = try Metrics.AttestationAggregateCoverageValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_validators", .{ .help = "Validator coverage in attestation aggregate reports, labeled by section and subnet. subnet=combined is the section total; subnet=subnet_N is per-subnet coverage. Updated each slot (slot is the X-axis)." }, .{}),
-        .zeam_attestation_aggregate_coverage_subnets = try Metrics.AttestationAggregateCoverageSubnetsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_subnets", .{ .help = "Number of covered subnets in attestation aggregate reports, labeled by section. Updated each slot (slot is the X-axis)." }, .{}),
-        .zeam_attestation_aggregate_coverage_diff_validators = try Metrics.AttestationAggregateCoverageDiffValidatorsGauge.init(allocator, io, "zeam_attestation_aggregate_coverage_diff_validators", .{ .help = "Validator coverage delta between block payloads and timely pre-merge payloads, labeled by direction (block_only|timely_only). Updated each slot (slot is the X-axis)." }, .{}),
+        .lean_attestation_aggregate_coverage_validators = try Metrics.AttestationAggregateCoverageValidatorsGauge.init(allocator, io, "lean_attestation_aggregate_coverage_validators", .{ .help = "Validator coverage in attestation aggregate reports, labeled by section and subnet. subnet=combined is the section total; subnet=subnet_N is per-subnet coverage. Updated each slot (slot is the X-axis)." }, .{}),
+        .lean_attestation_aggregate_coverage_subnets = try Metrics.AttestationAggregateCoverageSubnetsGauge.init(allocator, io, "lean_attestation_aggregate_coverage_subnets", .{ .help = "Number of covered subnets in attestation aggregate reports, labeled by section. Updated each slot (slot is the X-axis)." }, .{}),
+        .lean_attestation_aggregate_coverage_diff_validators = try Metrics.AttestationAggregateCoverageDiffValidatorsGauge.init(allocator, io, "lean_attestation_aggregate_coverage_diff_validators", .{ .help = "Validator coverage delta between block payloads and timely pre-merge payloads, labeled by direction (block_only|timely_only). Updated each slot (slot is the X-axis)." }, .{}),
         // Committee aggregation histogram
         .lean_committee_signatures_aggregation_time_seconds = Metrics.CommitteeSignaturesAggregationHistogram.init("lean_committee_signatures_aggregation_time_seconds", .{ .help = "Time taken to aggregate committee signatures" }, .{}),
         // Validator status gauges
@@ -969,24 +969,24 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics.lean_gossip_signatures.set(0);
     metrics.lean_latest_new_aggregated_payloads.set(0);
     metrics.lean_latest_known_aggregated_payloads.set(0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "timely", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "late", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "block", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "combined", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "agg_start_new", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_payloads", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_gossip", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_combined", .subnet = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "timely" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "late" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "block" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "agg_start_new" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_payloads" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_gossip" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_combined" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, 0);
-    try metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "timely", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "late", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "block", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "combined", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "agg_start_new", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_payloads", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_gossip", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "proposal_combined", .subnet = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "timely" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "late" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "block" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "agg_start_new" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_payloads" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_gossip" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "proposal_combined" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, 0);
+    try metrics.lean_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, 0);
 
     // Set context for histogram wrappers (observe functions already assigned at compile time)
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
@@ -1374,6 +1374,33 @@ test "slice (d)/(e) #803: fetch-dedup + root-compute-skipped counters appear in 
     for (fetch_outcomes) |lbl| {
         try testing.expect(std.mem.indexOf(u8, body, lbl) != null);
     }
+}
+
+test "attestation aggregate coverage metrics use leanSpec names" {
+    if (isZKVM()) return;
+
+    try init(std.heap.page_allocator);
+
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "timely", .subnet = "combined" }, 42);
+    try metrics.lean_attestation_aggregate_coverage_validators.set(.{ .section = "block", .subnet = "subnet_0" }, 7);
+    try metrics.lean_attestation_aggregate_coverage_subnets.set(.{ .section = "timely" }, 3);
+    try metrics.lean_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, 5);
+    try metrics.lean_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, 2);
+
+    var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer.deinit();
+    try writeMetrics(&alloc_writer.writer);
+    const body = alloc_writer.writer.buffered();
+
+    try testing.expect(std.mem.indexOf(u8, body, "lean_attestation_aggregate_coverage_validators") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "lean_attestation_aggregate_coverage_subnets") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "lean_attestation_aggregate_coverage_diff_validators") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_attestation_aggregate_coverage") == null);
+    try testing.expect(std.mem.indexOf(u8, body, "section=\"timely\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "subnet=\"combined\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "subnet=\"subnet_0\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "direction=\"block_only\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "direction=\"timely_only\"") != null);
 }
 
 // Issues #863 / #867: clock-loop xev drain observability must stay in the

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1407,9 +1407,9 @@ pub const ForkChoice = struct {
             }
         }
 
-        recordAggregateCoverageMetrics("proposal_payloads", proposal_payload_seen, proposal_payload_has_subnet);
-        recordAggregateCoverageMetrics("proposal_gossip", proposal_gossip_seen, proposal_gossip_has_subnet);
-        recordAggregateCoverageMetrics("proposal_combined", final_seen, final_has_subnet);
+        recordAggregateCoverageMetrics("proposal_payloads", slot, proposal_payload_seen, proposal_payload_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("proposal_gossip", slot, proposal_gossip_seen, proposal_gossip_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("proposal_combined", slot, final_seen, final_has_subnet, committee_count_u32);
 
         if (!has_any) {
             self.logger.info("block proposal slot={d}: attestation aggregate coverage=none", .{slot});
@@ -1871,12 +1871,12 @@ pub const ForkChoice = struct {
             if (pn and !b) prev_new_not_block += 1;
         }
 
-        recordAggregateCoverageMetrics("timely", prev_new_seen, prev_new_has_subnet);
-        recordAggregateCoverageMetrics("late", late_seen, late_has_subnet);
-        recordAggregateCoverageMetrics("block", block_seen, block_has_subnet);
-        recordAggregateCoverageMetrics("combined", combined_seen, combined_has_subnet);
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, @intCast(block_not_prev_new)) catch {};
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, @intCast(prev_new_not_block)) catch {};
+        recordAggregateCoverageMetrics("timely", slot, prev_new_seen, prev_new_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("late", slot, late_seen, late_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("block", slot, block_seen, block_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("combined", slot, combined_seen, combined_has_subnet, committee_count_u32);
+        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = slot, .direction = "block_only" }, @intCast(block_not_prev_new)) catch {};
+        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = slot, .direction = "timely_only" }, @intCast(prev_new_not_block)) catch {};
 
         var out: std.ArrayList(u8) = .empty;
         errdefer out.deinit(allocator);
@@ -1942,12 +1942,12 @@ pub const ForkChoice = struct {
         }
 
         if (!has_any) {
-            recordAggregateCoverageMetrics("agg_start_new", new_seen, new_has_subnet);
+            recordAggregateCoverageMetrics("agg_start_new", slot, new_seen, new_has_subnet, committee_count_u32);
             self.logger.info("agg start slot={d}: new payloads coverage=none", .{slot});
             return;
         }
 
-        recordAggregateCoverageMetrics("agg_start_new", new_seen, new_has_subnet);
+        recordAggregateCoverageMetrics("agg_start_new", slot, new_seen, new_has_subnet, committee_count_u32);
 
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(self.allocator);
@@ -3792,15 +3792,30 @@ fn countSeen(seen: []const bool) usize {
     return count;
 }
 
-fn recordAggregateCoverageMetrics(section: []const u8, seen: []const bool, has_subnet: []const bool) void {
+fn recordAggregateCoverageMetrics(
+    section: []const u8,
+    slot: types.Slot,
+    seen: []const bool,
+    has_subnet: []const bool,
+    committee_count: types.SubnetId,
+) void {
     zeam_metrics.metrics.zeam_attestation_aggregate_coverage_validators.set(
-        .{ .section = section },
+        .{ .section = section, .slot = slot, .subnet = "combined" },
         @intCast(countSeen(seen)),
     ) catch {};
     zeam_metrics.metrics.zeam_attestation_aggregate_coverage_subnets.set(
-        .{ .section = section },
+        .{ .section = section, .slot = slot },
         @intCast(countSeen(has_subnet)),
     ) catch {};
+
+    for (has_subnet, 0..) |_, subnet_index| {
+        var subnet_label_buf: [32]u8 = undefined;
+        const subnet_label = std.fmt.bufPrint(&subnet_label_buf, "subnet_{d}", .{subnet_index}) catch continue;
+        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_validators.set(
+            .{ .section = section, .slot = slot, .subnet = subnet_label },
+            @intCast(countSubnetSeen(seen, @intCast(subnet_index), committee_count)),
+        ) catch {};
+    }
 }
 
 fn countSubnetSeen(seen: []const bool, subnet_id: types.SubnetId, committee_count: types.SubnetId) usize {

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1407,9 +1407,9 @@ pub const ForkChoice = struct {
             }
         }
 
-        recordAggregateCoverageMetrics("proposal_payloads", slot, proposal_payload_seen, proposal_payload_has_subnet, committee_count_u32);
-        recordAggregateCoverageMetrics("proposal_gossip", slot, proposal_gossip_seen, proposal_gossip_has_subnet, committee_count_u32);
-        recordAggregateCoverageMetrics("proposal_combined", slot, final_seen, final_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("proposal_payloads", proposal_payload_seen, proposal_payload_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("proposal_gossip", proposal_gossip_seen, proposal_gossip_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("proposal_combined", final_seen, final_has_subnet, committee_count_u32);
 
         if (!has_any) {
             self.logger.info("block proposal slot={d}: attestation aggregate coverage=none", .{slot});
@@ -1871,12 +1871,12 @@ pub const ForkChoice = struct {
             if (pn and !b) prev_new_not_block += 1;
         }
 
-        recordAggregateCoverageMetrics("timely", slot, prev_new_seen, prev_new_has_subnet, committee_count_u32);
-        recordAggregateCoverageMetrics("late", slot, late_seen, late_has_subnet, committee_count_u32);
-        recordAggregateCoverageMetrics("block", slot, block_seen, block_has_subnet, committee_count_u32);
-        recordAggregateCoverageMetrics("combined", slot, combined_seen, combined_has_subnet, committee_count_u32);
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = slot, .direction = "block_only" }, @intCast(block_not_prev_new)) catch {};
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .slot = slot, .direction = "timely_only" }, @intCast(prev_new_not_block)) catch {};
+        recordAggregateCoverageMetrics("timely", prev_new_seen, prev_new_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("late", late_seen, late_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("block", block_seen, block_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("combined", combined_seen, combined_has_subnet, committee_count_u32);
+        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, @intCast(block_not_prev_new)) catch {};
+        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, @intCast(prev_new_not_block)) catch {};
 
         var out: std.ArrayList(u8) = .empty;
         errdefer out.deinit(allocator);
@@ -1942,12 +1942,12 @@ pub const ForkChoice = struct {
         }
 
         if (!has_any) {
-            recordAggregateCoverageMetrics("agg_start_new", slot, new_seen, new_has_subnet, committee_count_u32);
+            recordAggregateCoverageMetrics("agg_start_new", new_seen, new_has_subnet, committee_count_u32);
             self.logger.info("agg start slot={d}: new payloads coverage=none", .{slot});
             return;
         }
 
-        recordAggregateCoverageMetrics("agg_start_new", slot, new_seen, new_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("agg_start_new", new_seen, new_has_subnet, committee_count_u32);
 
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(self.allocator);
@@ -3794,17 +3794,16 @@ fn countSeen(seen: []const bool) usize {
 
 fn recordAggregateCoverageMetrics(
     section: []const u8,
-    slot: types.Slot,
     seen: []const bool,
     has_subnet: []const bool,
     committee_count: types.SubnetId,
 ) void {
     zeam_metrics.metrics.zeam_attestation_aggregate_coverage_validators.set(
-        .{ .section = section, .slot = slot, .subnet = "combined" },
+        .{ .section = section, .subnet = "combined" },
         @intCast(countSeen(seen)),
     ) catch {};
     zeam_metrics.metrics.zeam_attestation_aggregate_coverage_subnets.set(
-        .{ .section = section, .slot = slot },
+        .{ .section = section },
         @intCast(countSeen(has_subnet)),
     ) catch {};
 
@@ -3812,7 +3811,7 @@ fn recordAggregateCoverageMetrics(
         var subnet_label_buf: [32]u8 = undefined;
         const subnet_label = std.fmt.bufPrint(&subnet_label_buf, "subnet_{d}", .{subnet_index}) catch continue;
         zeam_metrics.metrics.zeam_attestation_aggregate_coverage_validators.set(
-            .{ .section = section, .slot = slot, .subnet = subnet_label },
+            .{ .section = section, .subnet = subnet_label },
             @intCast(countSubnetSeen(seen, @intCast(subnet_index), committee_count)),
         ) catch {};
     }

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1875,8 +1875,8 @@ pub const ForkChoice = struct {
         recordAggregateCoverageMetrics("late", late_seen, late_has_subnet, committee_count_u32);
         recordAggregateCoverageMetrics("block", block_seen, block_has_subnet, committee_count_u32);
         recordAggregateCoverageMetrics("combined", combined_seen, combined_has_subnet, committee_count_u32);
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, @intCast(block_not_prev_new)) catch {};
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, @intCast(prev_new_not_block)) catch {};
+        zeam_metrics.metrics.lean_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "block_only" }, @intCast(block_not_prev_new)) catch {};
+        zeam_metrics.metrics.lean_attestation_aggregate_coverage_diff_validators.set(.{ .direction = "timely_only" }, @intCast(prev_new_not_block)) catch {};
 
         var out: std.ArrayList(u8) = .empty;
         errdefer out.deinit(allocator);
@@ -3841,11 +3841,11 @@ fn recordAggregateCoverageMetrics(
     has_subnet: []const bool,
     committee_count: types.SubnetId,
 ) void {
-    zeam_metrics.metrics.zeam_attestation_aggregate_coverage_validators.set(
+    zeam_metrics.metrics.lean_attestation_aggregate_coverage_validators.set(
         .{ .section = section, .subnet = "combined" },
         @intCast(countSeen(seen)),
     ) catch {};
-    zeam_metrics.metrics.zeam_attestation_aggregate_coverage_subnets.set(
+    zeam_metrics.metrics.lean_attestation_aggregate_coverage_subnets.set(
         .{ .section = section },
         @intCast(countSeen(has_subnet)),
     ) catch {};
@@ -3853,7 +3853,7 @@ fn recordAggregateCoverageMetrics(
     for (has_subnet, 0..) |_, subnet_index| {
         var subnet_label_buf: [32]u8 = undefined;
         const subnet_label = std.fmt.bufPrint(&subnet_label_buf, "subnet_{d}", .{subnet_index}) catch continue;
-        zeam_metrics.metrics.zeam_attestation_aggregate_coverage_validators.set(
+        zeam_metrics.metrics.lean_attestation_aggregate_coverage_validators.set(
             .{ .section = section, .subnet = subnet_label },
             @intCast(countSubnetSeen(seen, @intCast(subnet_index), committee_count)),
         ) catch {};


### PR DESCRIPTION
## Summary
- add `slot` labels to aggregate coverage gauges/diff gauges so each sample is keyed to the slot it describes
- add `subnet` labels to validator coverage, with `subnet=combined` for the all-subnet total and `subnet=subnet_N` for per-subnet coverage
- keep covered-subnet counts labelled by section + slot and preserve existing section names from the coverage logs

## Validation
- `zig fmt pkgs/metrics/src/lib.zig pkgs/node/src/forkchoice.zig`
- `zig build test` passed locally

Builds on top of the metrics added in #876.