### PR TITLE
metrics, node: aggregate prove metrics and scoped snapshot (#907)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -202,6 +202,8 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
     });
     zeam_xmss.addImport("ssz", ssz);
+    zeam_xmss.addImport("@zeam/metrics", zeam_metrics);
+    zeam_xmss.addImport("@zeam/utils", zeam_utils);
 
     // add zeam-types
     const zeam_types = b.addModule("@zeam/types", .{

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -85,9 +85,17 @@ const Metrics = struct {
     lean_pq_sig_aggregated_signatures_building_time_seconds: PQSigBuildingTimeHistogram,
     // Zeam-specific phase attribution for aggregate production (#899).
     // phase="snapshot" clones live signature/payload maps under signatures_mutex.
-    // phase="compute_ffi" builds recursive aggregate proofs from the snapshot.
+    // phase="att_data_prep" serial prepareAggregateAttData (hashTreeRoot, greedy
+    // payload pick, handle setup) inside computeAggregatedSignatures.
+    // phase="xmss_prove" leanMultisig rec_xmss_aggregate via xmss_aggregate FFI.
+    // phase="compute_ffi" full computeAggregatedSignatures (prep + parallel proves).
     // phase="commit" publishes results back into latest_new_aggregated_payloads.
     zeam_pq_sig_aggregated_signatures_building_phase_seconds: PQSigBuildingPhaseHistogram,
+    /// Wall time inside `xmss_aggregate` / leanMultisig `rec_xmss_aggregate` only
+    /// (one recursive STARK prove per att_data). Compare directly to lean-bench /
+    /// `cargo run --release -- recursion --n 2`; zeam worker histograms include
+    /// snapshot, prep, child-proof deserialize, and serialize on top of this.
+    zeam_xmss_rec_aggregate_prove_seconds: XmssRecAggregateProveHistogram,
     lean_pq_sig_aggregated_signatures_verification_time_seconds: PQSigAggregatedVerificationHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
@@ -429,6 +437,7 @@ const Metrics = struct {
     const PQSigAttestationsInAggregatedTotalCounter = metrics_lib.Counter(u64);
     const PQSigBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
     const PQSigBuildingPhaseHistogram = metrics_lib.HistogramVec(f32, struct { phase: []const u8 }, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 4 });
+    const XmssRecAggregateProveHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0 });
     const PQSigAggregatedVerificationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
     const PQSigAggregatedValidCounter = metrics_lib.Counter(u64);
     const PQSigAggregatedInvalidCounter = metrics_lib.Counter(u64);
@@ -739,6 +748,12 @@ fn observeAggregateWorkerDuration(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn onXmssRecAggregateProveHistogram(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.XmssRecAggregateProveHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeAggregationIntervalTick(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return;
     const histogram: *Metrics.AggregationIntervalTickHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -863,6 +878,10 @@ pub var zeam_aggregate_worker_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeAggregateWorkerDuration,
 };
+pub var zeam_xmss_rec_aggregate_prove_seconds: Histogram = .{
+    .context = null,
+    .observe = &onXmssRecAggregateProveHistogram,
+};
 pub var lean_pending_blocks_drain_iters: Histogram = .{
     .context = null,
     .observe = &observePendingBlocksDrainIters,
@@ -909,8 +928,9 @@ pub fn init(allocator: std.mem.Allocator) !void {
         // Aggregated attestation signature metrics
         .lean_pq_sig_aggregated_signatures_total = Metrics.PQSigAggregatedSignaturesTotalCounter.init("lean_pq_sig_aggregated_signatures_total", .{ .help = "Total number of aggregated signatures" }, .{}),
         .lean_pq_sig_attestations_in_aggregated_signatures_total = Metrics.PQSigAttestationsInAggregatedTotalCounter.init("lean_pq_sig_attestations_in_aggregated_signatures_total", .{ .help = "Total number of attestations included into aggregated signatures" }, .{}),
-        .lean_pq_sig_aggregated_signatures_building_time_seconds = Metrics.PQSigBuildingTimeHistogram.init("lean_pq_sig_aggregated_signatures_building_time_seconds", .{ .help = "Time spent inside computeAggregatedSignatures per att_data (wrap/clone path only on zeam). Does NOT include the XMSS recursive STARK worker; use zeam_aggregate_worker_duration_seconds for end-to-end aggregate FFI cost (issue #907)." }, .{}),
-        .zeam_pq_sig_aggregated_signatures_building_phase_seconds = try Metrics.PQSigBuildingPhaseHistogram.init(allocator, io, "zeam_pq_sig_aggregated_signatures_building_phase_seconds", .{ .help = "Phase-level time taken to produce aggregate attestations, labeled by phase (snapshot|compute_ffi|commit). See #899." }, .{}),
+        .lean_pq_sig_aggregated_signatures_building_time_seconds = Metrics.PQSigBuildingTimeHistogram.init("lean_pq_sig_aggregated_signatures_building_time_seconds", .{ .help = "Per att_data wall time for AggregatedSignatureProof.aggregate (bitfield merge + xmss.aggregateSignatures, including leanMultisig STARK). For bare rec_xmss_aggregate prove time comparable to lean-bench, use zeam_xmss_rec_aggregate_prove_seconds." }, .{}),
+        .zeam_pq_sig_aggregated_signatures_building_phase_seconds = try Metrics.PQSigBuildingPhaseHistogram.init(allocator, io, "zeam_pq_sig_aggregated_signatures_building_phase_seconds", .{ .help = "Phase-level time for aggregate production, labeled by phase (snapshot|att_data_prep|xmss_prove|compute_ffi|commit). See #899 / #907." }, .{}),
+        .zeam_xmss_rec_aggregate_prove_seconds = Metrics.XmssRecAggregateProveHistogram.init("zeam_xmss_rec_aggregate_prove_seconds", .{ .help = "Wall time inside xmss_aggregate (leanMultisig rec_xmss_aggregate STARK prove + FFI key clones, one att_data). Compare to leanBench aggregate.flat_*_r2; worker/phase metrics add snapshot, prep, child-proof deserialize, and serialize." }, .{}),
         .lean_pq_sig_aggregated_signatures_verification_time_seconds = Metrics.PQSigAggregatedVerificationHistogram.init("lean_pq_sig_aggregated_signatures_verification_time_seconds", .{ .help = "Time taken to verify an aggregated attestation signature" }, .{}),
         .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures" }, .{}),
         .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures" }, .{}),
@@ -1068,6 +1088,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     zeam_fork_choice_tick_interval_duration_seconds.context = @ptrCast(&metrics.zeam_fork_choice_tick_interval_duration_seconds);
     zeam_node_aggregation_interval_tick_seconds.context = @ptrCast(&metrics.zeam_node_aggregation_interval_tick_seconds);
     zeam_aggregate_worker_duration_seconds.context = @ptrCast(&metrics.zeam_aggregate_worker_duration_seconds);
+    zeam_xmss_rec_aggregate_prove_seconds.context = @ptrCast(&metrics.zeam_xmss_rec_aggregate_prove_seconds);
     lean_pending_blocks_drain_iters.context = @ptrCast(&metrics.lean_pending_blocks_drain_iters);
     // Initialize sync status to idle at startup
     try metrics.lean_node_sync_status.set(.{ .status = "idle" }, 1);
@@ -1195,6 +1216,23 @@ pub fn writeMetrics(writer: *std.Io.Writer) !void {
     }
 
     try metrics_lib.write(&metrics, writer);
+}
+
+/// Record a sub-phase of aggregate attestation production (see
+/// `zeam_pq_sig_aggregated_signatures_building_phase_seconds`).
+pub fn observeAggregateAttestationBuildPhase(phase: []const u8, elapsed_seconds: f32) void {
+    if (!g_initialized or isZKVM()) return;
+    metrics.zeam_pq_sig_aggregated_signatures_building_phase_seconds.observe(
+        .{ .phase = phase },
+        elapsed_seconds,
+    ) catch {};
+}
+
+/// Record leanMultisig `rec_xmss_aggregate` wall time for one att_data (xmss_aggregate FFI).
+pub fn observeXmssRecAggregateProve(elapsed_seconds: f32) void {
+    if (!g_initialized or isZKVM()) return;
+    metrics.zeam_xmss_rec_aggregate_prove_seconds.observe(elapsed_seconds);
+    observeAggregateAttestationBuildPhase("xmss_prove", elapsed_seconds);
 }
 
 // ---------------------------------------------------------------------

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2118,16 +2118,11 @@ pub const ForkChoice = struct {
         defer _ = agg_timer.observe();
 
         // ─── Phase 1: snapshot ──────────────────────────────────────
-        // Deep-clone the three input maps under signatures_mutex so
-        // computeAggregatedSignatures (phase 2) can run on owned data
-        // without holding the lock. Cost is bounded by total entry
-        // count: SignaturesMap is POD (StoredSignature is 8B + SIGBYTES);
-        // AggregatedPayloadsMap entries each sszClone an
-        // AggregatedSignatureProof (Rust-allocated XMSS handle, refcount
-        // bump via FFI). Per-entry clone is sub-ms; total snapshot
-        // typically O(10 ms) on a healthy aggregator.
+        // Collect in-scope att_data keys under signatures_mutex (ethlambda-
+        // style job scoping) and deep-clone only those entries so we do not
+        // sszClone every stale proof retained in the live maps.
         const snapshot_start_ns = zeam_utils.monotonicTimestampNs();
-        var snap = try AggregateSnapshot.takeUnderLock(self);
+        var snap = try AggregateSnapshot.takeUnderLock(self, slot_filter);
         observeAggregateBuildPhase("snapshot", snapshot_start_ns);
         defer snap.deinit(self.allocator);
 
@@ -3674,6 +3669,95 @@ fn deinitAggregatedPayloadsMap(allocator: Allocator, map: *AggregatedPayloadsMap
     map.deinit();
 }
 
+/// Returns true when `att_data.slot` is in the optional slot window filter.
+fn aggregationSlotAllowed(slot: types.Slot, slot_filter: ?[]const types.Slot) bool {
+    const slots = slot_filter orelse return true;
+    for (slots) |allowed| {
+        if (slot == allowed) return true;
+    }
+    return false;
+}
+
+/// Collect `AttestationData` keys to snapshot, mirroring ethlambda's two-pass
+/// `snapshot_aggregation_inputs`: gossip groups first, then payload-only groups
+/// with at least two pending proofs. Scoped by `slot_filter` so zeam does not
+/// deep-clone every stale map entry on each worker run.
+fn collectAggregationSnapshotKeys(
+    allocator: Allocator,
+    fork_choice: *ForkChoice,
+    slot_filter: ?[]const types.Slot,
+    out_keys: *std.ArrayList(types.AttestationData),
+) !void {
+    var seen = std.AutoHashMap(types.AttestationData, void).init(allocator);
+    defer seen.deinit();
+
+    var gossip_roots = std.AutoHashMap(types.AttestationData, void).init(allocator);
+    defer gossip_roots.deinit();
+
+    {
+        var it = fork_choice.attestation_signatures.iterator();
+        while (it.next()) |entry| {
+            if (!aggregationSlotAllowed(entry.key_ptr.slot, slot_filter)) continue;
+            try gossip_roots.put(entry.key_ptr.*, {});
+            const gop = try seen.getOrPut(entry.key_ptr.*);
+            if (!gop.found_existing) try out_keys.append(allocator, entry.key_ptr.*);
+        }
+    }
+
+    {
+        var it = fork_choice.latest_new_aggregated_payloads.iterator();
+        while (it.next()) |entry| {
+            if (!aggregationSlotAllowed(entry.key_ptr.slot, slot_filter)) continue;
+            if (gossip_roots.contains(entry.key_ptr.*)) continue;
+            if (entry.value_ptr.items.len < 2) continue;
+            const gop = try seen.getOrPut(entry.key_ptr.*);
+            if (!gop.found_existing) try out_keys.append(allocator, entry.key_ptr.*);
+        }
+    }
+}
+
+/// Deep-clone one attestation-data entry from `src` into `dst`.
+fn cloneAggregatedPayloadsEntry(
+    allocator: Allocator,
+    att_data: types.AttestationData,
+    src_list: *const types.AggregatedPayloadsList,
+    dst: *AggregatedPayloadsMap,
+) !void {
+    if (src_list.items.len == 0) return;
+
+    const gop = try dst.getOrPut(att_data);
+    if (!gop.found_existing) gop.value_ptr.* = .empty;
+
+    try gop.value_ptr.ensureTotalCapacityPrecise(allocator, src_list.items.len);
+    for (src_list.items) |*stored| {
+        var cloned_proof: types.AggregatedSignatureProof = undefined;
+        try types.sszClone(allocator, types.AggregatedSignatureProof, stored.proof, &cloned_proof);
+        errdefer cloned_proof.deinit();
+
+        var cloned_source_payload: ?types.AggregationBits = null;
+        if (stored.source_payload_participants) |source_payload| {
+            var bits: types.AggregationBits = undefined;
+            try types.sszClone(allocator, types.AggregationBits, source_payload, &bits);
+            errdefer bits.deinit();
+            cloned_source_payload = bits;
+        }
+        var cloned_source_gossip: ?types.AggregationBits = null;
+        if (stored.source_gossip_participants) |source_gossip| {
+            var bits: types.AggregationBits = undefined;
+            try types.sszClone(allocator, types.AggregationBits, source_gossip, &bits);
+            errdefer bits.deinit();
+            cloned_source_gossip = bits;
+        }
+
+        try gop.value_ptr.append(allocator, .{
+            .slot = stored.slot,
+            .proof = cloned_proof,
+            .source_payload_participants = cloned_source_payload,
+            .source_gossip_participants = cloned_source_gossip,
+        });
+    }
+}
+
 /// Deep-clone an `AggregatedPayloadsMap`. Each stored
 /// `AggregatedSignatureProof` is `sszClone`d so the destination owns
 /// its own Rust XMSS handle (independent refcount). Caller releases
@@ -3687,82 +3771,63 @@ fn cloneAggregatedPayloadsMap(
 
     var it = src.iterator();
     while (it.next()) |entry| {
-        const gop = try dst.getOrPut(entry.key_ptr.*);
-        if (!gop.found_existing) gop.value_ptr.* = .empty;
-
-        try gop.value_ptr.ensureTotalCapacityPrecise(allocator, entry.value_ptr.items.len);
-        for (entry.value_ptr.items) |*stored| {
-            var cloned_proof: types.AggregatedSignatureProof = undefined;
-            try types.sszClone(allocator, types.AggregatedSignatureProof, stored.proof, &cloned_proof);
-            errdefer cloned_proof.deinit();
-
-            var cloned_source_payload: ?types.AggregationBits = null;
-            if (stored.source_payload_participants) |source_payload| {
-                var bits: types.AggregationBits = undefined;
-                try types.sszClone(allocator, types.AggregationBits, source_payload, &bits);
-                errdefer bits.deinit();
-                cloned_source_payload = bits;
-            }
-            var cloned_source_gossip: ?types.AggregationBits = null;
-            if (stored.source_gossip_participants) |source_gossip| {
-                var bits: types.AggregationBits = undefined;
-                try types.sszClone(allocator, types.AggregationBits, source_gossip, &bits);
-                errdefer bits.deinit();
-                cloned_source_gossip = bits;
-            }
-
-            try gop.value_ptr.append(allocator, .{
-                .slot = stored.slot,
-                .proof = cloned_proof,
-                .source_payload_participants = cloned_source_payload,
-                .source_gossip_participants = cloned_source_gossip,
-            });
-        }
+        try cloneAggregatedPayloadsEntry(allocator, entry.key_ptr.*, entry.value_ptr, &dst);
     }
     return dst;
 }
 
-/// Owned snapshot of the three signature/aggregation maps that
-/// `aggregateUnlocked` reads. Taken under `signatures_mutex` and
-/// then operated on outside the lock so the heavy XMSS FFI does
-/// not block libxev / chain-worker writers.
+/// Owned snapshot of signature/aggregation inputs for one aggregate worker pass.
+/// Taken under `signatures_mutex` using ethlambda-style job scoping: only
+/// in-window `att_data` keys (plus payload-only groups with ≥2 proofs) are
+/// cloned, not every entry retained in the live maps.
 const AggregateSnapshot = struct {
     signatures: types.SignaturesMap,
     new_payloads: AggregatedPayloadsMap,
     known_payloads: AggregatedPayloadsMap,
 
-    /// Acquires `fork_choice.signatures_mutex`, deep-clones the three
-    /// maps into freshly-allocated owned copies, then releases the
-    /// lock. Cost is dominated by `sszClone` of every
-    /// `AggregatedSignatureProof` (Rust FFI handle clone).
-    fn takeUnderLock(fork_choice: *ForkChoice) !AggregateSnapshot {
+    /// Acquires `fork_choice.signatures_mutex`, collects in-scope attestation
+    /// data keys, deep-clones only those entries, then releases the lock.
+    fn takeUnderLock(fork_choice: *ForkChoice, slot_filter: ?[]const types.Slot) !AggregateSnapshot {
         const allocator = fork_choice.allocator;
 
         fork_choice.signatures_mutex.lock();
         defer fork_choice.signatures_mutex.unlock();
 
+        var keys: std.ArrayList(types.AttestationData) = .empty;
+        defer keys.deinit(allocator);
+        try collectAggregationSnapshotKeys(allocator, fork_choice, slot_filter, &keys);
+
         var signatures = types.SignaturesMap.init(allocator);
         errdefer signatures.deinit();
 
-        var src_sig_it = fork_choice.attestation_signatures.iterator();
-        while (src_sig_it.next()) |entry| {
-            var inner = types.SignaturesMap.InnerMap.init(allocator);
-            errdefer inner.deinit();
-            try inner.ensureTotalCapacity(@intCast(entry.value_ptr.count()));
-
-            var inner_it = entry.value_ptr.iterator();
-            while (inner_it.next()) |vid_entry| {
-                try inner.put(vid_entry.key_ptr.*, vid_entry.value_ptr.*);
-            }
-
-            try signatures.put(entry.key_ptr.*, inner);
-        }
-
-        var new_payloads = try cloneAggregatedPayloadsMap(allocator, &fork_choice.latest_new_aggregated_payloads);
+        var new_payloads = AggregatedPayloadsMap.init(allocator);
         errdefer deinitAggregatedPayloadsMap(allocator, &new_payloads);
 
-        var known_payloads = try cloneAggregatedPayloadsMap(allocator, &fork_choice.latest_known_aggregated_payloads);
+        var known_payloads = AggregatedPayloadsMap.init(allocator);
         errdefer deinitAggregatedPayloadsMap(allocator, &known_payloads);
+
+        for (keys.items) |att_data| {
+            if (fork_choice.attestation_signatures.get(att_data)) |inner| {
+                var cloned_inner = types.SignaturesMap.InnerMap.init(allocator);
+                errdefer cloned_inner.deinit();
+                try cloned_inner.ensureTotalCapacity(@intCast(inner.count()));
+
+                var inner_it = inner.iterator();
+                while (inner_it.next()) |vid_entry| {
+                    try cloned_inner.put(vid_entry.key_ptr.*, vid_entry.value_ptr.*);
+                }
+
+                try signatures.put(att_data, cloned_inner);
+            }
+
+            if (fork_choice.latest_new_aggregated_payloads.getPtr(att_data)) |list| {
+                try cloneAggregatedPayloadsEntry(allocator, att_data, list, &new_payloads);
+            }
+
+            if (fork_choice.latest_known_aggregated_payloads.getPtr(att_data)) |list| {
+                try cloneAggregatedPayloadsEntry(allocator, att_data, list, &known_payloads);
+            }
+        }
 
         return .{
             .signatures = signatures,

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -557,7 +557,7 @@ pub const AggregatedAttestationsResult = struct {
             allocator.free(preps);
         }
 
-        var ffi_prep_count: usize = 0;
+        const prep_start_ns = zeam_utils.monotonicTimestampNs();
         for (att_data_keys, 0..) |data, i| {
             preps[i] = try prepareAggregateAttData(
                 allocator,
@@ -567,8 +567,8 @@ pub const AggregatedAttestationsResult = struct {
                 known_payloads,
                 data,
             );
-            if (preps[i].outcome == .ffi) ffi_prep_count += 1;
         }
+        observeAggregateAttDataPrepPhase(prep_start_ns);
 
         try runAggregateAttDataPreps(
             allocator,
@@ -694,6 +694,13 @@ fn attestationDataLessThan(_: void, a: attestation.AttestationData, b: attestati
     if (a.head.slot != b.head.slot) return a.head.slot < b.head.slot;
     if (a.target.slot != b.target.slot) return a.target.slot < b.target.slot;
     return a.source.slot < b.source.slot;
+}
+
+fn observeAggregateAttDataPrepPhase(start_ns: i128) void {
+    const end_ns = zeam_utils.monotonicTimestampNs();
+    const elapsed_ns: i128 = if (end_ns >= start_ns) end_ns - start_ns else 0;
+    const elapsed_s = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+    zeam_metrics.observeAggregateAttestationBuildPhase("att_data_prep", elapsed_s);
 }
 
 const AggregateAttDataOutcome = union(enum) {

--- a/pkgs/xmss/src/aggregation.zig
+++ b/pkgs/xmss/src/aggregation.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const hashsig = @import("hashsig.zig");
 const ssz = @import("ssz");
+const zeam_metrics = @import("@zeam/metrics");
+const zeam_utils = @import("@zeam/utils");
 
 pub const AggregationError = error{ SerializationFailed, DeserializationFailed, PublicKeysSignatureLengthMismatch, AggregationFailed, InvalidAggregateSignature };
 
@@ -74,6 +76,15 @@ extern fn xmss_aggregate_signature_from_bytes(
     bytes_len: usize,
 ) callconv(.c) ?*AggregatedXMSS;
 
+/// Cached after first successful init; Rust side uses OnceLock as well.
+var prover_ready = std.atomic.Value(bool).init(false);
+
+fn ensureProverReady() !void {
+    if (prover_ready.load(.acquire)) return;
+    try setupProver();
+    prover_ready.store(true, .release);
+}
+
 /// Configure the global rayon thread pool used by the XMSS aggregate prover.
 /// Must be called before `setupProver` and before any aggregation work begins.
 /// `num_threads = 0` means "use rayon's default" (one thread per logical CPU).
@@ -120,7 +131,7 @@ pub fn aggregateSignatures(
         return AggregationError.AggregationFailed;
     }
 
-    try setupProver();
+    try ensureProverReady();
 
     const num_children = children_pub_keys.len;
     const allocator = std.heap.c_allocator;
@@ -161,6 +172,7 @@ pub fn aggregateSignatures(
         child_proof_lens[i] = proof_slice.len;
     }
 
+    const prove_start_ns = zeam_utils.monotonicTimestampNs();
     const agg_sig = xmss_aggregate(
         public_keys.ptr,
         signatures.ptr,
@@ -174,6 +186,7 @@ pub fn aggregateSignatures(
         epoch,
         log_inv_rate,
     ) orelse return AggregationError.AggregationFailed;
+    recordXmssProveDuration(prove_start_ns);
 
     // Serialize the aggregate signature to bytes
     var buffer: [MAX_AGGREGATE_SIGNATURE_SIZE]u8 = undefined;
@@ -190,6 +203,13 @@ pub fn aggregateSignatures(
     for (buffer[0..bytes_written]) |byte| {
         try multisig_aggregated_signature.append(byte);
     }
+}
+
+fn recordXmssProveDuration(start_ns: i128) void {
+    const end_ns = zeam_utils.monotonicTimestampNs();
+    const elapsed_ns: i128 = if (end_ns >= start_ns) end_ns - start_ns else 0;
+    const elapsed_s = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+    zeam_metrics.observeXmssRecAggregateProve(elapsed_s);
 }
 
 pub fn verifyAggregatedPayload(public_keys: []*const hashsig.HashSigPublicKey, message_hash: *const [32]u8, epoch: u32, agg_sig: *const ByteListMiB) !void {


### PR DESCRIPTION
Closes #907

## Summary

- Add `zeam_xmss_rec_aggregate_prove_seconds` — wall time inside `xmss_aggregate` (leanMultisig `rec_xmss_aggregate`, one `att_data` per sample). Compare directly to leanBench `aggregate.flat_*_r2`.
- Split aggregate phase metrics: `att_data_prep`, `xmss_prove`, plus existing `snapshot` / `compute_ffi` / `commit`.
- Fix misleading HELP on `lean_pq_sig_aggregated_signatures_building_time_seconds` (it includes the STARK, not just wrap/clone).
- Cache prover init in `@zeam/xmss` via `ensureProverReady()`.
- **Scoped aggregate snapshot:** under `signatures_mutex`, collect only in-window `att_data` keys (slot filter + payload-only groups with ≥2 proofs) and deep-clone just those entries instead of every proof retained in the live maps. Targets the multi-second `snapshot` phase identified in #907.

## Devnet results (`0xpartha/zeam:local`, post-restart)

Measured on `zeam_8` and `zeam_4` aggregators (~15 min, slots 1–35+).

| Metric | Before (`devnet4`) | After (this PR) |
|---|---:|---:|
| `snapshot` phase | ~4.9 s | **~3 ms** |
| `att_data_prep` phase | n/a | **~3 ms** |
| `zeam_xmss_rec_aggregate_prove_seconds` p50 | n/a | **~0.60 s** (leanBench ~0.47 s) |
| `building_time` p50 | ~2.0 s | **~0.61 s** |
| `worker_duration` p50 | ~6.8 s | **~0.65 s** |
| `in_flight` skip rate | ~50% | **~12–17%** |
| Publish on-time (lag ≤ 2 slots) | poor | **97–100%** |

**What the new metric shows:** at the median, leanMultisig prove (~0.6 s) matches leanBench and peer clients. The old ~6–11 s worker time was almost entirely **full-map snapshot cloning**, not slow crypto.

**Remaining bottleneck:** `xmss_prove` dominates post-fix (expected). A tail of 3–10 s prove samples inflates means and causes residual `in_flight` skips — worth a follow-up, not a blocker for this change.

**Out of scope for this PR (separate follow-ups):** Finding 4 trivial-input fast path (`1 gossip + 0 children`), peer aggregate merge-window timing (#907 Finding 3).

## Why

#907 showed worker cost exceeding the slot budget with misleading standard histograms. Phase attribution revealed snapshot clone as the dominant cost; this PR fixes that and exposes bare prove time for honest cross-bench comparison.

## Test plan

- [x] `zig build` succeeds
- [x] Deploy to devnet aggregators (`0xpartha/zeam:local`); confirm `snapshot` phase drops (~4.9 s → ~3 ms)
- [x] Scrape `zeam_xmss_rec_aggregate_prove_seconds` — p50 ~0.60 s, aligned with leanBench
- [x] Worker p50 ~0.65 s (was ~6.8 s); publish lag p50 = 1 slot; 97–100% on-time