### PR TITLE
node, metrics: surface aggregator-publish counter and gossip-sig coverage

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -176,6 +176,14 @@ const Metrics = struct {
     zeam_aggregate_skip_total: AggregateSkipCounter,
     /// Histogram for the wall-clock duration of the aggregate FFI worker.
     zeam_aggregate_worker_duration_seconds: AggregateWorkerDurationHistogram,
+    /// Counter for SignedAggregatedAttestation messages published by the local
+    /// aggregator worker (after the FFI returned), labeled by attestation subnet.
+    /// Separate from the standard `lean_pq_sig_aggregated_signatures_total`
+    /// (which zeam increments only on the block-proposal path) so cross-client
+    /// dashboards keep the standard metric's semantics intact. Operators can
+    /// use this counter to tell whether the local aggregator is producing for
+    /// its duty subnet at all without inferring it from the worker histogram.
+    zeam_aggregator_publish_aggregations_total: AggregatorPublishAggregationsCounter,
     // BeamNode mutex contention metrics (issue #786)
     // Wait time = how long a callsite blocked before acquiring BeamNode.mutex.
     // Hold time = how long the callsite kept the mutex locked.
@@ -514,6 +522,7 @@ const Metrics = struct {
     const LeanNodeIntervalErrorCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
     const AggregateSkipCounter = metrics_lib.CounterVec(u64, struct { reason: []const u8 });
     const AggregateWorkerDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0 });
+    const AggregatorPublishAggregationsCounter = metrics_lib.CounterVec(u64, struct { subnet: []const u8 });
     // Validator status gauge types
     const LeanIsAggregatorGauge = metrics_lib.Gauge(u64);
     const LeanAttestationCommitteeSubnetGauge = metrics_lib.Gauge(u64);
@@ -924,6 +933,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_node_aggregation_interval_tick_seconds = Metrics.AggregationIntervalTickHistogram.init("zeam_node_aggregation_interval_tick_seconds", .{ .help = "Wall time for BeamNode at per-slot interval 2: maybeAggregateOnInterval plus publishProducedAggregations (includes null/skip/error paths)." }, .{}),
         .zeam_aggregate_skip_total = try Metrics.AggregateSkipCounter.init(allocator, io, "zeam_aggregate_skip_total", .{ .help = "Number of aggregate submissions skipped, labeled by reason: in_flight, not_aggregator, not_synced, missing_state." }, .{}),
         .zeam_aggregate_worker_duration_seconds = Metrics.AggregateWorkerDurationHistogram.init("zeam_aggregate_worker_duration_seconds", .{ .help = "Wall-clock duration of the aggregate FFI worker (XMSS recursive aggregation)." }, .{}),
+        .zeam_aggregator_publish_aggregations_total = try Metrics.AggregatorPublishAggregationsCounter.init(allocator, io, "zeam_aggregator_publish_aggregations_total", .{ .help = "SignedAggregatedAttestation messages published by the local aggregator worker, labeled by attestation subnet. Distinct from lean_pq_sig_aggregated_signatures_total (block-proposal path only) so cross-client dashboards keep the standard metric's semantics intact." }, .{}),
         // BeamNode mutex contention metrics (issue #786)
         .zeam_node_mutex_wait_time_seconds = try Metrics.NodeMutexWaitTimeHistogram.init(allocator, io, "zeam_node_mutex_wait_time_seconds", .{ .help = "Time spent waiting to acquire BeamNode.mutex, labeled by callsite (LEGACY — double-emitted from per-resource locks; will be removed after one release)." }, .{}),
         .zeam_node_mutex_hold_time_seconds = try Metrics.NodeMutexHoldTimeHistogram.init(allocator, io, "zeam_node_mutex_hold_time_seconds", .{ .help = "Time BeamNode.mutex was held, labeled by callsite (LEGACY — double-emitted from per-resource locks; will be removed after one release)." }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4397,7 +4397,41 @@ pub const BeamChain = struct {
 
         if (aggregations.len == 0) return;
 
+        // Per-subnet publish counter. Operators rely on this to tell whether the
+        // local aggregator is producing for its duty subnet at all; the standard
+        // `lean_pq_sig_aggregated_signatures_total` increments only on the
+        // block-proposal path (see chain.zig produceBlock) and stays near zero on
+        // a healthy aggregator that is not also a recent proposer, which makes it
+        // a poor signal for the aggregator role. Derive the subnet from the
+        // first set participant in each proof: all participants of a single
+        // SignedAggregatedAttestation come from the same committee subnet (cf.
+        // `computeSubnetId` = validator_index % attestation_committee_count).
+        const committee_count = chain.config.spec.attestation_committee_count;
+        if (committee_count > 0) {
+            for (aggregations) |signed| {
+                const subnet_id = firstParticipantSubnet(signed.proof.participants, committee_count) orelse continue;
+                var label_buf: [16]u8 = undefined;
+                const subnet_label = std.fmt.bufPrint(&label_buf, "{d}", .{subnet_id}) catch continue;
+                zeam_metrics.metrics.zeam_aggregator_publish_aggregations_total.incr(.{ .subnet = subnet_label }) catch {};
+            }
+        }
+
         node.publishProducedAggregations(aggregations);
+    }
+
+    /// Find the subnet of the first set participant in `participants`.
+    /// All participants in a single aggregated attestation come from the same
+    /// committee subnet, so the first one is representative. Returns null if
+    /// the bitfield is empty or every set bit is out of range.
+    fn firstParticipantSubnet(
+        participants: types.AggregationBits,
+        committee_count: types.SubnetId,
+    ) ?types.SubnetId {
+        for (0..participants.len()) |validator_index| {
+            if (!(participants.get(validator_index) catch false)) continue;
+            return types.computeSubnetId(@intCast(validator_index), committee_count) catch continue;
+        }
+        return null;
     }
 
     pub fn getStatus(self: *Self) types.Status {

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1897,8 +1897,23 @@ pub const ForkChoice = struct {
         return try out.toOwnedSlice(allocator);
     }
 
-    /// Log subnet-wise coverage of the current new payloads before starting aggregation.
-    /// Called from aggregateImpl just before fork-choice aggregation runs.
+    /// Log subnet-wise coverage of the aggregation input set before the FFI runs.
+    /// Called from aggregateImpl just before fork-choice aggregation.
+    ///
+    /// The aggregator's input is the **union** of two maps:
+    ///   - `latest_new_aggregated_payloads`: cross-subnet aggregations received
+    ///     from peers since the last accept-merge (reported as `new_payloads`).
+    ///   - `attestation_signatures`: individual gossip signatures from this
+    ///     node's subscribed subnets (reported as `gossip_sigs`).
+    ///
+    /// Earlier this function looked only at `latest_new_aggregated_payloads` and
+    /// reported `coverage=none` whenever it was empty, even when dozens of
+    /// individual gossip sigs were waiting on the local duty subnet (#899).
+    /// Operators misread the "none" line as "we have no input"; the input was
+    /// in fact a different map. Reporting both sections separately removes the
+    /// ambiguity and surfaces "we have raw sigs from subnet 0 but no
+    /// cross-subnet aggregations yet" — the common steady-state on a single-
+    /// subnet aggregator.
     pub fn logNewPayloadsCoverageForAggregation(self: *Self, slot: types.Slot) void {
         const validator_count: usize = @intCast(self.config.genesis.numValidators());
         if (validator_count == 0) return;
@@ -1910,6 +1925,10 @@ pub const ForkChoice = struct {
         defer self.allocator.free(new_seen);
         const new_has_subnet = self.allocator.alloc(bool, committee_count) catch return;
         defer self.allocator.free(new_has_subnet);
+        const gossip_seen = self.allocator.alloc(bool, validator_count) catch return;
+        defer self.allocator.free(gossip_seen);
+        const gossip_has_subnet = self.allocator.alloc(bool, committee_count) catch return;
+        defer self.allocator.free(gossip_has_subnet);
         const dummy_seen = self.allocator.alloc(bool, validator_count) catch return;
         defer self.allocator.free(dummy_seen);
         const dummy_has = self.allocator.alloc(bool, committee_count) catch return;
@@ -1917,6 +1936,8 @@ pub const ForkChoice = struct {
 
         @memset(new_seen, false);
         @memset(new_has_subnet, false);
+        @memset(gossip_seen, false);
+        @memset(gossip_has_subnet, false);
         @memset(dummy_seen, false);
         @memset(dummy_has, false);
 
@@ -1933,26 +1954,48 @@ pub const ForkChoice = struct {
             dummy_has,
         );
 
-        var has_any = false;
-        for (new_has_subnet) |h| {
-            if (h) {
-                has_any = true;
-                break;
-            }
-        }
+        collectGossipSigCoverageForSlot(
+            &self.attestation_signatures,
+            slot,
+            committee_count_u32,
+            validator_count,
+            gossip_seen,
+            gossip_has_subnet,
+        );
 
-        if (!has_any) {
-            recordAggregateCoverageMetrics("agg_start_new", new_seen, new_has_subnet, committee_count_u32);
-            self.logger.info("agg start slot={d}: new payloads coverage=none", .{slot});
-            return;
-        }
+        var new_has_any = false;
+        for (new_has_subnet) |h| if (h) {
+            new_has_any = true;
+            break;
+        };
+        var gossip_has_any = false;
+        for (gossip_has_subnet) |h| if (h) {
+            gossip_has_any = true;
+            break;
+        };
 
         recordAggregateCoverageMetrics("agg_start_new", new_seen, new_has_subnet, committee_count_u32);
+        recordAggregateCoverageMetrics("agg_start_gossip", gossip_seen, gossip_has_subnet, committee_count_u32);
+
+        if (!new_has_any and !gossip_has_any) {
+            self.logger.info("agg start slot={d}: new_payloads=none gossip_sigs=none", .{slot});
+            return;
+        }
 
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(self.allocator);
         appendFmt(self.allocator, &out, "agg start slot={d}: ", .{slot}) catch return;
-        appendCoverageSection(self.allocator, &out, "new", new_seen, new_has_subnet, validator_count, committee_count_u32) catch return;
+        if (new_has_any) {
+            appendCoverageSection(self.allocator, &out, "new_payloads", new_seen, new_has_subnet, validator_count, committee_count_u32) catch return;
+        } else {
+            appendFmt(self.allocator, &out, "new_payloads=none", .{}) catch return;
+        }
+        appendFmt(self.allocator, &out, " | ", .{}) catch return;
+        if (gossip_has_any) {
+            appendCoverageSection(self.allocator, &out, "gossip_sigs", gossip_seen, gossip_has_subnet, validator_count, committee_count_u32) catch return;
+        } else {
+            appendFmt(self.allocator, &out, "gossip_sigs=none", .{}) catch return;
+        }
         self.logger.info("{s}", .{out.items});
     }
 
@@ -3755,6 +3798,36 @@ fn collectCoverageFromSignaturesForData(
         if (std.mem.eql(u8, &entry.value_ptr.signature, &ZERO_SIGBYTES)) continue;
         _ = types.computeSubnetId(@intCast(validator_index), committee_count) catch continue;
         seen[validator_index] = true;
+    }
+}
+
+/// Aggregate validator/subnet coverage of every individual gossip signature
+/// in `map` whose `AttestationData.slot == slot`. Used by
+/// `logNewPayloadsCoverageForAggregation` to surface the local-subnet input
+/// that `latest_new_aggregated_payloads` alone does not see (#899).
+fn collectGossipSigCoverageForSlot(
+    map: *const SignaturesMap,
+    slot: types.Slot,
+    committee_count: types.SubnetId,
+    validator_count: usize,
+    seen: []bool,
+    has_subnet: []bool,
+) void {
+    var it = map.iterator();
+    while (it.next()) |entry| {
+        if (entry.key_ptr.slot != slot) continue;
+        var vid_it = entry.value_ptr.iterator();
+        while (vid_it.next()) |sig_entry| {
+            const validator_index: usize = @intCast(sig_entry.key_ptr.*);
+            if (validator_index >= validator_count) continue;
+            if (validator_index >= seen.len) continue;
+            if (std.mem.eql(u8, &sig_entry.value_ptr.signature, &ZERO_SIGBYTES)) continue;
+            const subnet_id = types.computeSubnetId(@intCast(validator_index), committee_count) catch continue;
+            const subnet_index: usize = @intCast(subnet_id);
+            if (subnet_index >= has_subnet.len) continue;
+            seen[validator_index] = true;
+            has_subnet[subnet_index] = true;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Two small observability improvements for aggregator operators, both surfaced while triaging #899:

1. **New counter `zeam_aggregator_publish_aggregations_total{subnet}`** — increments in `aggregateImpl` each time the worker publishes a `SignedAggregatedAttestation`. The standard `lean_pq_sig_aggregated_signatures_total` is incremented only on the block-proposal path in zeam (`pkgs/node/src/chain.zig:produceBlock`), so it stays near zero on a healthy aggregator that is not also a recent proposer — a very poor signal for the aggregator role. Re-purposing the standard metric would break cross-client comparability (see [the cross-client note on #899](https://github.com/blockblaz/zeam/issues/899)), so this PR adds a zeam-specific counter instead.

2. **`logNewPayloadsCoverageForAggregation` now reports both input maps.** Previously it inspected only `latest_new_aggregated_payloads` (cross-subnet aggregations received from peers) and printed `coverage=none` whenever that map was empty — even when `attestation_signatures` had dozens of individual sigs waiting on the local duty subnet. The new log line splits the two sections so operators can tell `new_payloads=none` apart from `gossip_sigs=none`, and emits a complementary `agg_start_gossip` per-subnet coverage gauge alongside the existing `agg_start_new`.

No behaviour change — only metric and log output. Standard `lean_pq_sig_aggregated_signatures_total` semantics are unchanged.

## Sample log lines

Before:

\`\`\`
[forkchoice] agg start slot=186: new payloads coverage=none
\`\`\`

After (subnet-0 aggregator with 12 raw subnet-0 sigs queued, no cross-subnet payloads yet):

\`\`\`
[forkchoice] agg start slot=186: new_payloads=none | gossip_sigs=subnet0=7/8(87.50%) network=7/64(10.94%)
\`\`\`

## Test plan

- [x] \`zig fmt --check .\`
- [x] \`cargo fmt --manifest-path rust/Cargo.toml --all -- --check\`
- [x] \`cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings\`
- [x] \`zig build test --summary all\` — all 8+ test targets pass
- [x] \`zig build simtest --summary all\` — all 15 integration tests pass
- [ ] On devnet: confirm \`zeam_aggregator_publish_aggregations_total{subnet="0"}\` rises on a zeam aggregator with subnet 0 duty, and that the new \`agg start\` log line correctly splits new_payloads vs gossip_sigs

## Related

- #899 (parent investigation: zeam aggregate-build slowness)
- #900 (slot-window the att_data set — already merged)