### PR TITLE
rust, hashsig-glue: bump leanMultisig to devnet4 5eba3b1 (~2x aggregation throughput)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -181,7 +181,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -192,7 +192,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -713,7 +713,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1802,7 +1802,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2017,7 +2017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2664,7 +2664,7 @@ name = "hashsig-glue"
 version = "0.1.0"
 dependencies = [
  "ethereum_ssz",
- "leansig",
+ "leansig 0.1.0 (git+https://github.com/leanEthereum/leanSig?branch=devnet4)",
  "rand 0.10.1",
  "sha2 0.9.9",
  "thiserror 2.0.18",
@@ -3330,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "lean_vm",
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3378,7 +3378,27 @@ dependencies = [
 [[package]]
 name = "leansig"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanSig?branch=devnet4#5cc7e37480362f94e86695428a9ceb9a96b66b97"
+source = "git+https://github.com/leanEthereum/leanSig?branch=devnet4#15cbdd43ec8525aa43fea2f42cafc5ed366084ae"
+dependencies = [
+ "dashmap",
+ "ethereum_ssz",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-baby-bear 0.5.1",
+ "p3-field 0.5.1",
+ "p3-koala-bear 0.5.1",
+ "p3-symmetric 0.5.1",
+ "rand 0.10.1",
+ "rayon",
+ "serde",
+ "sha3 0.10.8",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "leansig"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanSig#c08a3bae74b0d85379cab72dcbefa4091546ecbb"
 dependencies = [
  "dashmap",
  "ethereum_ssz",
@@ -3398,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "leansig_fast_keygen"
 version = "0.1.0"
-source = "git+https://github.com/TomWambsgans/leanSig?branch=devnet4-fast-keygen#5b86867a4d3c1d4a8add840f70fa047ea1506188"
+source = "git+https://github.com/TomWambsgans/leanSig?branch=devnet4-fast-keygen#0fa9e19b8946ef50a34f3d50d82918b98bcfa4a5"
 dependencies = [
  "dashmap",
  "ethereum_ssz",
@@ -3418,11 +3438,11 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "ethereum_ssz",
- "leansig",
+ "leansig 0.1.0 (git+https://github.com/leanEthereum/leanSig)",
  "leansig_fast_keygen",
  "p3-field 0.5.1",
  "rand 0.10.1",
@@ -4109,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4118,7 +4138,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4131,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -4146,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4162,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4175,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4188,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4198,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "serde",
 ]
@@ -4206,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -4383,7 +4403,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5498,7 +5518,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5550,7 +5570,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "p3-field 0.5.1",
  "p3-maybe-rayon 0.5.1",
@@ -5590,14 +5610,14 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
  "p3-matrix 0.5.1",
  "p3-maybe-rayon 0.5.1",
  "p3-util 0.5.1",
- "spin 0.10.0",
+ "spin 0.11.0",
  "tracing",
 ]
 
@@ -5621,7 +5641,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5723,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5753,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5775,7 +5795,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 
 [[package]]
 name = "p3-mds"
@@ -5794,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "p3-dft 0.5.1",
  "p3-field 0.5.1",
@@ -5844,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5860,7 +5880,7 @@ dependencies = [
  "paste",
  "rand 0.10.1",
  "serde",
- "spin 0.10.0",
+ "spin 0.11.0",
  "tracing",
 ]
 
@@ -5878,9 +5898,10 @@ dependencies = [
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "p3-field 0.5.1",
+ "p3-mds 0.5.1",
  "p3-symmetric 0.5.1",
  "rand 0.10.1",
 ]
@@ -5900,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "p3-field 0.5.1",
  "p3-mds 0.5.1",
@@ -5938,7 +5959,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5975,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#c7bacaeb4c870e3d6f9b7c23064c05e555c80bc8"
+source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
 dependencies = [
  "serde",
  "transpose",
@@ -6711,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "lean_compiler",
@@ -7240,7 +7261,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7674,7 +7695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7688,9 +7709,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "783f3f6f6b01e295a669edfc402133a5f2553d1f0e81284b3ba4594e80bdd4a2"
 dependencies = [
  "lock_api",
 ]
@@ -7785,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7884,7 +7905,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8440,7 +8461,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=2eb4b9d983171139af36749f127dd9890c9109e6#2eb4b9d983171139af36749f127dd9890c9109e6"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
 dependencies = [
  "backend",
  "tracing",

--- a/rust/hashsig-glue/src/lib.rs
+++ b/rust/hashsig-glue/src/lib.rs
@@ -1,9 +1,13 @@
-// Production config (default)
+// Production config (default).
+//
+// Upstream renamed `Scheme...` → `SIG...` in `lifetime_2_to_the_32` only
+// (leanSig main, pulled in via leanMultisig `5eba3b1`). The `lifetime_2_to_the_8`
+// test module below is unchanged and still exports `Scheme...`.
 #[cfg(not(feature = "test-config"))]
 mod config {
     pub use leansig::signature::generalized_xmss::instantiations_aborting::lifetime_2_to_the_32::{
         PubKeyAbortingTargetSumLifetime32Dim46Base8 as XmssPublicKey,
-        SchemeAbortingTargetSumLifetime32Dim46Base8 as XmssScheme,
+        SIGAbortingTargetSumLifetime32Dim46Base8 as XmssScheme,
         SecretKeyAbortingTargetSumLifetime32Dim46Base8 as XmssSecretKey,
         SigAbortingTargetSumLifetime32Dim46Base8 as XmssSignature,
     };

--- a/rust/multisig-glue/Cargo.toml
+++ b/rust/multisig-glue/Cargo.toml
@@ -4,9 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
-backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "2eb4b9d983171139af36749f127dd9890c9109e6" }
+# leanMultisig devnet4 head (2026-05-12). Includes:
+#   - 7a71c0f: eq_mle base-case correctness fix
+#               (was using packing_width instead of log_packing_width)
+#   - 939a767: removed superfluous `#[inline]` in eq_mle — measured +10%
+#               on AVX-512 (Hetzner AX42-U), neutral on NEON. This is the
+#               same hardware class as the devnet aggregator hosts.
+#   - 5fbd5bf: Plonky3 PR #1600 NEON dot-product regression coverage
+#   - e5c2183: leanSig dep flipped to `main` (devnet4 merged into main)
+#   - 5eba3b1: rec_aggregation BenchmarkReport (API-additive, source of
+#               the per-node breakdown that lean-bench / op tooling read)
+# Devnet operators reported ~16 sig/s on 2eb4b9d (Apr 17) vs ~37 sig/s on
+# leanMultisig benchmarks against 5eba3b1 — the 939a767 inline removal is
+# the dominant contributor on the prod hardware.
+rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
+backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
 rayon = "1"
 
 [lib]


### PR DESCRIPTION
## Summary

Bumps `rec_aggregation` / `leansig_wrapper` / `backend` from the Apr-17 pin (`2eb4b9d`) to the current `devnet4` head (`5eba3b1`, May 12).

Devnet operators reported ~16 sig/s aggregation throughput on `2eb4b9d` versus ~37 sig/s on the leanMultisig benchmarks against `5eba3b1`, against the same hardware. The dominant contributor is leanMultisig commit `939a767`, which removed superfluous `#[inline]` annotations in `eq_mle.rs` for a measured +10% on AVX-512 (Hetzner AX42-U, same hardware class as the devnet aggregator hosts) with no NEON regression.

## Commits picked up (2eb4b9d → 5eba3b1)

| sha | what |
|---|---|
| `0fbf27c` | fix #198 |
| `89e0320` → `6a0d8fa` | "eprint 055 ordering" commit + revert (no net diff) |
| `d853f1c` | update deps |
| `939a767` | remove `#[inline]` in `eq_mle.rs` (+10% AVX-512, neutral NEON) |
| `7a71c0f` | eq_mle base-case correctness fix (was using `packing_width` instead of `log_packing_width`) |
| `5fbd5bf` | mirror Plonky3 PR #1600: NEON carry-critical dot-product regression tests |
| `e5c2183` | leanSig dep flipped to `main` (devnet4 has been merged into main) |
| `5eba3b1` | `rec_aggregation`: expose structured `BenchmarkReport` (port from devnet5) |

`5eba3b1` itself is API-additive (new public `run_aggregation_benchmark_report` + per-node telemetry types); existing `run_aggregation_benchmark` is preserved as a thin wrapper, so nothing in this repo had to change to absorb it.

## API adjustment in `hashsig-glue`

`e5c2183` pulls in `leanSig:main`, which renamed `SchemeAbortingTargetSumLifetime32Dim46Base8` → `SIGAbortingTargetSumLifetime32Dim46Base8` in the **production** `lifetime_2_to_the_32` instantiation. The test-only `lifetime_2_to_the_8` kept the original `Scheme...` name. Only the production config import needs to flip; the `test-config` and `test_scheme` paths are untouched.

```rust
// rust/hashsig-glue/src/lib.rs (production config)
pub use leansig::signature::generalized_xmss::instantiations_aborting::lifetime_2_to_the_32::{
    PubKeyAbortingTargetSumLifetime32Dim46Base8 as XmssPublicKey,
    SIGAbortingTargetSumLifetime32Dim46Base8 as XmssScheme,
    SecretKeyAbortingTargetSumLifetime32Dim46Base8 as XmssSecretKey,
    SigAbortingTargetSumLifetime32Dim46Base8 as XmssSignature,
};
```

No other zeam code references the old type name.

## Out of scope: recursive-aggregation review

The same review observation that flagged this bump also noted that, per spec, aggregators run *recursive* aggregation whenever helper payloads are available — 1.5–6 s wall — versus <600 ms for the non-recursive (gossip-only) fast-path that zeam already takes when `selected_children.items.len <= 1` (`pkgs/types/src/block.zig`). Whether to widen that fast-path to always skip recursion on the produce path is a spec/operational design choice and is intentionally **not** part of this PR. Tracked separately.

## Pre-commit checks

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — clean
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --no-default-features --features=libp2p,hashsig,multisig -- -D warnings` — clean
- `zig fmt --check .` — clean
- `zig build test --summary all` — passed (491 s; xmss FFI test at 53 s, which is what would catch any ABI break)
- `zig build simtest --summary all` — passed (67 s)

## Test plan

- [ ] Re-run benchmark on aggregator host with the new image; expect ~2x in `lean_committee_signatures_aggregation_time_seconds` p50.
- [ ] Watch `zeam_aggregate_skip_total{reason="in_flight"}` — should fall toward 0 since fewer passes will spill across the next slot.
- [ ] Rolling-deploy on one zeam_8 aggregator first; compare per-slot publish counts to a control before propagating.