### PR TITLE
node, cli: opt-in aggregator tunables for stuck-chain operation

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -82,6 +82,28 @@ pub const NodeCommand = struct {
     /// worker path is the supported prod path; the synchronous path
     /// stays in place as a kill-switch via `--chain-worker false`.
     @"chain-worker": bool = true,
+    /// Drop gossip attestations older than this many slots before the current
+    /// slot. `0` (default) keeps the current behaviour and accepts any age
+    /// the spec permits. Symmetric to the implicit future-side bound
+    /// `GOSSIP_DISPARITY_INTERVALS`. Useful on stuck devnets where stale
+    /// peers re-broadcast attestations from finalisation-orphaned slots and
+    /// pile them into the aggregator input set (#899).
+    @"gossip-attestation-max-age-slots": u64 = 0,
+    /// Periodically evict attestation_signatures + aggregated_payloads
+    /// entries whose `data.slot` is more than this many slots behind the
+    /// current head, even when finalisation has not advanced. `0` (default)
+    /// leaves pruning gated on finalisation as before. The existing
+    /// `pruneStaleAttestationData(finalized_slot)` is unchanged; this is a
+    /// supplementary memory cap for chains where finalisation is stuck so
+    /// retained maps cannot grow unboundedly (#899).
+    @"max-unfinalized-attestation-age-slots": u64 = 0,
+    /// Maximum in-flight aggregate FFI worker tasks. Default `1` matches the
+    /// pre-existing `aggregate_group.concurrent_limit = .limited(1)`
+    /// invariant from #873 and keeps behaviour identical. On hosts where the
+    /// per-pass build is well under one slot (e.g. after PR #900's slot
+    /// window + ThinLTO + a larger rayon pool), operators can raise this so
+    /// a slow pass does not skip the next slot's aggregation.
+    @"aggregate-concurrent-limit": u32 = 1,
 
     pub const __shorts__ = .{
         .help = .h,
@@ -107,6 +129,9 @@ pub const NodeCommand = struct {
         .@"db-backend" = "Database backend to use for on-disk state: 'rocksdb' (default) or 'lmdb'",
         .@"chain-spec" = "Path to the chain specification file, if unspecified falls back to the default setting",
         .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread. On by default; pass `--chain-worker false` to fall back to the legacy synchronous path as a kill-switch.",
+        .@"gossip-attestation-max-age-slots" = "Drop gossip attestations older than this many slots (0 = off, default). Symmetric to the future-slot bound GOSSIP_DISPARITY_INTERVALS. Useful on stuck devnets to stop stale peers re-injecting old slots into the aggregator input set.",
+        .@"max-unfinalized-attestation-age-slots" = "Periodically evict attestation_signatures + aggregated_payloads entries older than this many slots behind head, even when finalisation has not advanced (0 = off, default; finalised-slot pruning is unchanged). Memory cap for stuck-chain operation.",
+        .@"aggregate-concurrent-limit" = "Maximum in-flight aggregate FFI worker tasks (default 1, matches the existing #873 invariant). Operators can raise this when per-pass build is well under one slot so a slow pass does not skip the next slot's aggregation.",
         .help = "Show help information for the node command",
     };
 };
@@ -842,6 +867,9 @@ fn mainInner(init: std.process.Init) !void {
                 .hash_sig_key_dir = &.{}, // Initialize to empty slice to avoid segfault in deinit
                 .node_registry = node_registry,
                 .db_backend = leancmd.@"db-backend",
+                .gossip_attestation_max_age_slots = leancmd.@"gossip-attestation-max-age-slots",
+                .max_unfinalized_attestation_age_slots = leancmd.@"max-unfinalized-attestation-age-slots",
+                .aggregate_concurrent_limit = leancmd.@"aggregate-concurrent-limit",
             };
 
             defer start_options.deinit(allocator);

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -103,6 +103,17 @@ pub const NodeOptions = struct {
     /// `--chain-worker false` as the kill-switch for the legacy
     /// synchronous path.
     chain_worker_enabled: bool = true,
+    /// Drop gossip attestations whose `data.slot + N < current_slot`.
+    /// `0` (default) disables the cutoff. Operator tunable for stuck-chain
+    /// scenarios (#899).
+    gossip_attestation_max_age_slots: u64 = 0,
+    /// Periodically evict attestation_signatures + aggregated_payloads
+    /// entries with `data.slot + N < head_slot` even when finalisation
+    /// has not advanced. `0` (default) disables the cap.
+    max_unfinalized_attestation_age_slots: u64 = 0,
+    /// Maximum in-flight aggregate FFI worker tasks. Default `1`
+    /// preserves the existing #873 invariant.
+    aggregate_concurrent_limit: u32 = 1,
 
     pub fn deinit(self: *NodeOptions, allocator: std.mem.Allocator) void {
         for (self.bootnodes) |b| allocator.free(b);
@@ -447,6 +458,9 @@ pub const Node = struct {
             .aggregation_subnet_ids = options.aggregation_subnet_ids,
             .thread_pool = self.thread_pool,
             .chain_worker_enabled = options.chain_worker_enabled,
+            .gossip_attestation_max_age_slots = options.gossip_attestation_max_age_slots,
+            .max_unfinalized_attestation_age_slots = options.max_unfinalized_attestation_age_slots,
+            .aggregate_concurrent_limit = options.aggregate_concurrent_limit,
         });
         errdefer self.beam_node.deinit();
 

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -66,6 +66,17 @@ pub const ChainOpts = struct {
     // Optional shared worker pool for CPU-bound work (signature verification).
     // When null, the chain falls back to the serial code paths.
     thread_pool: ?*ThreadPool = null,
+    /// Drop gossip attestations whose `data.slot + N < current_slot`.
+    /// `0` keeps current behaviour (no cutoff). See #899.
+    gossip_attestation_max_age_slots: u64 = 0,
+    /// On every aggregator interval, also prune attestation_signatures /
+    /// aggregated_payloads entries with `data.slot + N < head_slot`. `0`
+    /// disables (finalisation-based pruning still runs). See #899.
+    max_unfinalized_attestation_age_slots: u64 = 0,
+    /// Maximum in-flight aggregate FFI worker tasks. `1` preserves the
+    /// existing #873 invariant; larger values let a slow pass not skip
+    /// the next interval.
+    aggregate_concurrent_limit: u32 = 1,
 };
 
 pub const CachedProcessedBlockInfo = struct {
@@ -379,6 +390,14 @@ pub const BeamChain = struct {
     /// Long-lived group hosting submitted aggregate tasks.
     aggregate_group: std.Io.Group = .init,
 
+    /// Drop gossip attestations older than this many slots before current
+    /// (`data.slot + N < current_slot`). `0` disables (default). #899.
+    gossip_attestation_max_age_slots: u64 = 0,
+    /// Periodic non-finalization prune threshold. Evict
+    /// attestation_signatures + aggregated_payloads entries with
+    /// `data.slot + N < head_slot`. `0` disables (default). #899.
+    max_unfinalized_attestation_age_slots: u64 = 0,
+
     /// Optional chain-worker thread (slice c-2b commit 3 of #803).
     /// When non-null, `BeamChain` exposes the `submit*` family of
     /// methods which enqueue work onto the worker's queues; the
@@ -524,12 +543,21 @@ pub const BeamChain = struct {
         try states.put(fork_choice.head.blockRoot, anchor_rc);
 
         // Issue #873: dedicated Io.Threaded for aggregate FFI worker.
-        // concurrent_limit = .limited(1) ensures at most one in-flight aggregate task.
+        //
+        // `concurrent_limit` defaults to `.limited(1)` to preserve the
+        // historical "at most one in-flight aggregate task" invariant from
+        // #873 (a second submit returns `error.ConcurrencyUnavailable` and
+        // increments `zeam_aggregate_skip_total{reason="in_flight"}`).
+        // Operators on hosts where a single pass is comfortably under one
+        // slot (e.g. after PR #900's slot window + ThinLTO + larger rayon
+        // pool) can raise it via `--aggregate-concurrent-limit` so a slow
+        // pass does not cause the next interval to be skipped (#899).
+        const agg_concurrency: usize = @max(@as(usize, 1), @as(usize, opts.aggregate_concurrent_limit));
         const agg_io = try allocator.create(std.Io.Threaded);
         errdefer allocator.destroy(agg_io);
         agg_io.* = std.Io.Threaded.init(allocator, .{
             .async_limit = .nothing,
-            .concurrent_limit = .limited(1),
+            .concurrent_limit = .limited(agg_concurrency),
         });
         errdefer agg_io.deinit();
 
@@ -578,6 +606,8 @@ pub const BeamChain = struct {
             // aggregate_io: dedicated Io.Threaded for aggregate FFI worker (issue #873).
             .aggregate_io = agg_io,
             .aggregate_group = .init,
+            .gossip_attestation_max_age_slots = opts.gossip_attestation_max_age_slots,
+            .max_unfinalized_attestation_age_slots = opts.max_unfinalized_attestation_age_slots,
             // leanSpec _pending_attestations / _pending_aggregated_attestations
             // buffers — empty at init; FIFO-bounded by
             // constants.MAX_PENDING_ATTESTATIONS in the enqueue helpers.
@@ -4069,6 +4099,27 @@ pub const BeamChain = struct {
         return attestation_start_interval > max_allowed_interval;
     }
 
+    /// Operator-tunable past-side bound for gossip attestations, symmetric to
+    /// `attestationIsTooFarInFuture`. Returns `true` iff
+    /// `gossip_attestation_max_age_slots > 0` and
+    /// `data.slot + gossip_attestation_max_age_slots < current_slot`.
+    ///
+    /// `0` (the default) keeps current behaviour and accepts every age the
+    /// spec permits. Enabled only by operators on stuck devnets where stale
+    /// peers re-broadcast attestations from finalisation-orphaned slots and
+    /// pile them into the aggregator input set (#899). The bound is in
+    /// whole slots — unlike the future bound it does not need
+    /// interval-granularity, because the spec already requires
+    /// `target.slot <= current_slot` and the latency we are protecting
+    /// against here is gossip-bus age (multiple slots), not boundary timing.
+    pub fn attestationIsTooOld(self: *Self, data: types.AttestationData) bool {
+        const cutoff_slots = self.gossip_attestation_max_age_slots;
+        if (cutoff_slots == 0) return false;
+        const current_time = self.forkChoice.fcStore.slot_clock.time.load(.monotonic);
+        const current_slot: u64 = @divFloor(current_time, constants.INTERVALS_PER_SLOT);
+        return data.slot + cutoff_slots < current_slot;
+    }
+
     pub fn validateAttestationData(self: *Self, data: types.AttestationData, is_from_block: bool) !void {
         const timer = zeam_metrics.lean_attestation_validation_time_seconds.start();
         defer _ = timer.observe();
@@ -4097,6 +4148,21 @@ pub const BeamChain = struct {
                 self.forkChoice.fcStore.slot_clock.time.load(.monotonic),
             });
             return AttestationValidationError.AttestationTooFarInFuture;
+        }
+
+        // Operator-tunable past-side cutoff (`--gossip-attestation-max-age-slots`).
+        // Off by default; when enabled it is symmetric to the future bound and
+        // applies only to gossip — block-included attestations are trusted under
+        // the block's own validation. Hard drop (no pending-buffer replay):
+        // unlike the future-slot case there is no expected near-term event that
+        // would make the attestation valid again.
+        if (!is_from_block and self.attestationIsTooOld(data)) {
+            self.logger.debug("attestation validation failed: too old slot={d} time={d} max_age_slots={d}", .{
+                data.slot,
+                self.forkChoice.fcStore.slot_clock.time.load(.monotonic),
+                self.gossip_attestation_max_age_slots,
+            });
+            return AttestationValidationError.AttestationTooOld;
         }
 
         // 1. Validate that source, target, and head blocks exist in proto array (thread-safe)
@@ -4309,6 +4375,20 @@ pub const BeamChain = struct {
     /// skipped and the skip metric is incremented.
     pub fn submitAggregateOnInterval(self: *Self, node: *@import("./node.zig").BeamNode, time_intervals: usize) void {
         const slot = @divFloor(time_intervals, constants.INTERVALS_PER_SLOT);
+
+        // Operator-tunable non-finalisation prune (`--max-unfinalized-attestation-age-slots`).
+        // Runs once per aggregator interval — on aggregators only, because the
+        // map growth that motivates the cap is aggregator-driven. No-op when
+        // the flag is `0` (default) or when head is younger than the configured
+        // window. Pruning is best-effort: a failure must not stop the aggregator
+        // tick. See #899.
+        if (self.max_unfinalized_attestation_age_slots > 0) {
+            const head = self.forkChoice.getHead();
+            self.forkChoice.pruneStaleAttestationDataByHeadAge(head.slot, self.max_unfinalized_attestation_age_slots) catch |err| {
+                self.logger.warn("failed to prune non-finalized attestation data at slot={d}: {any}", .{ slot, err });
+            };
+        }
+
         if (!self.is_aggregator_enabled.load(.acquire) or self.registered_validator_ids.len == 0) {
             zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_aggregator" }) catch {};
             return;
@@ -4699,6 +4779,10 @@ const AttestationValidationError = error{
     HeadCheckpointSlotMismatch,
     HeadOlderThanTarget,
     AttestationTooFarInFuture,
+    /// Operator-tunable (`--gossip-attestation-max-age-slots`). Hard drop
+    /// for gossip attestations older than the configured slot window.
+    /// Never raised when the flag is left at its `0` default.
+    AttestationTooOld,
 };
 pub const BlockValidationError = error{
     UnknownParentBlock,

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2325,6 +2325,57 @@ pub const ForkChoice = struct {
         );
     }
 
+    /// Operator-tunable companion to `pruneStaleAttestationData` for chains
+    /// where finalisation has stalled. Removes attestation_signatures and
+    /// aggregated_payloads entries with `data.slot + max_age_slots < head_slot`,
+    /// regardless of whether their target has been finalised.
+    ///
+    /// Without this cap, a chain that never finalises (devnet partition, gossip
+    /// drop, validator-set issue) accumulates `AttestationData` entries
+    /// forever, slowing every aggregate pass and bloating memory (#899).
+    ///
+    /// No-op when `max_age_slots == 0` (the default) — callers are expected to
+    /// gate this method on the operator flag.
+    pub fn pruneStaleAttestationDataByHeadAge(self: *Self, head_slot: types.Slot, max_age_slots: u64) !void {
+        if (max_age_slots == 0) return;
+        if (head_slot <= max_age_slots) return;
+        const cutoff_slot: types.Slot = head_slot - max_age_slots;
+
+        self.signatures_mutex.lock();
+        defer self.signatures_mutex.unlock();
+
+        var att_sig_keys_to_remove: std.ArrayList(types.AttestationData) = .empty;
+        defer att_sig_keys_to_remove.deinit(self.allocator);
+
+        var att_sig_it = self.attestation_signatures.iterator();
+        while (att_sig_it.next()) |entry| {
+            if (entry.key_ptr.slot < cutoff_slot) {
+                try att_sig_keys_to_remove.append(self.allocator, entry.key_ptr.*);
+            }
+        }
+
+        for (att_sig_keys_to_remove.items) |data| {
+            self.attestation_signatures.removeAndDeinit(data);
+        }
+
+        const removed_known = try prunePayloadMapByDataSlot(self.allocator, &self.latest_known_aggregated_payloads, cutoff_slot);
+        const removed_new = try prunePayloadMapByDataSlot(self.allocator, &self.latest_new_aggregated_payloads, cutoff_slot);
+
+        if (att_sig_keys_to_remove.items.len + removed_known + removed_new > 0) {
+            self.logger.debug(
+                "pruned non-finalized attestation data: gossip={d} payloads_known={d} payloads_new={d} head_slot={d} cutoff_slot={d} max_age_slots={d}",
+                .{
+                    att_sig_keys_to_remove.items.len,
+                    removed_known,
+                    removed_new,
+                    head_slot,
+                    cutoff_slot,
+                    max_age_slots,
+                },
+            );
+        }
+    }
+
     fn prunePayloadMapBySlot(
         allocator: Allocator,
         payloads: *AggregatedPayloadsMap,
@@ -2337,6 +2388,37 @@ pub const ForkChoice = struct {
         var it = payloads.iterator();
         while (it.next()) |entry| {
             if (entry.key_ptr.target.slot > finalized_slot) continue;
+
+            removed_total += entry.value_ptr.items.len;
+            try keys_to_remove.append(allocator, entry.key_ptr.*);
+        }
+
+        for (keys_to_remove.items) |data| {
+            if (payloads.fetchRemove(data)) |kv| {
+                var mutable_val = kv.value;
+                deinitAggregatedPayloadsList(allocator, &mutable_val);
+            }
+        }
+        return removed_total;
+    }
+
+    /// Same as `prunePayloadMapBySlot` but filters by `entry.key_ptr.slot`
+    /// (`AttestationData.slot`) rather than `target.slot`. Used by the
+    /// non-finalisation, head-age-based prune which evicts everything whose
+    /// vote slot is older than the configured window — independent of where
+    /// the chain's target checkpoint sits.
+    fn prunePayloadMapByDataSlot(
+        allocator: Allocator,
+        payloads: *AggregatedPayloadsMap,
+        cutoff_slot: types.Slot,
+    ) !usize {
+        var keys_to_remove: std.ArrayList(types.AttestationData) = .empty;
+        defer keys_to_remove.deinit(allocator);
+
+        var removed_total: usize = 0;
+        var it = payloads.iterator();
+        while (it.next()) |entry| {
+            if (entry.key_ptr.slot >= cutoff_slot) continue;
 
             removed_total += entry.value_ptr.items.len;
             try keys_to_remove.append(allocator, entry.key_ptr.*);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -59,6 +59,15 @@ const NodeOpts = struct {
     /// `--chain-worker` (bool); `--chain-worker false` is the
     /// kill-switch for the legacy synchronous path.
     chain_worker_enabled: bool = true,
+    /// Plumbed to `ChainOpts.gossip_attestation_max_age_slots`. `0`
+    /// keeps current behaviour (no too-old gossip cutoff). See #899.
+    gossip_attestation_max_age_slots: u64 = 0,
+    /// Plumbed to `ChainOpts.max_unfinalized_attestation_age_slots`.
+    /// `0` keeps current behaviour (no non-finalisation prune). #899.
+    max_unfinalized_attestation_age_slots: u64 = 0,
+    /// Plumbed to `ChainOpts.aggregate_concurrent_limit`. `1`
+    /// preserves the historical #873 invariant.
+    aggregate_concurrent_limit: u32 = 1,
 };
 
 pub const BeamNode = struct {
@@ -138,6 +147,9 @@ pub const BeamNode = struct {
                 .node_registry = opts.node_registry,
                 .is_aggregator = opts.is_aggregator,
                 .thread_pool = opts.thread_pool,
+                .gossip_attestation_max_age_slots = opts.gossip_attestation_max_age_slots,
+                .max_unfinalized_attestation_age_slots = opts.max_unfinalized_attestation_age_slots,
+                .aggregate_concurrent_limit = opts.aggregate_concurrent_limit,
             },
             network.connected_peers,
         ) catch |init_err| {


### PR DESCRIPTION
## Summary

Three opt-in operator flags for stalled-chain aggregator behaviour, surfaced by [#899](https://github.com/blockblaz/zeam/issues/899). Every flag defaults to the pre-existing behaviour — non-aggregator nodes and healthy-chain aggregators see no change unless the flag is set.

### 1. \`--gossip-attestation-max-age-slots N\`  *(default 0 = off)*

Drops gossip attestations whose \`data.slot + N < current_slot\`. Symmetric to the implicit future-side bound \`GOSSIP_DISPARITY_INTERVALS\` (\`BeamChain.attestationIsTooFarInFuture\`).

Implementation:

- New \`AttestationValidationError.AttestationTooOld\` variant (deliberately **not** re-using \`AttestationTooFarInFuture\` so the pending-attestation buffer's replay logic does not retry too-old entries — there is no expected near-term event that would make a too-old attestation valid again).
- Block-included attestations skip the check, consistent with the future-side bound.

Useful on devnets where stale peers re-broadcast attestations from finalisation-orphaned slots and pile them into the aggregator input set faster than the aggregator can drain them.

### 2. \`--max-unfinalized-attestation-age-slots N\`  *(default 0 = off)*

Periodic non-finalisation prune. Today's \`pruneStaleAttestationData(finalized_slot)\` only runs from \`processFinalizationAdvancement\`, so on a chain that never finalises (devnet partition, gossip drop, validator-set issue) the retained maps grow unboundedly and slow every aggregate pass.

The new \`ForkChoice.pruneStaleAttestationDataByHeadAge(head_slot, max_age_slots)\` evicts \`attestation_signatures\` and aggregated_payloads entries with \`data.slot + N < head_slot\` regardless of finalisation state. Called from \`submitAggregateOnInterval\` once per slot. Finalisation-based pruning is unchanged. No-op when N=0.

New helper \`prunePayloadMapByDataSlot\` is a sibling of the existing \`prunePayloadMapBySlot\` that filters by \`AttestationData.slot\` instead of \`target.slot\` (the head-age window is independent of where the chain's target checkpoint sits).

### 3. \`--aggregate-concurrent-limit N\`  *(default 1)*

Surfaces the \`aggregate_group.concurrent_limit\` knob currently hardcoded to \`.limited(1)\` (the [#873](https://github.com/blockblaz/zeam/issues/873) invariant). Default \`1\` preserves the historical behaviour exactly. Larger values let a slow pass not skip the next interval on hosts where each pass is well under one slot (after [#900](https://github.com/blockblaz/zeam/pull/900)'s slot window + [#903](https://github.com/blockblaz/zeam/pull/903)'s ThinLTO + \`--rayon-threads\`).

## Plumbing

CLI args → \`pkgs/cli/src/node.zig:NodeOptions\` → \`pkgs/node/src/node.zig:NodeOpts\` → \`pkgs/node/src/chain.zig:ChainOpts\` → \`BeamChain\`. The \`std.Io.Threaded.init\` call in \`BeamChain.init\` now reads \`opts.aggregate_concurrent_limit\` instead of the literal \`.limited(1)\`.

## Test plan

- [x] \`zig fmt --check .\`
- [x] \`cargo fmt --manifest-path rust/Cargo.toml --all -- --check\`
- [x] \`cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings\`
- [x] \`zig build test --summary all\` — all targets pass
- [x] \`zig build simtest --summary all\` — all 15 integration tests pass
- [ ] On devnet: verify a zeam aggregator started with \`--gossip-attestation-max-age-slots 32 --max-unfinalized-attestation-age-slots 64 --aggregate-concurrent-limit 1\` drops fewer aggregate intervals (\`zeam_aggregate_skip_total{reason=\"in_flight\"}\`) without regressing block-proposal coverage

## Related

- [#899](https://github.com/blockblaz/zeam/issues/899) — parent investigation
- [#900](https://github.com/blockblaz/zeam/pull/900) — slot-window the att_data set (already merged); this PR is its operator-knob sibling
- [#902](https://github.com/blockblaz/zeam/pull/902) — aggregator observability counters (companion in this series)
- [#903](https://github.com/blockblaz/zeam/pull/903) — ThinLTO multisig-release profile + \`--rayon-threads\` (companion in this series)
- [#873](https://github.com/blockblaz/zeam/issues/873) — original concurrent_limit=1 invariant on aggregate_group