### PR TITLE
sync: keep checkpoint parent fetches on serving peer

### DIFF
--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -83,7 +83,7 @@ test "Network: preferred blocks_by_root peer is a hint with fallback" {
         }.cb,
     };
 
-    var pinned = (try network.ensureBlocksByRootRequestToPeer(&[_]types.Root{root_a}, 0, handler, "serving-peer")).?;
+    var pinned = (try network.ensureBlocksByRootRequest(&[_]types.Root{root_a}, 0, handler, "serving-peer")).?;
     defer pinned.deinit(allocator);
     try std.testing.expectEqualStrings("serving-peer", pinned.peer_id);
     try std.testing.expectEqualStrings("serving-peer", ctx.last_peer.?);
@@ -92,7 +92,7 @@ test "Network: preferred blocks_by_root peer is a hint with fallback" {
     try std.testing.expect(network.disconnectPeer("serving-peer"));
 
     const root_b: types.Root = [_]u8{0xbb} ** 32;
-    var fallback = (try network.ensureBlocksByRootRequestToPeer(&[_]types.Root{root_b}, 0, handler, "serving-peer")).?;
+    var fallback = (try network.ensureBlocksByRootRequest(&[_]types.Root{root_b}, 0, handler, "serving-peer")).?;
     defer fallback.deinit(allocator);
     try std.testing.expectEqualStrings("fallback-peer", fallback.peer_id);
     try std.testing.expectEqualStrings("fallback-peer", ctx.last_peer.?);
@@ -1024,26 +1024,11 @@ pub const Network = struct {
     /// `lean_block_fetch_dedup_total{outcome=…}` buckets.
     pub const EnsureBlocksByRootError = error{InFlightCapReached};
 
+    /// Issue #909 review #5: single public entry-point for blocks-by-root
+    /// requests.  `preferred_peer` is a **hint**, not a hard requirement
+    /// (see TOCTOU contract below): when the preferred peer is still
+    /// connected it will be used; otherwise we fall back to `selectPeer()`.
     pub fn ensureBlocksByRootRequest(
-        self: *Self,
-        roots: []const types.Root,
-        depth: u32,
-        handler: networks.OnReqRespResponseCbHandler,
-    ) !?BlocksByRootRequestResult {
-        return self.ensureBlocksByRootRequestWithPeer(roots, depth, handler, null);
-    }
-
-    pub fn ensureBlocksByRootRequestToPeer(
-        self: *Self,
-        roots: []const types.Root,
-        depth: u32,
-        handler: networks.OnReqRespResponseCbHandler,
-        peer_id: []const u8,
-    ) !?BlocksByRootRequestResult {
-        return self.ensureBlocksByRootRequestWithPeer(roots, depth, handler, peer_id);
-    }
-
-    fn ensureBlocksByRootRequestWithPeer(
         self: *Self,
         roots: []const types.Root,
         depth: u32,

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -951,6 +951,26 @@ pub const Network = struct {
         depth: u32,
         handler: networks.OnReqRespResponseCbHandler,
     ) !?BlocksByRootRequestResult {
+        return self.ensureBlocksByRootRequestWithPeer(roots, depth, handler, null);
+    }
+
+    pub fn ensureBlocksByRootRequestToPeer(
+        self: *Self,
+        roots: []const types.Root,
+        depth: u32,
+        handler: networks.OnReqRespResponseCbHandler,
+        peer_id: []const u8,
+    ) !?BlocksByRootRequestResult {
+        return self.ensureBlocksByRootRequestWithPeer(roots, depth, handler, peer_id);
+    }
+
+    fn ensureBlocksByRootRequestWithPeer(
+        self: *Self,
+        roots: []const types.Root,
+        depth: u32,
+        handler: networks.OnReqRespResponseCbHandler,
+        preferred_peer: ?[]const u8,
+    ) !?BlocksByRootRequestResult {
         if (roots.len == 0) return null;
 
         if (!self.shouldRequestBlocksByRoot(roots)) return null;
@@ -983,7 +1003,10 @@ pub const Network = struct {
             zeam_metrics.metrics.zeam_blocks_by_root_inflight.set(self.blocks_by_root_inflight.load(.monotonic));
         };
 
-        const peer = (try self.selectPeer()) orelse return error.NoPeersAvailable;
+        const peer = if (preferred_peer) |peer_id| blk: {
+            if (!self.hasPeer(peer_id)) return error.NoPeersAvailable;
+            break :blk try self.allocator.dupe(u8, peer_id);
+        } else (try self.selectPeer()) orelse return error.NoPeersAvailable;
         var peer_owned = true;
         errdefer if (peer_owned) self.allocator.free(peer);
 

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -35,6 +35,9 @@ test "Network: preferred blocks_by_root peer is a hint with fallback" {
             return true;
         }
 
+        fn subscribeGossip(_: *anyopaque, _: []networks.GossipTopic, _: networks.OnGossipCbHandler) anyerror!void {}
+        fn onGossip(_: *anyopaque, _: *networks.GossipMessage, _: []const u8) anyerror!void {}
+
         fn sendRequest(
             ptr: *anyopaque,
             peer_id: []const u8,
@@ -61,7 +64,12 @@ test "Network: preferred blocks_by_root peer is a hint with fallback" {
     defer ctx.deinit();
 
     var network = try Network.init(allocator, .{
-        .gossip = .{ .ptr = &ctx, .publishFn = Ctx.publish },
+        .gossip = .{
+            .ptr = &ctx,
+            .publishFn = Ctx.publish,
+            .subscribeFn = Ctx.subscribeGossip,
+            .onGossipFn = Ctx.onGossip,
+        },
         .reqresp = .{
             .ptr = &ctx,
             .sendRequestFn = Ctx.sendRequest,

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -19,6 +19,85 @@ pub const PeerInfo = struct {
     blocks_by_range_unavailable: bool = false,
 };
 
+test "Network: preferred blocks_by_root peer is a hint with fallback" {
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        allocator: Allocator,
+        last_peer: ?[]u8 = null,
+        next_request_id: u64 = 1,
+
+        fn deinit(self: *@This()) void {
+            if (self.last_peer) |peer| self.allocator.free(peer);
+        }
+
+        fn publish(_: *anyopaque, _: *const networks.GossipMessage) anyerror!bool {
+            return true;
+        }
+
+        fn sendRequest(
+            ptr: *anyopaque,
+            peer_id: []const u8,
+            _: *const networks.ReqRespRequest,
+            _: ?networks.OnReqRespResponseCbHandler,
+        ) anyerror!u64 {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (self.last_peer) |old| self.last_peer = blk: {
+                self.allocator.free(old);
+                break :blk null;
+            };
+            self.last_peer = try self.allocator.dupe(u8, peer_id);
+            const id = self.next_request_id;
+            self.next_request_id += 1;
+            return id;
+        }
+
+        fn onReqRespRequest(_: *anyopaque, _: *networks.ReqRespRequest, _: networks.ReqRespServerStream) anyerror!void {}
+        fn subscribeReqResp(_: *anyopaque, _: networks.OnReqRespRequestCbHandler) anyerror!void {}
+        fn subscribePeers(_: *anyopaque, _: networks.OnPeerEventCbHandler) anyerror!void {}
+    };
+
+    var ctx = Ctx{ .allocator = allocator };
+    defer ctx.deinit();
+
+    var network = try Network.init(allocator, .{
+        .gossip = .{ .ptr = &ctx, .publishFn = Ctx.publish },
+        .reqresp = .{
+            .ptr = &ctx,
+            .sendRequestFn = Ctx.sendRequest,
+            .onReqRespRequestFn = Ctx.onReqRespRequest,
+            .subscribeFn = Ctx.subscribeReqResp,
+        },
+        .peers = .{ .ptr = &ctx, .subscribeFn = Ctx.subscribePeers },
+    });
+    defer network.deinit();
+
+    try network.connectPeer("serving-peer");
+    try network.connectPeer("fallback-peer");
+
+    const root_a: types.Root = [_]u8{0xaa} ** 32;
+    const handler: networks.OnReqRespResponseCbHandler = .{
+        .ptr = &ctx,
+        .onReqRespResponseCb = struct {
+            fn cb(_: *anyopaque, _: *const networks.ReqRespResponseEvent) anyerror!void {}
+        }.cb,
+    };
+
+    var pinned = (try network.ensureBlocksByRootRequestToPeer(&[_]types.Root{root_a}, 0, handler, "serving-peer")).?;
+    defer pinned.deinit(allocator);
+    try std.testing.expectEqualStrings("serving-peer", pinned.peer_id);
+    try std.testing.expectEqualStrings("serving-peer", ctx.last_peer.?);
+    network.finalizePendingRequest(pinned.request_id);
+
+    try std.testing.expect(network.disconnectPeer("serving-peer"));
+
+    const root_b: types.Root = [_]u8{0xbb} ** 32;
+    var fallback = (try network.ensureBlocksByRootRequestToPeer(&[_]types.Root{root_b}, 0, handler, "serving-peer")).?;
+    defer fallback.deinit(allocator);
+    try std.testing.expectEqualStrings("fallback-peer", fallback.peer_id);
+    try std.testing.expectEqualStrings("fallback-peer", ctx.last_peer.?);
+}
+
 pub const StatusRequestContext = struct {
     peer_id: []const u8,
 
@@ -1003,9 +1082,16 @@ pub const Network = struct {
             zeam_metrics.metrics.zeam_blocks_by_root_inflight.set(self.blocks_by_root_inflight.load(.monotonic));
         };
 
+        // `preferred_peer` is a routing hint, not a hard requirement. It keeps
+        // checkpoint/parent walks on the peer that just proved it can serve the
+        // chain, but if that peer disconnects before the next request, fall
+        // back to normal peer selection instead of stalling the walk.
+        // There is still an unavoidable TOCTOU window between this check and
+        // the transport dispatch below; in that case sendBlocksByRootRequest
+        // returns the backend error and the existing retry paths handle it.
         const peer = if (preferred_peer) |peer_id| blk: {
-            if (!self.hasPeer(peer_id)) return error.NoPeersAvailable;
-            break :blk try self.allocator.dupe(u8, peer_id);
+            if (self.hasPeer(peer_id)) break :blk try self.allocator.dupe(u8, peer_id);
+            break :blk (try self.selectPeer()) orelse return error.NoPeersAvailable;
         } else (try self.selectPeer()) orelse return error.NoPeersAvailable;
         var peer_owned = true;
         errdefer if (peer_owned) self.allocator.free(peer);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2200,6 +2200,13 @@ pub const BeamNode = struct {
     /// stream, causing 300+ sequential round-trips when a peer walks a long parent chain.
     /// Collecting roots here and flushing them in one request reduces that to a single
     /// round-trip for the same burst of missing parents.
+    ///
+    /// **Throughput trade-off (review #3):** when `preferred_peer` is non-null, all
+    /// roots in this batch are sent to a single peer.  This keeps checkpoint /
+    /// parent walks fast (the peer already proved it can serve the chain), but
+    /// concentrates load and loses parallelism that random peer selection would
+    /// provide.  If the peer's bandwidth becomes a bottleneck, callers can pass
+    /// `null` (gossip and cached-descendant paths already do) to spread load.
     fn flushPendingParentFetches(self: *Self, preferred_peer: ?[]const u8) void {
         // Drain under the dedicated lock so the gossip / req-resp paths
         // can keep enqueueing while we issue the batched fetch.
@@ -2341,10 +2348,7 @@ pub const BeamNode = struct {
         if (missing_roots.items.len == 0) return;
 
         const handler = self.getReqRespResponseHandler();
-        const maybe_request = (if (preferred_peer) |peer_id|
-            self.network.ensureBlocksByRootRequestToPeer(missing_roots.items, depth, handler, peer_id)
-        else
-            self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler)) catch |err| blk: {
+        const maybe_request = self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler, preferred_peer) catch |err| blk: {
             switch (err) {
                 error.NoPeersAvailable => {
                     // PR #842 review #1: previously this path bumped

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2805,6 +2805,17 @@ pub const BeamNode = struct {
         }
         // Finalize clears pending state + releases in-flight slot.
         self.network.finalizePendingRequest(request_id);
+
+        // `processBlockByRootChunk` may have discovered the next parent while
+        // this request was still counted in `blocks_by_root_inflight`. During a
+        // long parent walk (late-start sync / checkpoint catch-up) that can hit
+        // MAX_CONCURRENT_BLOCKS_BY_ROOT before any completion event releases a
+        // slot, leaving the newest parent root queued in
+        // `batch_pending_parent_roots` with nobody left to flush it. Now that
+        // this request is finalized, immediately drain any queued parent roots
+        // and keep the walk on the peer that served this response.
+        self.flushPendingParentFetches(peer_id);
+
         // Re-schedule each unserved root; fetchBlockByRoots will
         // dedup against forkchoice/cache/pending and pick a new peer.
         for (roots_to_retry.items) |item| {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -399,7 +399,7 @@ pub const BeamNode = struct {
                         }
                     }
                     // Flush any pending parent root fetches accumulated during caching.
-                    self.flushPendingParentFetches();
+                    self.flushPendingParentFetches(null);
                     // Return early - don't pass to chain until parent arrives
                     return;
                 }
@@ -534,7 +534,7 @@ pub const BeamNode = struct {
         }
 
         // Flush any parent roots accumulated during block/descendant processing.
-        self.flushPendingParentFetches();
+        self.flushPendingParentFetches(null);
     }
 
     fn pruneCachedBlocksCallback(ptr: *anyopaque, finalized: types.Checkpoint) usize {
@@ -660,7 +660,7 @@ pub const BeamNode = struct {
 
         // Coalesce any parent fetches accumulated during the
         // descendant retry into one batched `blocks_by_root` request.
-        self.flushPendingParentFetches();
+        self.flushPendingParentFetches(null);
     }
 
     /// Rejected-block backchannel handler (#890 zclawz review). Fires
@@ -722,7 +722,7 @@ pub const BeamNode = struct {
                         );
                     }
                 }
-                self.flushPendingParentFetches();
+                self.flushPendingParentFetches(null);
             },
             .pre_finalized => {
                 self.finishRangeAsyncChunkImport(block_root, false, true);
@@ -1267,7 +1267,7 @@ pub const BeamNode = struct {
                             });
                         }
                     }
-                    self.flushPendingParentFetches();
+                    self.flushPendingParentFetches(block_ctx.peer_id);
                     return;
                 }
 
@@ -1318,7 +1318,7 @@ pub const BeamNode = struct {
         // Flush any parent roots queued during this RPC block's processing. When a syncing peer
         // walks a long parent chain one block at a time, each response triggers one more parent
         // fetch. Batching them here consolidates concurrent parent requests into one round-trip.
-        self.flushPendingParentFetches();
+        self.flushPendingParentFetches(block_ctx.peer_id);
     }
 
     // --- blocks_by_range catch-up orchestration (issue #893) ---
@@ -1369,7 +1369,7 @@ pub const BeamNode = struct {
 
     fn syncFetchPeerHeadByRoot(self: *Self, peer_id: []const u8, head_root: types.Root) void {
         const roots = [_]types.Root{head_root};
-        self.fetchBlockByRoots(&roots, 0) catch |err| {
+        self.fetchBlockByRootsFromPeer(&roots, 0, peer_id) catch |err| {
             self.logger.warn("failed to fetch peer head block 0x{x} from peer {s}{f}: {any}", .{
                 &head_root,
                 peer_id,
@@ -1728,7 +1728,7 @@ pub const BeamNode = struct {
                         self.logger.warn("blocks_by_range: failed to cache block 0x{x}: {any}", .{ &block_root, cache_err });
                     }
                 }
-                self.flushPendingParentFetches();
+                self.flushPendingParentFetches(peer_id);
                 return;
             }
             if (err == forkchoice.ForkChoiceError.PreFinalizedSlot) {
@@ -1750,10 +1750,10 @@ pub const BeamNode = struct {
         self.chain.onBlockFollowup(true, signed_block);
         self.replayPendingAttestationsAsync(.gossip_or_rpc_followup);
         self.processCachedDescendants(block_root);
-        self.fetchBlockByRoots(missing_roots, 0) catch |err| {
+        self.fetchBlockByRootsFromPeer(missing_roots, 0, peer_id) catch |err| {
             self.logger.warn("blocks_by_range: failed to fetch {d} missing block(s): {any}", .{ missing_roots.len, err });
         };
-        self.flushPendingParentFetches();
+        self.flushPendingParentFetches(peer_id);
     }
 
     fn completeBlocksByRangeRequest(self: *Self, request_id: u64, snap: networkFactory.Network.PendingRequestSnapshot) void {
@@ -2195,7 +2195,7 @@ pub const BeamNode = struct {
     /// stream, causing 300+ sequential round-trips when a peer walks a long parent chain.
     /// Collecting roots here and flushing them in one request reduces that to a single
     /// round-trip for the same burst of missing parents.
-    fn flushPendingParentFetches(self: *Self) void {
+    fn flushPendingParentFetches(self: *Self, preferred_peer: ?[]const u8) void {
         // Drain under the dedicated lock so the gossip / req-resp paths
         // can keep enqueueing while we issue the batched fetch.
         var roots: std.ArrayList(types.Root) = .empty;
@@ -2224,7 +2224,7 @@ pub const BeamNode = struct {
         if (roots.items.len == 0) return;
         self.logger.debug("flushing {d} pending parent root(s) as one batched blocks_by_root request", .{roots.items.len});
 
-        self.fetchBlockByRoots(roots.items, max_depth) catch |err| {
+        self.fetchBlockByRootsFromPeer(roots.items, max_depth, preferred_peer) catch |err| {
             self.logger.warn("failed to batch-fetch {d} pending parent root(s): {any}", .{ roots.items.len, err });
         };
     }
@@ -2233,6 +2233,15 @@ pub const BeamNode = struct {
         self: *Self,
         roots: []const types.Root,
         depth: u32,
+    ) !void {
+        return self.fetchBlockByRootsFromPeer(roots, depth, null);
+    }
+
+    fn fetchBlockByRootsFromPeer(
+        self: *Self,
+        roots: []const types.Root,
+        depth: u32,
+        preferred_peer: ?[]const u8,
     ) !void {
         if (roots.len == 0) return;
 
@@ -2327,7 +2336,10 @@ pub const BeamNode = struct {
         if (missing_roots.items.len == 0) return;
 
         const handler = self.getReqRespResponseHandler();
-        const maybe_request = self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler) catch |err| blk: {
+        const maybe_request = (if (preferred_peer) |peer_id|
+            self.network.ensureBlocksByRootRequestToPeer(missing_roots.items, depth, handler, peer_id)
+        else
+            self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler)) catch |err| blk: {
             switch (err) {
                 error.NoPeersAvailable => {
                     // PR #842 review #1: previously this path bumped


### PR DESCRIPTION
## Summary
- keep `blocks_by_root` catch-up anchored to the peer whose status/chunk proved it can serve the requested chain
- use that same serving peer for checkpoint-sync parent walks and by-range fallback parent fetches
- avoid randomly routing the next parent request to a connected helper with `head_slot=0`, which can stall `fc_initing`

## Hive failure
Investigated Hive sync test 285:
https://hive.leanroadmap.org/suite.html?suiteid=1779256418-f34322deaf329bb18567955ff881335b.json&suitename=sync&client=zeam_devnet4#test-285

The failing checkpoint-sync run anchored at finalized slot 17, fetched the peer head at slot 23, then routed the next parent fetch to the other connected peer (`head_slot=0`). The node stayed at head slot 17 and kept logging `forkchoice still initing (awaiting first justified checkpoint)` until Hive timed out.

## Validation
- `zig fmt pkgs/node/src/node.zig pkgs/node/src/network.zig`
- `zig build test` could not run in this workspace because local Zig is `0.15.2` while the repo/Dockerfile expects `0.16.0`; dependencies fail before compiling zeam (`Build.Graph` has no field `io`).
