### PR TITLE
node, types, metrics, xmss: cut recursive-STARK aggregation tail + per-call instrumentation (#940)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -103,6 +103,14 @@ const Metrics = struct {
     /// Buckets are deliberately low-cardinality — see `numRawBucket` /
     /// `numChildrenBucket` below for the exact mapping.
     zeam_xmss_rec_aggregate_prove_by_input_seconds: XmssRecAggregateProveByInputHistogram,
+    /// Per-phase breakdown inside `xmss_aggregate` reported back from the
+    /// Rust FFI via out-pointers. The three phases ("marshal", "stark",
+    /// "post") sum to a value very close to one observation on
+    /// `zeam_xmss_rec_aggregate_prove_seconds` (delta is the FFI call/return
+    /// overhead, sub-microsecond). This lets us tell whether zeam's per-call
+    /// cost lives in argument deserialization or in the leanMultisig STARK
+    /// itself — the two have very different fixes. See #940.
+    zeam_xmss_rec_aggregate_phase_seconds: XmssRecAggregatePhaseHistogram,
     lean_pq_sig_aggregated_signatures_verification_time_seconds: PQSigAggregatedVerificationHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
@@ -450,6 +458,11 @@ const Metrics = struct {
     const XmssRecAggregateProveHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0 });
     const XmssRecAggregateProveByInputLabel = struct { num_raw: []const u8, num_children: []const u8 };
     const XmssRecAggregateProveByInputHistogram = metrics_lib.HistogramVec(f32, XmssRecAggregateProveByInputLabel, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0 });
+    // Buckets span sub-millisecond (post phase = pointer wrap, typically ns)
+    // through multi-second STARK proves. Phase label values are
+    // "marshal" | "stark" | "post" — see XmssRecAggregatePhaseLabel below.
+    const XmssRecAggregatePhaseLabel = struct { phase: []const u8 };
+    const XmssRecAggregatePhaseHistogram = metrics_lib.HistogramVec(f32, XmssRecAggregatePhaseLabel, &[_]f32{ 0.0001, 0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0 });
     const PQSigAggregatedVerificationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
     const PQSigAggregatedValidCounter = metrics_lib.Counter(u64);
     const PQSigAggregatedInvalidCounter = metrics_lib.Counter(u64);
@@ -945,6 +958,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_pq_sig_aggregated_signatures_building_phase_seconds = try Metrics.PQSigBuildingPhaseHistogram.init(allocator, io, "zeam_pq_sig_aggregated_signatures_building_phase_seconds", .{ .help = "Phase-level time for aggregate production, labeled by phase (snapshot|att_data_prep|xmss_prove|compute_ffi|commit). See #899 / #907." }, .{}),
         .zeam_xmss_rec_aggregate_prove_seconds = Metrics.XmssRecAggregateProveHistogram.init("zeam_xmss_rec_aggregate_prove_seconds", .{ .help = "Wall time inside xmss_aggregate (leanMultisig rec_xmss_aggregate STARK prove + FFI key clones, one att_data). Compare to leanBench aggregate.flat_*_r2; worker/phase metrics add snapshot, prep, child-proof deserialize, and serialize." }, .{}),
         .zeam_xmss_rec_aggregate_prove_by_input_seconds = try Metrics.XmssRecAggregateProveByInputHistogram.init(allocator, io, "zeam_xmss_rec_aggregate_prove_by_input_seconds", .{ .help = "Same observation as zeam_xmss_rec_aggregate_prove_seconds, additionally labeled by num_raw (count of raw gossip XMSS signatures) and num_children (count of recursive child STARK proofs) input-size buckets (#940). Buckets: num_raw in {0,1,2,3,4,5,6,7,8,9-15,16-31,32+}; num_children in {0,1,2,3-4,5-7,8+}. Used to classify the aggregate build histogram tail (steady-state full-committee prove vs partial-input reprove)." }, .{}),
+        .zeam_xmss_rec_aggregate_phase_seconds = try Metrics.XmssRecAggregatePhaseHistogram.init(allocator, io, "zeam_xmss_rec_aggregate_phase_seconds", .{ .help = "Per-phase wall time inside xmss_aggregate FFI (#940), reported back from Rust via out-pointers. phase=\"marshal\" covers argument deserialization (raw XMSS PK/sig clones + child PK collection + child proof deserialize). phase=\"stark\" is the leanMultisig rec_xmss_aggregate STARK call — expected to scale linearly with num_raw per lean-bench (~3.6 ms/sig at log_inv_rate=2 on Hetzner 16-core). phase=\"post\" is Box::into_raw of the returned aggregate (pointer wrap, typically nanoseconds). The three phases sum to ~zeam_xmss_rec_aggregate_prove_seconds." }, .{}),
         .lean_pq_sig_aggregated_signatures_verification_time_seconds = Metrics.PQSigAggregatedVerificationHistogram.init("lean_pq_sig_aggregated_signatures_verification_time_seconds", .{ .help = "Time taken to verify an aggregated attestation signature" }, .{}),
         .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures" }, .{}),
         .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures" }, .{}),
@@ -1278,6 +1292,20 @@ fn numRawBucket(n: usize) []const u8 {
         16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 => "16-31",
         else => "32+",
     };
+}
+
+/// Record one phase of `xmss_aggregate`'s internal timing breakdown
+/// (`zeam_xmss_rec_aggregate_phase_seconds`). `phase` must be one of the
+/// constants documented on the metric (currently "marshal", "stark", "post");
+/// callers are the xmss aggregation module on a successful prove only.
+/// `elapsed_ns` is the value the Rust FFI wrote into its out-pointer.
+pub fn observeXmssRecAggregatePhase(phase: []const u8, elapsed_ns: u64) void {
+    if (!g_initialized or isZKVM()) return;
+    const elapsed_s = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+    metrics.zeam_xmss_rec_aggregate_phase_seconds.observe(
+        .{ .phase = phase },
+        elapsed_s,
+    ) catch {};
 }
 
 /// Coarse low-cardinality bucket for the `num_children` label on

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -96,6 +96,13 @@ const Metrics = struct {
     /// `cargo run --release -- recursion --n 2`; zeam worker histograms include
     /// snapshot, prep, child-proof deserialize, and serialize on top of this.
     zeam_xmss_rec_aggregate_prove_seconds: XmssRecAggregateProveHistogram,
+    /// Same wall time as `zeam_xmss_rec_aggregate_prove_seconds`, labeled by
+    /// coarse `num_raw` / `num_children` input-size buckets so the build
+    /// histogram tail can be classified as steady-state full-committee proves
+    /// vs partial-input reproves (see #940 investigation plan item 1).
+    /// Buckets are deliberately low-cardinality — see `numRawBucket` /
+    /// `numChildrenBucket` below for the exact mapping.
+    zeam_xmss_rec_aggregate_prove_by_input_seconds: XmssRecAggregateProveByInputHistogram,
     lean_pq_sig_aggregated_signatures_verification_time_seconds: PQSigAggregatedVerificationHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
@@ -441,6 +448,8 @@ const Metrics = struct {
     const PQSigBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
     const PQSigBuildingPhaseHistogram = metrics_lib.HistogramVec(f32, struct { phase: []const u8 }, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 4 });
     const XmssRecAggregateProveHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0 });
+    const XmssRecAggregateProveByInputLabel = struct { num_raw: []const u8, num_children: []const u8 };
+    const XmssRecAggregateProveByInputHistogram = metrics_lib.HistogramVec(f32, XmssRecAggregateProveByInputLabel, &[_]f32{ 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 15.0 });
     const PQSigAggregatedVerificationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 4 });
     const PQSigAggregatedValidCounter = metrics_lib.Counter(u64);
     const PQSigAggregatedInvalidCounter = metrics_lib.Counter(u64);
@@ -935,6 +944,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_pq_sig_aggregated_signatures_building_time_seconds = Metrics.PQSigBuildingTimeHistogram.init("lean_pq_sig_aggregated_signatures_building_time_seconds", .{ .help = "Per att_data wall time for AggregatedSignatureProof.aggregate (bitfield merge + xmss.aggregateSignatures, including leanMultisig STARK). For bare rec_xmss_aggregate prove time comparable to lean-bench, use zeam_xmss_rec_aggregate_prove_seconds." }, .{}),
         .zeam_pq_sig_aggregated_signatures_building_phase_seconds = try Metrics.PQSigBuildingPhaseHistogram.init(allocator, io, "zeam_pq_sig_aggregated_signatures_building_phase_seconds", .{ .help = "Phase-level time for aggregate production, labeled by phase (snapshot|att_data_prep|xmss_prove|compute_ffi|commit). See #899 / #907." }, .{}),
         .zeam_xmss_rec_aggregate_prove_seconds = Metrics.XmssRecAggregateProveHistogram.init("zeam_xmss_rec_aggregate_prove_seconds", .{ .help = "Wall time inside xmss_aggregate (leanMultisig rec_xmss_aggregate STARK prove + FFI key clones, one att_data). Compare to leanBench aggregate.flat_*_r2; worker/phase metrics add snapshot, prep, child-proof deserialize, and serialize." }, .{}),
+        .zeam_xmss_rec_aggregate_prove_by_input_seconds = try Metrics.XmssRecAggregateProveByInputHistogram.init(allocator, io, "zeam_xmss_rec_aggregate_prove_by_input_seconds", .{ .help = "Same observation as zeam_xmss_rec_aggregate_prove_seconds, additionally labeled by num_raw (count of raw gossip XMSS signatures) and num_children (count of recursive child STARK proofs) input-size buckets (#940). Buckets: num_raw in {0,1,2,3,4,5,6,7,8,9-15,16-31,32+}; num_children in {0,1,2,3-4,5-7,8+}. Used to classify the aggregate build histogram tail (steady-state full-committee prove vs partial-input reprove)." }, .{}),
         .lean_pq_sig_aggregated_signatures_verification_time_seconds = Metrics.PQSigAggregatedVerificationHistogram.init("lean_pq_sig_aggregated_signatures_verification_time_seconds", .{ .help = "Time taken to verify an aggregated attestation signature" }, .{}),
         .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures" }, .{}),
         .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures" }, .{}),
@@ -1233,11 +1243,56 @@ pub fn observeAggregateAttestationBuildPhase(phase: []const u8, elapsed_seconds:
     ) catch {};
 }
 
-/// Record leanMultisig `rec_xmss_aggregate` wall time for one att_data (xmss_aggregate FFI).
-pub fn observeXmssRecAggregateProve(elapsed_seconds: f32) void {
+/// Record leanMultisig `rec_xmss_aggregate` wall time for one att_data
+/// (xmss_aggregate FFI). `num_raw` is the count of raw gossip XMSS signatures
+/// fed to this prove; `num_children` is the count of recursive child STARK
+/// proofs included. Both flow into the labeled
+/// `zeam_xmss_rec_aggregate_prove_by_input_seconds` companion via
+/// low-cardinality bucket strings (see #940).
+pub fn observeXmssRecAggregateProve(elapsed_seconds: f32, num_raw: usize, num_children: usize) void {
     if (!g_initialized or isZKVM()) return;
     metrics.zeam_xmss_rec_aggregate_prove_seconds.observe(elapsed_seconds);
     observeAggregateAttestationBuildPhase("xmss_prove", elapsed_seconds);
+    metrics.zeam_xmss_rec_aggregate_prove_by_input_seconds.observe(
+        .{ .num_raw = numRawBucket(num_raw), .num_children = numChildrenBucket(num_children) },
+        elapsed_seconds,
+    ) catch {};
+}
+
+/// Coarse low-cardinality bucket for the `num_raw` label on
+/// `zeam_xmss_rec_aggregate_prove_by_input_seconds`. Current ansible-devnet
+/// committees are 8-validator so values 0..8 stay distinct; larger committees
+/// roll into wider buckets to bound Prometheus series cardinality.
+fn numRawBucket(n: usize) []const u8 {
+    return switch (n) {
+        0 => "0",
+        1 => "1",
+        2 => "2",
+        3 => "3",
+        4 => "4",
+        5 => "5",
+        6 => "6",
+        7 => "7",
+        8 => "8",
+        9, 10, 11, 12, 13, 14, 15 => "9-15",
+        16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 => "16-31",
+        else => "32+",
+    };
+}
+
+/// Coarse low-cardinality bucket for the `num_children` label on
+/// `zeam_xmss_rec_aggregate_prove_by_input_seconds`. `num_children=0` is the
+/// only value seen on flat aggregation today (#940); other buckets exist for
+/// the recursive path.
+fn numChildrenBucket(n: usize) []const u8 {
+    return switch (n) {
+        0 => "0",
+        1 => "1",
+        2 => "2",
+        3, 4 => "3-4",
+        5, 6, 7 => "5-7",
+        else => "8+",
+    };
 }
 
 // ---------------------------------------------------------------------

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2219,6 +2219,28 @@ pub const ForkChoice = struct {
 
         const gop = try self.latest_new_aggregated_payloads.getOrPut(att_data);
         if (!gop.found_existing) gop.value_ptr.* = .empty;
+
+        // Drop any existing stored aggregate whose participants are fully
+        // contained in the new one (#940 deferred-aggregation path). With
+        // the live-raws change below, successive aggregator ticks re-prove
+        // flat over a growing raw set, so the new aggregate normally
+        // dominates every prior aggregate for this att_data. Without this
+        // pass the payload list would accumulate one strictly-dominated
+        // entry per tick until finalization pruned them.
+        {
+            var idx: usize = 0;
+            while (idx < gop.value_ptr.items.len) {
+                if (types.participantsContainsAll(stored_proof.participants, gop.value_ptr.items[idx].proof.participants)) {
+                    var dropped = gop.value_ptr.swapRemove(idx);
+                    dropped.proof.deinit();
+                    if (dropped.source_payload_participants) |*bits| bits.deinit();
+                    if (dropped.source_gossip_participants) |*bits| bits.deinit();
+                } else {
+                    idx += 1;
+                }
+            }
+        }
+
         try gop.value_ptr.append(self.allocator, .{
             .slot = att_data.slot,
             .proof = stored_proof,
@@ -2229,18 +2251,26 @@ pub const ForkChoice = struct {
         source_payload_bits_owned = false;
         source_gossip_bits_owned = false;
 
+        // Drop the snapshot's per-att_data inner map (snapshot ownership only).
+        //
+        // The previous implementation also deleted the snapshot's vids from the
+        // LIVE `attestation_signatures` map, freeing memory but forcing every
+        // subsequent aggregator tick to recursively merge the just-committed
+        // aggregate (now sitting in `latest_new_aggregated_payloads`) with any
+        // newly-arrived raws. That merge fires `rec_xmss_aggregate` with
+        // children, which costs ~4.5 s on the devnet aggregator vs ~0.5 s for
+        // an equivalent flat re-prove (#940 phase metric: 99.97% of cost is
+        // the STARK kernel, recursive proves dominate the p95 tail).
+        //
+        // Keeping raws live lets `prepareAggregateAttData` flat-re-prove over
+        // the larger raw set on later ticks; the `anyStoredProofCoversAll`
+        // pre-check there short-circuits when nothing new has arrived, so we
+        // do not re-aggregate redundantly. Memory is still bounded — the
+        // finalization-driven prune at `pruneStaleSignatures` removes
+        // signatures whose `target.slot <= finalized_slot`, same as before.
         if (snap.signatures.fetchRemove(att_data)) |snap_inner_kv| {
             var snap_inner = snap_inner_kv.value;
-            defer snap_inner.deinit();
-            if (self.attestation_signatures.getPtr(att_data)) |live_inner| {
-                var snap_vid_it = snap_inner.iterator();
-                while (snap_vid_it.next()) |vid_entry| {
-                    _ = live_inner.remove(vid_entry.key_ptr.*);
-                }
-                if (live_inner.count() == 0) {
-                    self.attestation_signatures.removeAndDeinit(att_data);
-                }
-            }
+            snap_inner.deinit();
         }
 
         zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_total.incr();
@@ -2984,7 +3014,13 @@ test "aggregate prunes attestation signatures" {
     }
 
     try std.testing.expectEqual(@as(usize, 1), aggregations.len);
-    try std.testing.expectEqual(@as(usize, 0), fork_choice.attestation_signatures.count());
+    // After #940 deferred-aggregation: raws stay live so that the next
+    // aggregator tick can flat-re-prove over a growing set instead of paying
+    // ~4.5 s for a recursive merge of the just-committed aggregate with new
+    // gossip arrivals. The two raw sigs we inserted for this att_data are
+    // still present after the commit; only `snap.signatures` (the worker's
+    // private snapshot of the same map) was drained.
+    try std.testing.expectEqual(@as(usize, 1), fork_choice.attestation_signatures.count());
     try std.testing.expect(fork_choice.latest_new_aggregated_payloads.get(attestation_data) != null);
 }
 

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -3964,7 +3964,7 @@ test "commitOneAggregateResult: stored and publish proofs are independent SSZ co
     };
 
     var zeam_logger_config = zeam_utils.getTestLoggerConfig();
-    const test_thread_pool = try initTestThreadPool();
+    const test_thread_pool = try setupTestPrimitives();
     defer test_thread_pool.deinit();
     var fork_choice = try ForkChoice.init(allocator, .{
         .config = chain_config,

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -683,6 +683,71 @@ const CompactGroupResult = struct {
     signature: aggregation.AggregatedSignatureProof,
 };
 
+/// Returns true if every bit set in `subset` is also set in `superset`,
+/// i.e. `superset` covers a (non-strict) superset of `subset`'s validators.
+/// Out-of-bounds bits in either bitlist are treated as zero (unset), which
+/// matches `AggregationBits.get(i) catch false` semantics elsewhere in this
+/// file. Pure read-only helper; allocates nothing.
+fn participantsContainsAll(superset: attestation.AggregationBits, subset: attestation.AggregationBits) bool {
+    var i: usize = 0;
+    while (i < subset.len()) : (i += 1) {
+        const sub_bit = subset.get(i) catch false;
+        if (!sub_bit) continue;
+        const sup_bit = if (i < superset.len()) (superset.get(i) catch false) else false;
+        if (!sup_bit) return false;
+    }
+    return true;
+}
+
+/// Drop greedy-selected children whose participant set is fully covered by
+/// another selected child's. `extendProofsGreedily` is called twice in
+/// `prepareAggregateAttData` (new_payloads then known_payloads); each call
+/// only counts new coverage on top of already-selected children from
+/// previous calls, so a proof picked from new_payloads can be strictly
+/// subsumed by a proof later picked from known_payloads — the second pass
+/// could not see new_payloads' candidate to compare against. Both end up
+/// in `selected_children`, and the combined `rec_xmss_aggregate` STARK
+/// merges them into a proof equivalent to the dominating child alone,
+/// paying ~4 s of prove time for no extra validator coverage (#940).
+///
+/// This pass removes any child whose participants are contained in another
+/// selected child's. Validator union is preserved (the dominating child
+/// already covers everything the dropped child did), so `covered_by_children`
+/// stays correct and the gossip-sig filter at the call site is unaffected.
+/// When only one child remains after pruning and there are no gossip sigs,
+/// the existing `!has_gossip and selected_children.len == 1` fast path
+/// below skips the STARK entirely.
+///
+/// Tie-break for equal sets: keep the lower-indexed entry (which comes from
+/// `new_payloads` first, then `known_payloads`) so behaviour is stable.
+fn pruneSubsumedChildren(
+    selected_children: *std.ArrayList(aggregation.AggregatedSignatureProof),
+) void {
+    if (selected_children.items.len < 2) return;
+    var i: usize = 0;
+    while (i < selected_children.items.len) {
+        const i_bits = selected_children.items[i].participants;
+        var subsumed = false;
+        for (selected_children.items, 0..) |*other, j| {
+            if (i == j) continue;
+            const j_bits = other.participants;
+            if (!participantsContainsAll(j_bits, i_bits)) continue;
+            // i ⊆ j. Drop i unless the sets are equal AND j comes after i —
+            // in the equal case keep the lower-indexed entry.
+            const equal = participantsContainsAll(i_bits, j_bits);
+            if (equal and j > i) continue;
+            subsumed = true;
+            break;
+        }
+        if (subsumed) {
+            selected_children.items[i].deinit();
+            _ = selected_children.orderedRemove(i);
+        } else {
+            i += 1;
+        }
+    }
+}
+
 pub fn attestationDataLessThan(_: void, a: attestation.AttestationData, b: attestation.AttestationData) bool {
     if (a.slot != b.slot) return a.slot < b.slot;
     const head_cmp = std.mem.order(u8, &a.head.root, &b.head.root);
@@ -822,6 +887,15 @@ fn prepareAggregateAttData(
 
     try extendProofsGreedily(allocator, new_payloads, data, &selected_children, &covered_by_children, &empty_available);
     try extendProofsGreedily(allocator, known_payloads, data, &selected_children, &covered_by_children, &empty_available);
+    // Drop children whose participant set is dominated by another selected
+    // child's. The two greedy passes above scan new_payloads and known_payloads
+    // independently and cannot cross-compare candidates, so a small proof from
+    // new_payloads can survive even when a strictly larger known_payloads proof
+    // is later selected on top. Merging dominated children via STARK costs
+    // ~4 s per call for no extra coverage (#940). `covered_by_children` is
+    // unaffected because the dominating child already covers the dropped
+    // child's validators.
+    pruneSubsumedChildren(&selected_children);
 
     var sigmap_sigs: std.ArrayList(xmss.Signature) = .empty;
     errdefer {

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -688,7 +688,7 @@ const CompactGroupResult = struct {
 /// Out-of-bounds bits in either bitlist are treated as zero (unset), which
 /// matches `AggregationBits.get(i) catch false` semantics elsewhere in this
 /// file. Pure read-only helper; allocates nothing.
-fn participantsContainsAll(superset: attestation.AggregationBits, subset: attestation.AggregationBits) bool {
+pub fn participantsContainsAll(superset: attestation.AggregationBits, subset: attestation.AggregationBits) bool {
     var i: usize = 0;
     while (i < subset.len()) : (i += 1) {
         const sub_bit = subset.get(i) catch false;
@@ -746,6 +746,38 @@ fn pruneSubsumedChildren(
             i += 1;
         }
     }
+}
+
+/// Returns true if any stored aggregate for `data` in `payloads_map` already
+/// covers every validator id in `raw_vids` (i.e. running an aggregator pass
+/// would not add any new coverage). #940 deferred-aggregation guard: once
+/// an aggregate dominates the raw signature set we hold, the next slot tick
+/// should skip and let the next gossip arrival re-fire the aggregator. An
+/// empty `raw_vids` is treated as "covered" (vacuously true for any stored
+/// proof, including no proofs — but the caller's other early-exit paths
+/// already handle that no-input case).
+fn anyStoredProofCoversAll(
+    raw_vids: *const std.DynamicBitSet,
+    payloads_map: ?*const AggregatedPayloadsMap,
+    data: attestation.AttestationData,
+) bool {
+    const pm = payloads_map orelse return false;
+    const candidates = pm.get(data) orelse return false;
+    for (candidates.items) |*stored| {
+        const p = &stored.proof.participants;
+        var all_covered = true;
+        var bit_idx: usize = 0;
+        while (bit_idx < raw_vids.capacity()) : (bit_idx += 1) {
+            if (!raw_vids.isSet(bit_idx)) continue;
+            const covered_by_proof = bit_idx < p.len() and (p.get(bit_idx) catch false);
+            if (!covered_by_proof) {
+                all_covered = false;
+                break;
+            }
+        }
+        if (all_covered) return true;
+    }
+    return false;
 }
 
 pub fn attestationDataLessThan(_: void, a: attestation.AttestationData, b: attestation.AttestationData) bool {
@@ -871,22 +903,58 @@ fn prepareAggregateAttData(
     var message_hash: [32]u8 = undefined;
     try zeam_utils.hashTreeRoot(attestation.AttestationData, data, &message_hash, allocator);
 
+    const max_validator = validators.len();
+
+    // Collect the validator ids backed by a raw XMSS signature for this att_data
+    // up front (#940 deferred-aggregation path). Two uses below:
+    //   1. If any single stored aggregate already covers every raw vid, the
+    //      worker has nothing new to add — skip.
+    //   2. Otherwise, pass `raw_vids` as the `gossip_available` argument to
+    //      `extendProofsGreedily` so the greedy pick does not select children
+    //      whose only validator coverage is already in the raw set. Combined
+    //      with the change in `commitOneAggregateResult` to no longer delete
+    //      live raws after a commit, this converts the previously dominant
+    //      "recursive merge of stored aggregate + new raws" pattern (mean
+    //      ~4.5 s per call on devnet) into a flat re-prove over the raw set
+    //      (~0.5 s).
+    var raw_vids = try std.DynamicBitSet.initEmpty(allocator, max_validator);
+    defer raw_vids.deinit();
+
+    if (signatures_map.get(data)) |im| {
+        var vid_it = im.iterator();
+        while (vid_it.next()) |entry| {
+            const vid: usize = @intCast(entry.key_ptr.*);
+            const sig_entry = entry.value_ptr.*;
+            if (std.mem.eql(u8, &sig_entry.signature, &ZERO_SIGBYTES)) continue;
+            if (vid >= max_validator) continue;
+            if (vid >= raw_vids.capacity()) try raw_vids.resize(vid + 1, false);
+            raw_vids.set(vid);
+        }
+    }
+
+    // Skip when an existing stored aggregate already dominates our raw set.
+    // Empty raw_vids would also short-circuit here, but the existing
+    // `!has_gossip and !has_children` branch below covers that case more
+    // cleanly (after greedy runs and decides whether to bring in children).
+    if (raw_vids.count() > 0) {
+        if (anyStoredProofCoversAll(&raw_vids, new_payloads, data) or
+            anyStoredProofCoversAll(&raw_vids, known_payloads, data))
+        {
+            return .{ .data = data, .outcome = .skip };
+        }
+    }
+
     var selected_children: std.ArrayList(aggregation.AggregatedSignatureProof) = .empty;
     errdefer {
         for (selected_children.items) |*child| child.deinit();
         selected_children.deinit(allocator);
     }
 
-    const max_validator = validators.len();
-
     var covered_by_children = try std.DynamicBitSet.initEmpty(allocator, max_validator);
     defer covered_by_children.deinit();
 
-    var empty_available = try std.DynamicBitSet.initEmpty(allocator, max_validator);
-    defer empty_available.deinit();
-
-    try extendProofsGreedily(allocator, new_payloads, data, &selected_children, &covered_by_children, &empty_available);
-    try extendProofsGreedily(allocator, known_payloads, data, &selected_children, &covered_by_children, &empty_available);
+    try extendProofsGreedily(allocator, new_payloads, data, &selected_children, &covered_by_children, &raw_vids);
+    try extendProofsGreedily(allocator, known_payloads, data, &selected_children, &covered_by_children, &raw_vids);
     // Drop children whose participant set is dominated by another selected
     // child's. The two greedy passes above scan new_payloads and known_payloads
     // independently and cannot cross-compare candidates, so a small proof from

--- a/pkgs/types/src/lib.zig
+++ b/pkgs/types/src/lib.zig
@@ -39,6 +39,7 @@ pub const default_min_aggregation_inputs = block.default_min_aggregation_inputs;
 pub const SingleAggregatedSignature = block.SingleAggregatedSignature;
 pub const computeSingleAggregatedSignature = block.computeSingleAggregatedSignature;
 pub const attestationDataLessThan = block.attestationDataLessThan;
+pub const participantsContainsAll = block.participantsContainsAll;
 
 const state = @import("./state.zig");
 pub const BeamStateConfig = state.BeamStateConfig;

--- a/pkgs/xmss/src/aggregation.zig
+++ b/pkgs/xmss/src/aggregation.zig
@@ -167,7 +167,7 @@ pub fn aggregateSignatures(
         epoch,
         log_inv_rate,
     ) orelse return AggregationError.AggregationFailed;
-    recordXmssProveDuration(prove_start_ns);
+    recordXmssProveDuration(prove_start_ns, public_keys.len, num_children);
 
     // Serialize the aggregate signature to bytes
     var buffer: [MAX_AGGREGATE_SIGNATURE_SIZE]u8 = undefined;
@@ -186,11 +186,11 @@ pub fn aggregateSignatures(
     }
 }
 
-fn recordXmssProveDuration(start_ns: i128) void {
+fn recordXmssProveDuration(start_ns: i128, num_raw: usize, num_children: usize) void {
     const end_ns = zeam_utils.monotonicTimestampNs();
     const elapsed_ns: i128 = if (end_ns >= start_ns) end_ns - start_ns else 0;
     const elapsed_s = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
-    zeam_metrics.observeXmssRecAggregateProve(elapsed_s);
+    zeam_metrics.observeXmssRecAggregateProve(elapsed_s, num_raw, num_children);
 }
 
 /// Precondition: `setupXmssAggregation` must have been called once in this process.

--- a/pkgs/xmss/src/aggregation.zig
+++ b/pkgs/xmss/src/aggregation.zig
@@ -38,6 +38,11 @@ extern fn xmss_aggregate(
     message_hash_ptr: [*]const u8,
     slot: u32,
     log_inv_rate: usize,
+    // Phase timing out-params (#940). See multisig-glue/src/lib.rs for the
+    // exact phase definitions. Nullable.
+    out_marshal_ns: ?*u64,
+    out_stark_ns: ?*u64,
+    out_post_ns: ?*u64,
 ) callconv(.c) ?*AggregatedXMSS;
 
 extern fn xmss_verify_aggregated(
@@ -153,6 +158,14 @@ pub fn aggregateSignatures(
         child_proof_lens[i] = proof_slice.len;
     }
 
+    // Phase-timing buckets filled by the Rust FFI (#940). Zero-initialized so
+    // an early-return inside xmss_aggregate that skips the writes still leaves
+    // a defined state; the success path below overwrites all three before we
+    // observe them.
+    var ffi_marshal_ns: u64 = 0;
+    var ffi_stark_ns: u64 = 0;
+    var ffi_post_ns: u64 = 0;
+
     const prove_start_ns = zeam_utils.monotonicTimestampNs();
     const agg_sig = xmss_aggregate(
         public_keys.ptr,
@@ -166,8 +179,14 @@ pub fn aggregateSignatures(
         message_hash,
         epoch,
         log_inv_rate,
+        &ffi_marshal_ns,
+        &ffi_stark_ns,
+        &ffi_post_ns,
     ) orelse return AggregationError.AggregationFailed;
     recordXmssProveDuration(prove_start_ns, public_keys.len, num_children);
+    zeam_metrics.observeXmssRecAggregatePhase("marshal", ffi_marshal_ns);
+    zeam_metrics.observeXmssRecAggregatePhase("stark", ffi_stark_ns);
+    zeam_metrics.observeXmssRecAggregatePhase("post", ffi_post_ns);
 
     // Serialize the aggregate signature to bytes
     var buffer: [MAX_AGGREGATE_SIGNATURE_SIZE]u8 = undefined;

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -6,6 +6,7 @@ use rec_aggregation::{
 };
 use std::slice;
 use std::sync::OnceLock;
+use std::time::Instant;
 
 // Mirror hashsig-glue's struct layout with #[repr(C)]
 // These must match hashsig-glue/src/lib.rs exactly
@@ -74,10 +75,30 @@ pub unsafe extern "C" fn xmss_aggregate(
     message_hash_ptr: *const u8,
     slot: u32,
     log_inv_rate: usize,
+    // Phase timing out-params (#940). Each pointer is optional (null = ignored).
+    // On a successful call, the function writes elapsed nanoseconds for each
+    // internal phase:
+    //   * `out_marshal_ns`  — Rust-side argument deserialize: raw XMSS clones,
+    //                         child public-key collection, child proof
+    //                         deserialize (the work between FFI entry and the
+    //                         `rec_xmss_aggregate` call).
+    //   * `out_stark_ns`    — `rec_xmss_aggregate` itself (leanMultisig STARK
+    //                         prove). This is the only phase whose cost is
+    //                         expected to scale with `num_raw` per lean-bench.
+    //   * `out_post_ns`     — `Box::into_raw` of the returned aggregate (no
+    //                         work beyond a pointer wrap; instrumented for
+    //                         completeness so the three buckets sum to the
+    //                         total observed externally on
+    //                         `zeam_xmss_rec_aggregate_prove_seconds`).
+    // On the early-return error paths the out-pointers are left untouched.
+    out_marshal_ns: *mut u64,
+    out_stark_ns: *mut u64,
+    out_post_ns: *mut u64,
 ) -> *const AggregatedXMSS {
     if message_hash_ptr.is_null() {
         return std::ptr::null();
     }
+    let t_entry = Instant::now();
     if num_raw > 0 && (raw_pub_keys.is_null() || raw_signatures.is_null()) {
         return std::ptr::null();
     }
@@ -156,6 +177,8 @@ pub unsafe extern "C" fn xmss_aggregate(
         .map(|(pks, proof)| (pks.as_slice(), proof))
         .collect();
 
+    let t_marshal_done = Instant::now();
+
     // Call rec_aggregation
     let (_pub_keys, agg_sig) = rec_xmss_aggregate(
         &children_with_keys,
@@ -165,7 +188,24 @@ pub unsafe extern "C" fn xmss_aggregate(
         log_inv_rate,
     );
 
-    Box::into_raw(Box::new(agg_sig))
+    let t_stark_done = Instant::now();
+
+    let result = Box::into_raw(Box::new(agg_sig));
+
+    let t_post_done = Instant::now();
+
+    // Write phase timings if the caller passed non-null out-pointers.
+    if !out_marshal_ns.is_null() {
+        *out_marshal_ns = t_marshal_done.duration_since(t_entry).as_nanos() as u64;
+    }
+    if !out_stark_ns.is_null() {
+        *out_stark_ns = t_stark_done.duration_since(t_marshal_done).as_nanos() as u64;
+    }
+    if !out_post_ns.is_null() {
+        *out_post_ns = t_post_done.duration_since(t_stark_done).as_nanos() as u64;
+    }
+
+    result
 }
 
 /// Verify aggregated signatures.


### PR DESCRIPTION
Addresses #940 (and #899) — drives the aggregate-build p95 down by changing the
aggregator from *eager-aggregate-then-recursively-merge* to *defer-and-flat-re-prove
over growing raws*, plus the metric instrumentation that made the diagnosis
possible.

## TL;DR

- **Root cause** (measured, not guessed): every successful aggregate deleted the
  raw signatures it consumed. The next aggregator tick on the same `att_data`
  saw the freshly-stored aggregate as a *child* + any new gossip arrivals as
  raws, forcing `rec_xmss_aggregate` to take the recursive code path at
  **~4.5 s mean** per call. On the live devnet, 60 % of proves were recursive.
- **Fix**: keep raw sigs live; pre-check whether any stored aggregate already
  covers them (skip if yes); pass raw vids as `gossip_available` to greedy so
  children dominated by raws are not picked. The FFI now runs flat
  (`num_children = 0`) on the vast majority of ticks. lean-bench extrapolation
  for flat on 16-core Hetzner: ~0.5 s for 8-validator committees.
- **Instrumentation**: new `zeam_xmss_rec_aggregate_phase_seconds{phase}` and
  `zeam_xmss_rec_aggregate_prove_by_input_seconds{num_raw, num_children}`
  histograms. Together they answered the #940 investigation plan's decision
  table from production data (see *How we got here* below) and will be the
  before/after evidence on the next devnet restart.

## Commits, in narrative order

| Commit | What | Why |
|--------|------|-----|
| `80e5d8fd` | `node`: fix missing `setupTestPrimitives` reference in `commitOneAggregateResult` test | Unblocks `zig build` / `zig build test` on `origin/main`; the helper introduced in #933 referenced an undeclared name |
| `743c42a0` | `metrics, xmss`: new `zeam_xmss_rec_aggregate_prove_by_input_seconds{num_raw, num_children}` (low-cardinality buckets) | #940 plan item 1 — input-size attribution on the prove histogram so the tail can be classified |
| `7be975b4` | `metrics, xmss, multisig-glue`: split the FFI timer 3-ways via Rust out-pointers; new `zeam_xmss_rec_aggregate_phase_seconds{phase="marshal"\|"stark"\|"post"}` | #940 plan item 2 (hypothesis A vs B) — needed to tell wrapper overhead from prover overhead |
| `cf336cf3` | `types`: drop subsumed children before STARK (`pruneSubsumedChildren`) | First-attempt perf fix targeting the two-pass greedy's subsumption edge case; left in place since it is harmless and orthogonal to commit 5 |
| `7931e696` | `node, types`: deferred aggregation — keep raw sigs live, skip when stored proof dominates raws, pass `raw_vids` to greedy, prune dominated stored aggregates on commit | The actual fix once the metrics in commits 2–3 had localized the cost to the recursive STARK driven by the eager-delete-raws lifecycle |

## How we got here (live-devnet evidence)

Snapshot of `zeam_8` (16-core Hetzner, log_inv_rate=2) before the fix:

```
zeam_xmss_rec_aggregate_phase_seconds:
  marshal  0.4 ms / call    (0.02 %)
  stark    1830 ms / call   (99.97 %)
  post     0.2 µs / call    (0.00001 %)

zeam_xmss_rec_aggregate_prove_by_input_seconds:
  num_children=0   flat        250–470 ms / call
  num_children=3-4 recursive   ~4500 ms / call
  recursive share:             60 % of proves
```

The phase split (commit 3) eliminated hypothesis A — zeam wrapper overhead is
not the bottleneck; marshal + post sum to <1 ms. The input-size labels
(commit 2) eliminated the cross-client / hardware speculation: flat proves at
this scale already meet the lean-bench extrapolation (~3.6 ms/sig). The tail
is entirely from `num_children > 0` cases at a flat ~4.5 s each.

The subset-prune (commit 4) was the natural first guess at what creates those
recursive cases — two greedy passes over `new_payloads` / `known_payloads`
that cannot cross-compare candidates. On the devnet that hypothesis was
disproved by the **fast-path delta** metric staying at 1 across runs: greedy
almost never produces strictly-dominated children at this topology, so the
prune is essentially a no-op. (Kept anyway — harmless, defensive.)

Reading the data again with that ruled out: the recursive cases arise because
the local store always contains the previously-published aggregate as a
"child" candidate, while any newly-arrived raws appear separately — and that
is structural, not a greedy bug. Commit 5 changes the lifecycle so this no
longer happens.

## Detailed change in commit 5 (the actual fix)

### Before

```text
slot S    : raws = {0..3}             → flat prove → aggregate A {0..3}
            DELETE raws from live
slot S+1  : raws = {4,5}              ← only the NEW arrivals
            stored = [A]              ← from S
            extendProofsGreedily → picks A
            sigmap iter → picks {4,5}
            recursive STARK over (A + raws)    ~4.5 s ❌
            DELETE raws → aggregate B {0..5}
slot S+2  : same shape with newer raws → another 4.5 s recursive merge
```

### After

```text
slot S    : raws = {0..3}             → flat prove → aggregate A {0..3}
            KEEP raws live
slot S+1  : raws = {0..5}             ← cumulative
            stored = [A]
            anyStoredProofCoversAll(raws ⊆ A.participants)? no
            extendProofsGreedily(gossip_available = raws) → A's bits all in raws → coverage 0 → A NOT picked
            sigmap iter → picks {0..5}
            flat STARK over raws (num_children = 0)    ~0.5 s ✅
            store aggregate B {0..5}; drop A as subsumed (commit-time prune)
slot S+2  : raws = {0..5} (no new)
            anyStoredProofCoversAll(raws ⊆ B.participants)? yes → SKIP entirely
slot S+3  : raws = {0..7} (more new)  → flat prove → aggregate C {0..7}
            ...
```

Three coupled changes:

1. **`forkchoice.zig` `commitOneAggregateResult`** — stop deleting consumed raw
   sigs from `attestation_signatures`. Drain only the snapshot's private inner
   map. Finalization-driven prune (`pruneStaleSignatures`) still bounds memory.

2. **`block.zig` `prepareAggregateAttData`** — compute `raw_vids` up front;
   `anyStoredProofCoversAll` short-circuit to `skip` when a stored aggregate
   already covers them; pass `raw_vids` as `gossip_available` to
   `extendProofsGreedily` so dominated children are not selected.

3. **`forkchoice.zig` `commitOneAggregateResult`** — before appending the new
   aggregate to `latest_new_aggregated_payloads[att_data]`, drop any existing
   entry whose participants are contained in the new one. Otherwise the list
   would accumulate one strictly-dominated entry per tick.

`shouldSuppressDuplicateAggregateCommit` is left unchanged — its predicate
(`none of snap's vids are in live`) now normally evaluates false, so it stops
firing. That is safe: `anyStoredProofCoversAll` plays that role earlier in the
pipeline, before the worker produces a duplicate proof.

`participantsContainsAll` is promoted to `pub` in `block.zig` and re-exported
via `types/lib.zig` so `forkchoice.zig` can use it for the dominated-stored-
aggregate prune.

## Metrics changes (commits 2–3, recap)

Both are zeam-internal (`zeam_*`); the cross-client spec metric
`lean_pq_sig_aggregated_signatures_building_time_seconds` is **not modified**,
so existing dashboards keep working.

- `zeam_xmss_rec_aggregate_prove_by_input_seconds{num_raw, num_children}` —
  same wall-time observation as the unlabeled prove histogram, additionally
  labeled by coarse input-size buckets.
  - `num_raw` buckets: `0`, `1`, …, `8`, `9-15`, `16-31`, `32+`
  - `num_children` buckets: `0`, `1`, `2`, `3-4`, `5-7`, `8+`
- `zeam_xmss_rec_aggregate_phase_seconds{phase}` — per-phase split inside the
  Rust FFI, reported back via out-pointers from `xmss_aggregate`:
  - `marshal` — `raw_xmss` Vec build + `.inner.clone()` × 2N + child deserialize
  - `stark` — `rec_xmss_aggregate` itself (the leanMultisig STARK)
  - `post` — `Box::into_raw` of the returned aggregate
- The bare `zeam_xmss_rec_aggregate_prove_seconds` is preserved unchanged so
  lean-bench `aggregate.flat_*_r2` comparisons stay apples-to-apples.

FFI signature change in `rust/multisig-glue/src/lib.rs`: `xmss_aggregate` now
takes three additional `*mut u64` out-params (`out_marshal_ns`, `out_stark_ns`,
`out_post_ns`). All nullable; the only caller is `pkgs/xmss/src/aggregation.zig`
which passes three stack u64s.

## Behaviour contracts

- **Validator coverage is preserved**, with or without the fix. Both the
  subset-prune (commit 4) and the dominated-stored-aggregate prune (commit 5
  step 3) drop entries that are fully covered by another entry — the
  union of validators in the kept set is unchanged.
- **Memory** stays bounded: finalization still prunes both
  `attestation_signatures` (via `pruneStaleSignatures`) and
  `latest_new_aggregated_payloads` (via `prunePayloadMapBySlot`).
- **Cross-client wire format** is unchanged. Aggregates produced by the new
  flow are ordinary `SignedAggregatedAttestation`s; peers cannot tell the
  difference. The number of aggregates published per slot may go up
  modestly (deferred path re-publishes as raws grow), but each is strictly
  larger than any prior one for the same `att_data` and the commit-time
  prune ensures we don't store redundant copies locally.

## Test plan

- [x] `zig build -Dprover=dummy` — clean.
- [x] `zig build test -Dprover=dummy` — 310 tests pass across the test
      binaries.
- [x] Test `aggregate prunes attestation signatures` updated: previously
      asserted `attestation_signatures.count() == 0` after commit
      (encoding the old delete-on-commit behaviour); now asserts the new
      contract (count stays at the original raw count).
- [ ] Deploy `0xpartha/zeam:local` to ansible devnet `zeam_8`; verify on
      the new image:
      - `zeam_xmss_rec_aggregate_prove_by_input_seconds_count{num_children!="0"}`
        drops sharply (target: <10 % of proves vs 60 % baseline)
      - `zeam_xmss_rec_aggregate_phase_seconds{phase="stark"}` mean drops
        toward lean-bench extrapolation (~30–500 ms depending on raw count)
      - `lean_pq_sig_aggregated_signatures_building_time_seconds` mean
        below 0.5 s, p95 below 1 s
      - Fast-path delta (counter − prove_count) grows: skips when no new
        coverage to add
      - No duplicate-aggregate gossip storms (peer dedup behaviour
        verified via `lean_pq_sig_aggregated_signatures_verification_time_seconds`
        and gossip volume metrics)

## Out of scope (deliberately)

- Renaming or re-scoping `lean_pq_sig_aggregated_signatures_*` for cross-
  client comparison. The leanMetrics spec text is too thin to pin
  semantics; the divergence is the same one documented in #940's
  cross-client analysis. Separate spec work.
- Upstream leanMultisig changes (persistent prover state, batched FFI
  accepting multiple `att_data` per call). The structural change in this
  PR avoids the recursive code path almost entirely at this topology, so
  the upstream cost reduction is no longer on the critical path.
- Changing `min_aggregation_inputs` or `isAggregatorTrivialInput`. Those
  remain as the early-bail filters; deferred aggregation just changes
  what the worker does once those filters say "yes, aggregate."