### PR TITLE
node: refresh peer status when synced head lags wall clock

### DIFF
--- a/pkgs/node/src/blocks_by_range_sync.zig
+++ b/pkgs/node/src/blocks_by_range_sync.zig
@@ -27,29 +27,38 @@ pub fn rangesOverlap(
     return a_start < b_end and b_start < a_end;
 }
 
-pub fn wallGapSlots(our_head_slot: types.Slot, wall_slot: types.Slot) u64 {
-    if (wall_slot <= our_head_slot) return 0;
-    return wall_slot - our_head_slot;
-}
-
 pub fn cappedSyncGapSlots(peer_head_slot: types.Slot, our_head_slot: types.Slot, wall_slot: types.Slot) u64 {
     if (peer_head_slot <= our_head_slot) return 0;
     const peer_gap: u64 = peer_head_slot - our_head_slot;
-    return @min(peer_gap, wallGapSlots(our_head_slot, wall_slot));
+    const wall_gap: u64 = if (wall_slot > our_head_slot) wall_slot - our_head_slot else 0;
+    return @min(peer_gap, wall_gap);
 }
 
-pub const PeriodicRefreshDecision = struct {
+pub const PeerStatusRefreshDecision = struct {
     refresh: bool,
     wall_head_lag_slots: u64,
 };
 
-pub fn periodicRefreshPeerStatusDecision(
+/// Pure periodic peer-status refresh policy.
+///
+/// Callers supply the current interval/slot cadence plus head snapshots; this helper
+/// owns the decision about whether a status refresh is useful. Wall-clock head lag is
+/// computed through `cappedSyncGapSlots` by treating `wall_slot` as the peer head,
+/// keeping all slot-gap arithmetic on one path.
+pub fn shouldRefreshPeerStatus(
     sync_status: anytype,
+    interval_in_slot: usize,
+    slot: types.Slot,
     our_head_slot: types.Slot,
     wall_slot: types.Slot,
+    refresh_interval_slots: u64,
     wall_head_lag_threshold_slots: u64,
-) PeriodicRefreshDecision {
-    const wall_head_lag_slots = wallGapSlots(our_head_slot, wall_slot);
+) PeerStatusRefreshDecision {
+    const wall_head_lag_slots = cappedSyncGapSlots(wall_slot, our_head_slot, wall_slot);
+    if (interval_in_slot != 0 or slot % refresh_interval_slots != 0) {
+        return .{ .refresh = false, .wall_head_lag_slots = wall_head_lag_slots };
+    }
+
     const refresh = switch (sync_status) {
         .fc_initing, .behind_peers => true,
         .synced => wall_head_lag_slots >= wall_head_lag_threshold_slots,
@@ -199,7 +208,7 @@ test "cappedSyncGapSlots limits range catch-up to wall-clock head" {
     try std.testing.expectEqual(@as(u64, 0), cappedSyncGapSlots(200, 150, 100));
 }
 
-test "periodicRefreshPeerStatusDecision handles sync state and wall lag" {
+test "shouldRefreshPeerStatus handles cadence sync state and wall lag" {
     const TestSyncStatus = union(enum) {
         synced,
         no_peers,
@@ -207,30 +216,39 @@ test "periodicRefreshPeerStatusDecision handles sync state and wall lag" {
         behind_peers,
     };
 
-    try std.testing.expectEqual(@as(u64, 0), wallGapSlots(100, 100));
-    try std.testing.expectEqual(@as(u64, 0), wallGapSlots(100, 99));
-    try std.testing.expectEqual(@as(u64, 4), wallGapSlots(100, 104));
+    // Wall-lag arithmetic is shared with cappedSyncGapSlots by treating wall_slot as
+    // the remote head: no lag at/past wall, positive lag only when wall is ahead.
+    try std.testing.expectEqual(@as(u64, 0), cappedSyncGapSlots(100, 100, 100));
+    try std.testing.expectEqual(@as(u64, 0), cappedSyncGapSlots(99, 100, 99));
+    try std.testing.expectEqual(@as(u64, 4), cappedSyncGapSlots(104, 100, 104));
 
     const cases = [_]struct {
         status: TestSyncStatus,
+        interval_in_slot: usize,
+        slot: types.Slot,
         our_head_slot: types.Slot,
         wall_slot: types.Slot,
         threshold_slots: u64,
         want_refresh: bool,
         want_lag: u64,
     }{
-        .{ .status = .synced, .our_head_slot = 100, .wall_slot = 103, .threshold_slots = 4, .want_refresh = false, .want_lag = 3 },
-        .{ .status = .synced, .our_head_slot = 100, .wall_slot = 104, .threshold_slots = 4, .want_refresh = true, .want_lag = 4 },
-        .{ .status = .fc_initing, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
-        .{ .status = .behind_peers, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
-        .{ .status = .no_peers, .our_head_slot = 100, .wall_slot = 200, .threshold_slots = 4, .want_refresh = false, .want_lag = 100 },
+        .{ .status = .synced, .interval_in_slot = 1, .slot = 104, .our_head_slot = 100, .wall_slot = 104, .threshold_slots = 4, .want_refresh = false, .want_lag = 4 },
+        .{ .status = .synced, .interval_in_slot = 0, .slot = 103, .our_head_slot = 100, .wall_slot = 104, .threshold_slots = 4, .want_refresh = false, .want_lag = 4 },
+        .{ .status = .synced, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 103, .threshold_slots = 4, .want_refresh = false, .want_lag = 3 },
+        .{ .status = .synced, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 104, .threshold_slots = 4, .want_refresh = true, .want_lag = 4 },
+        .{ .status = .fc_initing, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
+        .{ .status = .behind_peers, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
+        .{ .status = .no_peers, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 200, .threshold_slots = 4, .want_refresh = false, .want_lag = 100 },
     };
 
     for (cases) |case| {
-        const decision = periodicRefreshPeerStatusDecision(
+        const decision = shouldRefreshPeerStatus(
             case.status,
+            case.interval_in_slot,
+            case.slot,
             case.our_head_slot,
             case.wall_slot,
+            constants.SYNC_STATUS_REFRESH_INTERVAL_SLOTS,
             case.threshold_slots,
         );
         try std.testing.expectEqual(case.want_refresh, decision.refresh);

--- a/pkgs/node/src/blocks_by_range_sync.zig
+++ b/pkgs/node/src/blocks_by_range_sync.zig
@@ -27,11 +27,35 @@ pub fn rangesOverlap(
     return a_start < b_end and b_start < a_end;
 }
 
+pub fn wallGapSlots(our_head_slot: types.Slot, wall_slot: types.Slot) u64 {
+    if (wall_slot <= our_head_slot) return 0;
+    return wall_slot - our_head_slot;
+}
+
 pub fn cappedSyncGapSlots(peer_head_slot: types.Slot, our_head_slot: types.Slot, wall_slot: types.Slot) u64 {
     if (peer_head_slot <= our_head_slot) return 0;
     const peer_gap: u64 = peer_head_slot - our_head_slot;
-    const wall_gap: u64 = if (wall_slot > our_head_slot) wall_slot - our_head_slot else 0;
-    return @min(peer_gap, wall_gap);
+    return @min(peer_gap, wallGapSlots(our_head_slot, wall_slot));
+}
+
+pub const PeriodicRefreshDecision = struct {
+    refresh: bool,
+    wall_head_lag_slots: u64,
+};
+
+pub fn periodicRefreshPeerStatusDecision(
+    sync_status: anytype,
+    our_head_slot: types.Slot,
+    wall_slot: types.Slot,
+    wall_head_lag_threshold_slots: u64,
+) PeriodicRefreshDecision {
+    const wall_head_lag_slots = wallGapSlots(our_head_slot, wall_slot);
+    const refresh = switch (sync_status) {
+        .fc_initing, .behind_peers => true,
+        .synced => wall_head_lag_slots >= wall_head_lag_threshold_slots,
+        .no_peers => false,
+    };
+    return .{ .refresh = refresh, .wall_head_lag_slots = wall_head_lag_slots };
 }
 
 /// Whether a peer status should trigger proactive catch-up (issue #893 / PR #894).
@@ -173,6 +197,45 @@ test "cappedSyncGapSlots limits range catch-up to wall-clock head" {
     try std.testing.expectEqual(@as(u64, 50), cappedSyncGapSlots(200, 100, 150));
     try std.testing.expectEqual(@as(u64, 100), cappedSyncGapSlots(200, 100, 250));
     try std.testing.expectEqual(@as(u64, 0), cappedSyncGapSlots(200, 150, 100));
+}
+
+test "periodicRefreshPeerStatusDecision handles sync state and wall lag" {
+    const TestSyncStatus = union(enum) {
+        synced,
+        no_peers,
+        fc_initing,
+        behind_peers,
+    };
+
+    try std.testing.expectEqual(@as(u64, 0), wallGapSlots(100, 100));
+    try std.testing.expectEqual(@as(u64, 0), wallGapSlots(100, 99));
+    try std.testing.expectEqual(@as(u64, 4), wallGapSlots(100, 104));
+
+    const cases = [_]struct {
+        status: TestSyncStatus,
+        our_head_slot: types.Slot,
+        wall_slot: types.Slot,
+        threshold_slots: u64,
+        want_refresh: bool,
+        want_lag: u64,
+    }{
+        .{ .status = .synced, .our_head_slot = 100, .wall_slot = 103, .threshold_slots = 4, .want_refresh = false, .want_lag = 3 },
+        .{ .status = .synced, .our_head_slot = 100, .wall_slot = 104, .threshold_slots = 4, .want_refresh = true, .want_lag = 4 },
+        .{ .status = .fc_initing, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
+        .{ .status = .behind_peers, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
+        .{ .status = .no_peers, .our_head_slot = 100, .wall_slot = 200, .threshold_slots = 4, .want_refresh = false, .want_lag = 100 },
+    };
+
+    for (cases) |case| {
+        const decision = periodicRefreshPeerStatusDecision(
+            case.status,
+            case.our_head_slot,
+            case.wall_slot,
+            case.threshold_slots,
+        );
+        try std.testing.expectEqual(case.want_refresh, decision.refresh);
+        try std.testing.expectEqual(case.want_lag, decision.wall_head_lag_slots);
+    }
 }
 
 test "shouldCatchUpFromPeerStatus triggers on head gap before finalization" {

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -108,11 +108,20 @@ pub const MAX_FC_CHAIN_PRINT_DEPTH = 5;
 // stuck sync chains recover quickly.
 pub const RPC_REQUEST_TIMEOUT_SECONDS: i64 = 8;
 
-// How often to re-send status requests to all connected peers when not synced.
-// Ensures that already-connected peers are probed again after a restart, and that
-// a node stuck in fc_initing can recover without waiting for new peer connections.
-// 8 slots = 32 seconds at 4s/slot.
+// How often to re-send status requests to connected peers when sync may need
+// recovery: always while fc_initing/behind_peers, and while synced only after
+// the local head has fallen behind wall-clock slots. Ensures that already-
+// connected peers are probed again after a restart and that early devnets with
+// finalized_slot=0 can recover from a gossip-ingress stall via status-driven
+// RPC catch-up. 8 slots = 32 seconds at 4s/slot.
 pub const SYNC_STATUS_REFRESH_INTERVAL_SLOTS: u64 = 8;
+
+// If the high-level sync state is `synced` but our head is this many wall-clock
+// slots behind, keep probing peers with status RPC anyway. Four slots tolerates
+// normal propagation/missed-slot jitter without waiting for the 64-slot proposer
+// rotation to reveal the stall. With the 8-slot refresh cadence, worst-case first
+// recovery probe is just under 12 slots (~48s) after the node stops advancing.
+pub const SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS: u64 = 4;
 
 // Threshold (in slots) above which we prefer a `blocks_by_range` bulk sync over the
 // recursive head-by-root walk. When the peer's head is more than this many slots

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2681,14 +2681,32 @@ pub const BeamNode = struct {
                 self.refreshSyncFromPeers();
             }
 
-            // Periodically re-send status to all connected peers when not synced.
-            // This recovers from the case where peers were already connected when
-            // the node was in fc_initing and the status-exchange-triggered sync
-            // was skipped (now fixed, but existing connections need a re-probe).
+            // Periodically re-send status to connected peers when sync may need
+            // recovery. Finalization-only sync state can report `synced` on early
+            // devnets while finalized_slot stays at zero; if gossip ingress stalls,
+            // the head then falls behind wall-clock slots but no new status response
+            // arrives to trigger RPC catch-up. Keep the pure policy in
+            // `blocks_by_range_sync.zig`; this tick path only supplies snapshots
+            // and performs the RPC side effect.
             if (interval_in_slot == 0 and slot % constants.SYNC_STATUS_REFRESH_INTERVAL_SLOTS == 0) {
-                switch (self.chain.getSyncStatus()) {
-                    .fc_initing, .behind_peers => self.refreshSyncFromPeers(),
-                    .synced, .no_peers => {},
+                const sync_status = self.chain.getSyncStatus();
+                const our_head_slot = self.chain.forkChoice.getHead().slot;
+                const wall_slot = self.clock.wallSlotNow();
+                const refresh_decision = blocks_by_range_sync.periodicRefreshPeerStatusDecision(
+                    sync_status,
+                    our_head_slot,
+                    wall_slot,
+                    constants.SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS,
+                );
+                if (refresh_decision.refresh) {
+                    switch (sync_status) {
+                        .synced => self.logger.info(
+                            "head is {d} wall-clock slots behind while synced; refreshing peer status for catch-up",
+                            .{refresh_decision.wall_head_lag_slots},
+                        ),
+                        else => {},
+                    }
+                    self.refreshSyncFromPeers();
                 }
             }
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2688,26 +2688,27 @@ pub const BeamNode = struct {
             // arrives to trigger RPC catch-up. Keep the pure policy in
             // `blocks_by_range_sync.zig`; this tick path only supplies snapshots
             // and performs the RPC side effect.
-            if (interval_in_slot == 0 and slot % constants.SYNC_STATUS_REFRESH_INTERVAL_SLOTS == 0) {
-                const sync_status = self.chain.getSyncStatus();
-                const our_head_slot = self.chain.forkChoice.getHead().slot;
-                const wall_slot = self.clock.wallSlotNow();
-                const refresh_decision = blocks_by_range_sync.periodicRefreshPeerStatusDecision(
-                    sync_status,
-                    our_head_slot,
-                    wall_slot,
-                    constants.SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS,
-                );
-                if (refresh_decision.refresh) {
-                    switch (sync_status) {
-                        .synced => self.logger.info(
-                            "head is {d} wall-clock slots behind while synced; refreshing peer status for catch-up",
-                            .{refresh_decision.wall_head_lag_slots},
-                        ),
-                        else => {},
-                    }
-                    self.refreshSyncFromPeers();
+            const sync_status = self.chain.getSyncStatus();
+            const our_head_slot = self.chain.forkChoice.getHead().slot;
+            const wall_slot = self.clock.wallSlotNow();
+            const refresh_decision = blocks_by_range_sync.shouldRefreshPeerStatus(
+                sync_status,
+                interval_in_slot,
+                slot,
+                our_head_slot,
+                wall_slot,
+                constants.SYNC_STATUS_REFRESH_INTERVAL_SLOTS,
+                constants.SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS,
+            );
+            if (refresh_decision.refresh) {
+                switch (sync_status) {
+                    .synced => self.logger.info(
+                        "head is {d} wall-clock slots behind while synced; refreshing peer status for catch-up",
+                        .{refresh_decision.wall_head_lag_slots},
+                    ),
+                    else => {},
                 }
+                self.refreshSyncFromPeers();
             }
 
             if (interval_in_slot == 2) {


### PR DESCRIPTION
## Summary

Fixes #926 by making sync recovery independent of finalization-only sync status.

On early/devnet networks where peers keep `finalized_slot=0`, `getSyncStatus()` can correctly remain `.synced` even after gossip ingress stalls and the local head stops advancing. Previously the periodic status refresh was skipped in `.synced`, so no new peer status responses arrived to trigger the existing status-driven `blocks_by_root` / `blocks_by_range` catch-up path.

This PR:

- adds a canonical `wallGapSlots` helper reused by sync-gap and periodic-refresh policy
- keeps the periodic peer-status refresh decision as pure/tested logic in `blocks_by_range_sync.zig`
- adds `SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS = 4`
- refreshes peer status while `.synced` when `wall_slot - our_head_slot >= 4`
- keeps `.no_peers` quiet and preserves the existing `.fc_initing` / `.behind_peers` refresh behavior

The result is that a node whose gossip ingress goes quiet will continue probing peers every `SYNC_STATUS_REFRESH_INTERVAL_SLOTS`; once a peer reports a higher head, the existing `.synced` status-response catch-up logic fetches the missing blocks over RPC.

## Tradeoff

The simpler fix would refresh status in every `.synced` interval too:

```zig
.fc_initing, .behind_peers, .synced => self.refreshSyncFromPeers(),
.no_peers => {},
```

This PR keeps the thresholded path to avoid steady-state status RPC fanout every 8 slots when the node is healthy. The cost is bounded recovery latency: lag must reach 4 wall-clock slots and then hit the 8-slot refresh cadence, so the first recovery probe can take just under 12 slots (~48s at 4s/slot) after the node stops advancing.

## Validation

- `zig fmt pkgs/node/src/constants.zig pkgs/node/src/blocks_by_range_sync.zig pkgs/node/src/node.zig`
- `git diff --check`
- Attempted `zig build test --summary all`, but the local runner has Zig 0.15.2 while `build.zig.zon` requires 0.16.0; dependency build scripts fail on removed/changed Build API fields before project tests compile.

```text
build.zig.zon: .minimum_zig_version = "0.16.0"
zig version: 0.15.2
error: no field named 'io' in struct 'Build.Graph'
```
