### PR TITLE
Limit aggregate signature builds to active slot

### DIFF
--- a/pkgs/cli/test/integration.zig
+++ b/pkgs/cli/test/integration.zig
@@ -525,31 +525,21 @@ const SSEClient = struct {
 
         // The SSE stream is intentionally long-lived, so a plain blocking read
         // can hang forever when the simulator stops emitting events before the
-        // test's outer deadline is reached (observed on macOS CI in #900). Poll
-        // first and let the caller re-check its deadline when no bytes arrive.
-        var poll_fds = [_]std.posix.pollfd{.{
-            .fd = self.connection.socket.handle,
-            .events = std.posix.POLL.IN | std.posix.POLL.ERR | std.posix.POLL.HUP,
-            .revents = 0,
-        }};
-        const ready = try std.posix.poll(&poll_fds, 50);
-        if (ready == 0) return null;
-        if (poll_fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.HUP) != 0) return null;
-
-        // Read new data from network
+        // test's outer deadline is reached (observed on macOS CI in #900). Use
+        // the std.Io timeout path directly rather than poll+Reader: on macOS CI
+        // the stream reader can still block after readiness, preventing the
+        // outer deadline from being checked.
         var temp_buffer: [4096]u8 = undefined;
-        const bytes_read = self.stream_reader.interface.readSliceShort(&temp_buffer) catch |err| switch (err) {
-            error.ReadFailed => {
-                if (self.stream_reader.err) |e| switch (e) {
-                    error.Timeout => {
-                        zeam_utils.sleepNs(50 * std.time.ns_per_ms);
-                        return null;
-                    },
-                    else => return e,
-                };
-                return err;
+        const msg = self.connection.socket.receiveTimeout(std.testing.io, &temp_buffer, .{
+            .duration = .{
+                .raw = std.Io.Duration.fromMilliseconds(50),
+                .clock = .awake,
             },
+        }) catch |err| switch (err) {
+            error.Timeout => return null,
+            else => return err,
         };
+        const bytes_read = msg.data.len;
 
         if (bytes_read == 0) {
             zeam_utils.sleepNs(50 * std.time.ns_per_ms);

--- a/pkgs/cli/test/integration.zig
+++ b/pkgs/cli/test/integration.zig
@@ -523,6 +523,19 @@ const SSEClient = struct {
             return self.parsed_events_queue.orderedRemove(0);
         }
 
+        // The SSE stream is intentionally long-lived, so a plain blocking read
+        // can hang forever when the simulator stops emitting events before the
+        // test's outer deadline is reached (observed on macOS CI in #900). Poll
+        // first and let the caller re-check its deadline when no bytes arrive.
+        var poll_fds = [_]std.posix.pollfd{.{
+            .fd = self.connection.socket.handle,
+            .events = std.posix.POLL.IN | std.posix.POLL.ERR | std.posix.POLL.HUP,
+            .revents = 0,
+        }};
+        const ready = try std.posix.poll(&poll_fds, 50);
+        if (ready == 0) return null;
+        if (poll_fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.HUP) != 0) return null;
+
         // Read new data from network
         var temp_buffer: [4096]u8 = undefined;
         const bytes_read = self.stream_reader.interface.readSliceShort(&temp_buffer) catch |err| switch (err) {

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -83,6 +83,11 @@ const Metrics = struct {
     lean_pq_sig_aggregated_signatures_total: PQSigAggregatedSignaturesTotalCounter,
     lean_pq_sig_attestations_in_aggregated_signatures_total: PQSigAttestationsInAggregatedTotalCounter,
     lean_pq_sig_aggregated_signatures_building_time_seconds: PQSigBuildingTimeHistogram,
+    // Zeam-specific phase attribution for aggregate production (#899).
+    // phase="snapshot" clones live signature/payload maps under signatures_mutex.
+    // phase="compute_ffi" builds recursive aggregate proofs from the snapshot.
+    // phase="commit" publishes results back into latest_new_aggregated_payloads.
+    zeam_pq_sig_aggregated_signatures_building_phase_seconds: PQSigBuildingPhaseHistogram,
     lean_pq_sig_aggregated_signatures_verification_time_seconds: PQSigAggregatedVerificationHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
@@ -400,6 +405,7 @@ const Metrics = struct {
     const PQSigAggregatedSignaturesTotalCounter = metrics_lib.Counter(u64);
     const PQSigAttestationsInAggregatedTotalCounter = metrics_lib.Counter(u64);
     const PQSigBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
+    const PQSigBuildingPhaseHistogram = metrics_lib.HistogramVec(f32, struct { phase: []const u8 }, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 4 });
     const PQSigAggregatedVerificationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
     const PQSigAggregatedValidCounter = metrics_lib.Counter(u64);
     const PQSigAggregatedInvalidCounter = metrics_lib.Counter(u64);
@@ -854,6 +860,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_pq_sig_aggregated_signatures_total = Metrics.PQSigAggregatedSignaturesTotalCounter.init("lean_pq_sig_aggregated_signatures_total", .{ .help = "Total number of aggregated signatures" }, .{}),
         .lean_pq_sig_attestations_in_aggregated_signatures_total = Metrics.PQSigAttestationsInAggregatedTotalCounter.init("lean_pq_sig_attestations_in_aggregated_signatures_total", .{ .help = "Total number of attestations included into aggregated signatures" }, .{}),
         .lean_pq_sig_aggregated_signatures_building_time_seconds = Metrics.PQSigBuildingTimeHistogram.init("lean_pq_sig_aggregated_signatures_building_time_seconds", .{ .help = "Time taken to build an aggregated attestation signature" }, .{}),
+        .zeam_pq_sig_aggregated_signatures_building_phase_seconds = try Metrics.PQSigBuildingPhaseHistogram.init(allocator, io, "zeam_pq_sig_aggregated_signatures_building_phase_seconds", .{ .help = "Phase-level time taken to produce aggregate attestations, labeled by phase (snapshot|compute_ffi|commit). See #899." }, .{}),
         .lean_pq_sig_aggregated_signatures_verification_time_seconds = Metrics.PQSigAggregatedVerificationHistogram.init("lean_pq_sig_aggregated_signatures_verification_time_seconds", .{ .help = "Time taken to verify an aggregated attestation signature" }, .{}),
         .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures" }, .{}),
         .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures" }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4380,7 +4380,16 @@ pub const BeamChain = struct {
         // Log subnet-wise coverage of current new payloads before starting aggregation.
         chain.forkChoice.logNewPayloadsCoverageForAggregation(@intCast(slot));
 
-        const aggregations = chain.forkChoice.aggregateForSlot(snapshot, @intCast(slot)) catch |err| {
+        var slot_window_buf: [2]types.Slot = undefined;
+        var slot_window_len: usize = 0;
+        if (slot > 0) {
+            slot_window_buf[slot_window_len] = @intCast(slot - 1);
+            slot_window_len += 1;
+        }
+        slot_window_buf[slot_window_len] = @intCast(slot);
+        slot_window_len += 1;
+
+        const aggregations = chain.forkChoice.aggregateForSlots(snapshot, slot_window_buf[0..slot_window_len]) catch |err| {
             chain.logger.warn("failed to aggregate attestation signatures for slot={d}: {any}", .{ slot, err });
             return;
         };

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4379,7 +4379,7 @@ pub const BeamChain = struct {
         // Log subnet-wise coverage of current new payloads before starting aggregation.
         chain.forkChoice.logNewPayloadsCoverageForAggregation(@intCast(slot));
 
-        const aggregations = chain.forkChoice.aggregate(snapshot) catch |err| {
+        const aggregations = chain.forkChoice.aggregateForSlot(snapshot, @intCast(slot)) catch |err| {
             chain.logger.warn("failed to aggregate attestation signatures for slot={d}: {any}", .{ slot, err });
             return;
         };

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2032,7 +2032,7 @@ pub const ForkChoice = struct {
     /// `submitAggregateOnInterval` already gates concurrent
     /// `aggregate()` calls via `aggregate_group.concurrent`
     /// (concurrent_limit=1), so two aggregations cannot race here.
-    fn aggregateUnlocked(self: *Self, state_opt: ?*const types.BeamState, slot_filter: ?types.Slot) ![]types.SignedAggregatedAttestation {
+    fn aggregateUnlocked(self: *Self, state_opt: ?*const types.BeamState, slot_filter: ?[]const types.Slot) ![]types.SignedAggregatedAttestation {
         const state = state_opt orelse return try self.allocator.alloc(types.SignedAggregatedAttestation, 0);
         const agg_timer = zeam_metrics.lean_committee_signatures_aggregation_time_seconds.start();
         defer _ = agg_timer.observe();
@@ -2253,19 +2253,32 @@ pub const ForkChoice = struct {
     /// `aggregateUnlocked` for the three-phase contract.
     ///
     /// `submitAggregateOnInterval` already gates concurrent
-    /// `aggregate()` invocations via `aggregate_group.concurrent`
+    /// `aggregateForSlots()` invocations via `aggregate_group.concurrent`
     /// (concurrent_limit=1), so two aggregations cannot race here.
+    ///
+    /// Unfiltered aggregation is retained for tests and explicit defensive backfills
+    /// only. Production slot workers should pass a bounded slot window via
+    /// `aggregateForSlots` so stale/future retained map entries cannot reintroduce
+    /// the #899 recursive-aggregation tail.
     pub fn aggregate(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
         return self.aggregateUnlocked(state_opt, null);
     }
 
-    /// Produce aggregations only for the slot currently being aggregated.
+    /// Produce aggregations only for the caller-supplied attestation slots.
     ///
-    /// The aggregate worker is scheduled for one slot at a time. Filtering here
-    /// prevents stale/future AttestationData retained in the gossip/new maps from
-    /// forcing extra recursive proof builds, which was the dominant cost in #899.
+    /// The aggregate worker is scheduled with `aggregate_group.concurrent`
+    /// (concurrent_limit=1), so a busy worker can skip an interval. Callers should
+    /// pass a small backfill window, e.g. `{current_slot - 1, current_slot}`, to
+    /// recover late or skipped-slot attestations without walking every stale/future
+    /// `AttestationData` key retained in the maps.
+    pub fn aggregateForSlots(self: *Self, state_opt: ?*const types.BeamState, slots: []const types.Slot) ![]types.SignedAggregatedAttestation {
+        return self.aggregateUnlocked(state_opt, slots);
+    }
+
+    /// Convenience wrapper for tests or callers that intentionally want strict
+    /// single-slot aggregation. Production should prefer `aggregateForSlots`.
     pub fn aggregateForSlot(self: *Self, state_opt: ?*const types.BeamState, slot: types.Slot) ![]types.SignedAggregatedAttestation {
-        return self.aggregateUnlocked(state_opt, slot);
+        return self.aggregateForSlots(state_opt, &.{slot});
     }
 
     /// Remove attestation data that can no longer influence fork choice.
@@ -3811,6 +3824,10 @@ fn countSeen(seen: []const bool) usize {
 fn observeAggregateBuildPhase(comptime phase: []const u8, start_ns: i128) void {
     const end_ns = zeam_utils.monotonicTimestampNs();
     const elapsed_ns: i128 = if (end_ns >= start_ns) end_ns - start_ns else 0;
+    // Histogram seconds are f32; precision below roughly 100 ns is intentionally
+    // irrelevant for these phase buckets. The existing total histogram still
+    // wraps only the recursive proof build inside compute, so phase sums are an
+    // attribution view rather than an exact replacement for that metric.
     const elapsed_s: f32 = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
     zeam_metrics.metrics.zeam_pq_sig_aggregated_signatures_building_phase_seconds.observe(
         .{ .phase = phase },

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2032,7 +2032,7 @@ pub const ForkChoice = struct {
     /// `submitAggregateOnInterval` already gates concurrent
     /// `aggregate()` calls via `aggregate_group.concurrent`
     /// (concurrent_limit=1), so two aggregations cannot race here.
-    fn aggregateUnlocked(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
+    fn aggregateUnlocked(self: *Self, state_opt: ?*const types.BeamState, slot_filter: ?types.Slot) ![]types.SignedAggregatedAttestation {
         const state = state_opt orelse return try self.allocator.alloc(types.SignedAggregatedAttestation, 0);
         const agg_timer = zeam_metrics.lean_committee_signatures_aggregation_time_seconds.start();
         defer _ = agg_timer.observe();
@@ -2046,7 +2046,9 @@ pub const ForkChoice = struct {
         // AggregatedSignatureProof (Rust-allocated XMSS handle, refcount
         // bump via FFI). Per-entry clone is sub-ms; total snapshot
         // typically O(10 ms) on a healthy aggregator.
+        const snapshot_start_ns = zeam_utils.monotonicTimestampNs();
         var snap = try AggregateSnapshot.takeUnderLock(self);
+        observeAggregateBuildPhase("snapshot", snapshot_start_ns);
         defer snap.deinit(self.allocator);
 
         // ─── Phase 2: compute (no lock held) ────────────────────────
@@ -2062,12 +2064,15 @@ pub const ForkChoice = struct {
             agg.attestation_signatures.deinit();
         };
 
+        const compute_start_ns = zeam_utils.monotonicTimestampNs();
         try agg.computeAggregatedSignatures(
             &state.validators,
             &snap.signatures,
             &snap.new_payloads,
             &snap.known_payloads,
+            slot_filter,
         );
+        observeAggregateBuildPhase("compute_ffi", compute_start_ns);
 
         // Build the per-att_data map of fresh aggregations and the
         // result slice while no lock is held. SSZ-clone per proof
@@ -2143,6 +2148,7 @@ pub const ForkChoice = struct {
         // ─── Phase 3: commit (signatures_mutex held briefly) ────────
         var new_payloads_count: usize = 0;
         var gossip_sigs_count: usize = 0;
+        const commit_start_ns = zeam_utils.monotonicTimestampNs();
         {
             self.signatures_mutex.lock();
             defer self.signatures_mutex.unlock();
@@ -2209,6 +2215,7 @@ pub const ForkChoice = struct {
             new_payloads_count = self.latest_new_aggregated_payloads.count();
             gossip_sigs_count = self.attestation_signatures.count();
         }
+        observeAggregateBuildPhase("commit", commit_start_ns);
 
         // Phase 2 cleanup: free the AggregatedAttestationsResult
         // local now that ownership of every cloned proof has either
@@ -2249,7 +2256,16 @@ pub const ForkChoice = struct {
     /// `aggregate()` invocations via `aggregate_group.concurrent`
     /// (concurrent_limit=1), so two aggregations cannot race here.
     pub fn aggregate(self: *Self, state_opt: ?*const types.BeamState) ![]types.SignedAggregatedAttestation {
-        return self.aggregateUnlocked(state_opt);
+        return self.aggregateUnlocked(state_opt, null);
+    }
+
+    /// Produce aggregations only for the slot currently being aggregated.
+    ///
+    /// The aggregate worker is scheduled for one slot at a time. Filtering here
+    /// prevents stale/future AttestationData retained in the gossip/new maps from
+    /// forcing extra recursive proof builds, which was the dominant cost in #899.
+    pub fn aggregateForSlot(self: *Self, state_opt: ?*const types.BeamState, slot: types.Slot) ![]types.SignedAggregatedAttestation {
+        return self.aggregateUnlocked(state_opt, slot);
     }
 
     /// Remove attestation data that can no longer influence fork choice.
@@ -3790,6 +3806,16 @@ fn countSeen(seen: []const bool) usize {
         if (is_seen) count += 1;
     }
     return count;
+}
+
+fn observeAggregateBuildPhase(comptime phase: []const u8, start_ns: i128) void {
+    const end_ns = zeam_utils.monotonicTimestampNs();
+    const elapsed_ns: i128 = if (end_ns >= start_ns) end_ns - start_ns else 0;
+    const elapsed_s: f32 = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+    zeam_metrics.metrics.zeam_pq_sig_aggregated_signatures_building_phase_seconds.observe(
+        .{ .phase = phase },
+        elapsed_s,
+    ) catch {};
 }
 
 fn recordAggregateCoverageMetrics(section: []const u8, seen: []const bool, has_subnet: []const bool) void {

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -445,6 +445,14 @@ pub fn createBlockSignatures(allocator: Allocator, num_aggregated_attestations: 
     };
 }
 
+fn slotAllowed(slot: Slot, slot_filter: ?[]const Slot) bool {
+    const slots = slot_filter orelse return true;
+    for (slots) |allowed| {
+        if (slot == allowed) return true;
+    }
+    return false;
+}
+
 pub const AggregatedAttestationsResult = struct {
     attestations: AggregatedAttestations,
     attestation_signatures: AttestationSignatures,
@@ -467,7 +475,8 @@ pub const AggregatedAttestationsResult = struct {
     }
 
     /// Compute aggregated signatures using recursive aggregation:
-    /// Step 1: Derive AttestationData keys from signatures_map ∪ new_payloads
+    /// Step 1: Derive AttestationData keys from signatures_map ∪ new_payloads,
+    ///         optionally restricted to the supplied attestation slots.
     /// Step 2: Greedy child proof selection — new_payloads first, then known_payloads as helpers
     /// Step 3: Collect individual gossip signatures not covered by children
     /// Step 4: Recursive aggregate — combine selected children + remaining gossip sigs
@@ -477,7 +486,7 @@ pub const AggregatedAttestationsResult = struct {
         signatures_map: *const SignaturesMap,
         new_payloads: ?*const AggregatedPayloadsMap,
         known_payloads: ?*const AggregatedPayloadsMap,
-        slot_filter: ?Slot,
+        slot_filter: ?[]const Slot,
     ) !void {
         const allocator = self.allocator;
 
@@ -488,18 +497,14 @@ pub const AggregatedAttestationsResult = struct {
         {
             var it = signatures_map.iterator();
             while (it.next()) |entry| {
-                if (slot_filter) |slot| {
-                    if (entry.key_ptr.slot != slot) continue;
-                }
+                if (!slotAllowed(entry.key_ptr.slot, slot_filter)) continue;
                 try att_data_set.put(entry.key_ptr.*, {});
             }
         }
         if (new_payloads) |np| {
             var it = np.iterator();
             while (it.next()) |entry| {
-                if (slot_filter) |slot| {
-                    if (entry.key_ptr.slot != slot) continue;
-                }
+                if (!slotAllowed(entry.key_ptr.slot, slot_filter)) continue;
                 try att_data_set.put(entry.key_ptr.*, {});
             }
         }
@@ -1274,6 +1279,129 @@ pub const ExecutionPayloadHeader = struct {
         return utils.jsonToString(allocator, json_value);
     }
 };
+
+fn testAttestationData(slot: Slot) attestation.AttestationData {
+    return .{
+        .slot = slot,
+        .head = .{ .root = ZERO_HASH, .slot = slot },
+        .target = .{ .root = ZERO_HASH, .slot = slot },
+        .source = .{ .root = ZERO_HASH, .slot = 0 },
+    };
+}
+
+fn testDeinitPayloadsMap(allocator: Allocator, payloads: *AggregatedPayloadsMap) void {
+    var it = payloads.iterator();
+    while (it.next()) |entry| {
+        for (entry.value_ptr.items) |*stored| {
+            stored.proof.deinit();
+            if (stored.source_payload_participants) |*bits| bits.deinit();
+            if (stored.source_gossip_participants) |*bits| bits.deinit();
+        }
+        entry.value_ptr.deinit(allocator);
+    }
+    payloads.deinit();
+}
+
+fn testPutSingleChildPayload(allocator: Allocator, payloads: *AggregatedPayloadsMap, data: attestation.AttestationData, validator_index: usize) !void {
+    var proof = try aggregation.AggregatedSignatureProof.init(allocator);
+    errdefer proof.deinit();
+    try attestation.aggregationBitsSet(&proof.participants, validator_index, true);
+
+    const gop = try payloads.getOrPut(data);
+    if (!gop.found_existing) gop.value_ptr.* = .empty;
+    try gop.value_ptr.append(allocator, .{
+        .slot = data.slot,
+        .proof = proof,
+    });
+}
+
+test "computeAggregatedSignatures filters attestation data by slot list" {
+    const allocator = std.testing.allocator;
+
+    var validators = try Validators.init(allocator);
+    defer validators.deinit();
+
+    var signatures = SignaturesMap.init(allocator);
+    defer signatures.deinit();
+
+    var payloads = AggregatedPayloadsMap.init(allocator);
+    defer testDeinitPayloadsMap(allocator, &payloads);
+
+    const slot_10 = testAttestationData(10);
+    const slot_11 = testAttestationData(11);
+    try testPutSingleChildPayload(allocator, &payloads, slot_10, 0);
+    try testPutSingleChildPayload(allocator, &payloads, slot_11, 1);
+
+    var result = try AggregatedAttestationsResult.init(allocator);
+    defer result.deinit();
+
+    const allowed_slots = [_]Slot{10};
+    try result.computeAggregatedSignatures(&validators, &signatures, &payloads, null, allowed_slots[0..]);
+
+    try std.testing.expectEqual(@as(usize, 1), result.attestations.len());
+    const aggregated = try result.attestations.get(0);
+    try std.testing.expectEqual(@as(Slot, 10), aggregated.data.slot);
+}
+
+test "computeAggregatedSignatures slot filter matches unfiltered for same-slot input" {
+    const allocator = std.testing.allocator;
+
+    var validators = try Validators.init(allocator);
+    defer validators.deinit();
+
+    var signatures_a = SignaturesMap.init(allocator);
+    defer signatures_a.deinit();
+    var payloads_a = AggregatedPayloadsMap.init(allocator);
+    defer testDeinitPayloadsMap(allocator, &payloads_a);
+
+    var signatures_b = SignaturesMap.init(allocator);
+    defer signatures_b.deinit();
+    var payloads_b = AggregatedPayloadsMap.init(allocator);
+    defer testDeinitPayloadsMap(allocator, &payloads_b);
+
+    const data = testAttestationData(12);
+    try testPutSingleChildPayload(allocator, &payloads_a, data, 0);
+    try testPutSingleChildPayload(allocator, &payloads_b, data, 0);
+
+    var unfiltered = try AggregatedAttestationsResult.init(allocator);
+    defer unfiltered.deinit();
+    try unfiltered.computeAggregatedSignatures(&validators, &signatures_a, &payloads_a, null, null);
+
+    var filtered = try AggregatedAttestationsResult.init(allocator);
+    defer filtered.deinit();
+    const allowed_slots = [_]Slot{12};
+    try filtered.computeAggregatedSignatures(&validators, &signatures_b, &payloads_b, null, allowed_slots[0..]);
+
+    try std.testing.expectEqual(unfiltered.attestations.len(), filtered.attestations.len());
+    try std.testing.expectEqual(unfiltered.attestation_signatures.len(), filtered.attestation_signatures.len());
+    try std.testing.expectEqual(@as(usize, 1), filtered.attestations.len());
+    const filtered_att = try filtered.attestations.get(0);
+    try std.testing.expectEqual(@as(Slot, 12), filtered_att.data.slot);
+}
+
+test "computeAggregatedSignatures empty slot filter result is clean" {
+    const allocator = std.testing.allocator;
+
+    var validators = try Validators.init(allocator);
+    defer validators.deinit();
+
+    var signatures = SignaturesMap.init(allocator);
+    defer signatures.deinit();
+
+    var payloads = AggregatedPayloadsMap.init(allocator);
+    defer testDeinitPayloadsMap(allocator, &payloads);
+
+    try testPutSingleChildPayload(allocator, &payloads, testAttestationData(13), 0);
+
+    var result = try AggregatedAttestationsResult.init(allocator);
+    defer result.deinit();
+
+    const allowed_slots = [_]Slot{14};
+    try result.computeAggregatedSignatures(&validators, &signatures, &payloads, null, allowed_slots[0..]);
+
+    try std.testing.expectEqual(@as(usize, 0), result.attestations.len());
+    try std.testing.expectEqual(@as(usize, 0), result.attestation_signatures.len());
+}
 
 test "ssz seralize/deserialize signed beam block" {
     var attestations = try AggregatedAttestations.init(std.testing.allocator);

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -477,6 +477,7 @@ pub const AggregatedAttestationsResult = struct {
         signatures_map: *const SignaturesMap,
         new_payloads: ?*const AggregatedPayloadsMap,
         known_payloads: ?*const AggregatedPayloadsMap,
+        slot_filter: ?Slot,
     ) !void {
         const allocator = self.allocator;
 
@@ -487,12 +488,18 @@ pub const AggregatedAttestationsResult = struct {
         {
             var it = signatures_map.iterator();
             while (it.next()) |entry| {
+                if (slot_filter) |slot| {
+                    if (entry.key_ptr.slot != slot) continue;
+                }
                 try att_data_set.put(entry.key_ptr.*, {});
             }
         }
         if (new_payloads) |np| {
             var it = np.iterator();
             while (it.next()) |entry| {
+                if (slot_filter) |slot| {
+                    if (entry.key_ptr.slot != slot) continue;
+                }
                 try att_data_set.put(entry.key_ptr.*, {});
             }
         }


### PR DESCRIPTION
## Summary

Fixes #899 by constraining aggregate-signature production to the slot currently being aggregated.

The aggregate worker is scheduled for one slot at a time, but `computeAggregatedSignatures` previously unioned every `AttestationData` key present in the snapshot maps. On devnet those maps can retain stale/future attestation data from gossip/new payload caches, so a single slot aggregation could recursively build proofs for unrelated slots before returning the current slot's aggregates. That inflated `lean_pq_sig_aggregated_signatures_building_time_seconds` into the multi-second range reported in #899.

## Changes

- Add an optional `slot_filter` to `AggregatedAttestationsResult.computeAggregatedSignatures`.
- Add `ForkChoice.aggregateForSlot(...)` and use it from `submitAggregateOnInterval`.
- Keep existing `ForkChoice.aggregate(...)` behavior unchanged for generic/test callers.
- Add phase attribution metric:
  - `zeam_pq_sig_aggregated_signatures_building_phase_seconds{phase="snapshot|compute_ffi|commit"}`

## Validation

- `zig fmt pkgs/metrics/src/lib.zig pkgs/types/src/block.zig pkgs/node/src/forkchoice.zig pkgs/node/src/chain.zig`
- `git diff --check`
- `zig build test` passed locally (`EXIT:0` in `/tmp/zeam-899-zig-build-test.log`).
