### PR TITLE
cli, node, types: cap aggregator-worker children per call to bound STARK latency (#940)

### DIFF
--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -98,6 +98,16 @@ pub const NodeCommand = struct {
     /// on chatty subnets. See issue #907 finding 4.
     @"min-aggregation-inputs": u32 = types.default_min_aggregation_inputs,
 
+    /// Cap on the number of child STARK proofs the aggregator worker merges
+    /// with raw signatures via `rec_xmss_aggregate` (#940 follow-up).
+    /// Default `0` keeps per-call latency bounded by flat-prove cost
+    /// (~0.5 s on 16-core Hetzner per lean-bench at log_inv_rate=2). Higher
+    /// values let the worker emit broader aggregates per tick at the cost
+    /// of ~1.3 s per additional child (devnet snapshot:
+    /// `num_children=3-4` proves averaged ~4.8 s, dominated the p95 tail).
+    /// See `types.default_max_aggregation_children` for full rationale.
+    @"max-aggregation-children": u32 = types.default_max_aggregation_children,
+
     pub const __shorts__ = .{
         .help = .h,
     };
@@ -124,6 +134,7 @@ pub const NodeCommand = struct {
         .@"chain-worker" = "Route gossip block + attestation handlers through the dedicated chain-worker thread. On by default; pass `--chain-worker false` to fall back to the legacy synchronous path as a kill-switch.",
         .@"rayon-threads" = "Override the rayon worker count used by the multisig aggregate prover. If unset, half of the post-system-thread budget goes to the Zig pool and half to rayon. Aggregators in CPU-rich environments benefit from a higher value (e.g. 12 on a 16-vCPU host); non-aggregators can leave it unset.",
         .@"min-aggregation-inputs" = "Minimum (children + gossip-sig) inputs required before the aggregator invokes the recursive STARK prover for an AttestationData. Default 2 skips the trivial 'no children + 1 local sig' case (the lone sig is already on the gossip topic, so peers can fold it in directly; building a 1-validator aggregate spends the full prover budget for zero consensus signal). Set 1 to revert to pre-#908 behavior. Higher values trade slot latency for fewer sub-threshold aggregates on chatty subnets.",
+        .@"max-aggregation-children" = "Cap on the number of child STARK proofs the aggregator worker merges with raw signatures via rec_xmss_aggregate. Default 0 keeps per-call latency bounded by flat-prove cost (~0.5 s/call on devnet aggregator hardware) by never taking the recursive code path; peer-published aggregates for the same att_data remain in latest_known_aggregated_payloads for the block proposer to compact at proposal time. Set 1 to allow at most one peer child to be merged (~1.5 s/call). Higher values reintroduce the multi-second tail (#940 devnet snapshot: num_children=3-4 averaged ~4.8 s).",
         .help = "Show help information for the node command",
     };
 };
@@ -861,6 +872,7 @@ fn mainInner(init: std.process.Init) !void {
                 .db_backend = leancmd.@"db-backend",
                 .rayon_threads = leancmd.@"rayon-threads",
                 .min_aggregation_inputs = leancmd.@"min-aggregation-inputs",
+                .max_aggregation_children = leancmd.@"max-aggregation-children",
             };
 
             defer start_options.deinit(allocator);

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -121,6 +121,14 @@ pub const NodeOptions = struct {
     /// `pkgs/types/src/block.zig:default_min_aggregation_inputs`. See
     /// issue #907 finding 4.
     min_aggregation_inputs: u32 = types.default_min_aggregation_inputs,
+    /// Cap on the number of child STARK proofs merged with raw signatures
+    /// by the aggregator-worker path. Threaded through to
+    /// `ForkChoice.max_aggregation_children` and applied by
+    /// `prepareAggregateAttData` after greedy + subset-prune. Surfaced as
+    /// `--max-aggregation-children` on the `zeam node` CLI; default is
+    /// `pkgs/types/src/block.zig:default_max_aggregation_children` (0 —
+    /// flat-only worker path). See #940 follow-up.
+    max_aggregation_children: u32 = types.default_max_aggregation_children,
 
     pub fn deinit(self: *NodeOptions, allocator: std.mem.Allocator) void {
         for (self.bootnodes) |b| allocator.free(b);
@@ -597,6 +605,7 @@ pub const Node = struct {
             .thread_pool = self.thread_pool,
             .chain_worker_enabled = options.chain_worker_enabled,
             .min_aggregation_inputs = options.min_aggregation_inputs,
+            .max_aggregation_children = options.max_aggregation_children,
             .aggregate_max_inflight = aggregate_max_inflight,
         });
         errdefer self.beam_node.deinit();

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -71,6 +71,10 @@ pub const ChainOpts = struct {
     /// `pkgs/types/src/block.zig:default_min_aggregation_inputs` for the
     /// default and `isTrivialAggregationInput` for the predicate semantics.
     min_aggregation_inputs: u32 = types.default_min_aggregation_inputs,
+    /// Surfaces the `--max-aggregation-children` CLI flag to the
+    /// per-`ForkChoice` recursive-child cap. See
+    /// `pkgs/types/src/block.zig:default_max_aggregation_children`.
+    max_aggregation_children: u32 = types.default_max_aggregation_children,
     /// Max in-flight aggregations on the shared `ThreadPool`. Soft ceiling
     /// enforced lock-free by `submitAggregateOnInterval`. When the cap is
     /// reached the trigger is coalesced into `aggregate_reschedule_intervals`
@@ -540,6 +544,7 @@ pub const BeamChain = struct {
             .logger = logger_config.logger(.forkchoice),
             .thread_pool = opts.thread_pool,
             .min_aggregation_inputs = opts.min_aggregation_inputs,
+            .max_aggregation_children = opts.max_aggregation_children,
         });
 
         var states = std.AutoHashMap(types.Root, *RcBeamState).init(allocator);

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -286,6 +286,13 @@ pub const ForkChoiceParams = struct {
     /// `pruneTrivialFromAggregateSnapshot` (NOT by the FFI). See
     /// `isAggregatorTrivialInput` for the predicate semantics.
     min_aggregation_inputs: u32 = types.default_min_aggregation_inputs,
+    /// Cap on the number of child STARK proofs the aggregator worker
+    /// merges with raw signatures via `rec_xmss_aggregate`. Threaded from
+    /// the `--max-aggregation-children` CLI flag. Default `0` keeps
+    /// per-call latency bounded by flat-prove cost; see
+    /// `types.default_max_aggregation_children` for the full rationale
+    /// and operator trade-offs.
+    max_aggregation_children: u32 = types.default_max_aggregation_children,
 };
 
 // Use shared signature map types from types package
@@ -348,6 +355,14 @@ pub const ForkChoice = struct {
     /// level so test struct literals that don't care about the
     /// threshold can omit it.
     min_aggregation_inputs: u32 = types.default_min_aggregation_inputs,
+    /// Cap on the number of child STARK proofs merged with raw signatures
+    /// by the aggregator-worker path. Threaded from
+    /// `ForkChoiceParams.max_aggregation_children` (and ultimately from
+    /// the `--max-aggregation-children` CLI flag). Default
+    /// `types.default_max_aggregation_children` keeps worker latency
+    /// bounded by flat-prove cost; see that constant's doc for trade-offs.
+    /// Field-level default so test struct literals can omit it.
+    max_aggregation_children: u32 = types.default_max_aggregation_children,
     last_node_tick_time_ms: ?i64,
 
     const Self = @This();
@@ -441,6 +456,7 @@ pub const ForkChoice = struct {
             .status = if (opts.anchorState.slot == 0) .ready else .initing,
             .thread_pool = opts.thread_pool,
             .min_aggregation_inputs = opts.min_aggregation_inputs,
+            .max_aggregation_children = opts.max_aggregation_children,
             .last_node_tick_time_ms = null,
         };
         if (fc.status == .initing) {
@@ -2130,6 +2146,7 @@ pub const ForkChoice = struct {
                 &snap.new_payloads,
                 &snap.known_payloads,
                 data,
+                self.max_aggregation_children,
             );
             if (maybe_result) |*result| {
                 defer result.attestation.deinit();

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -62,6 +62,10 @@ const NodeOpts = struct {
     /// aggregation threshold; see
     /// `pkgs/types/src/block.zig:default_min_aggregation_inputs`.
     min_aggregation_inputs: u32 = types.default_min_aggregation_inputs,
+    /// CLI knob (`--max-aggregation-children`) capping child STARK proofs
+    /// merged with raw signatures by the aggregator worker. See
+    /// `pkgs/types/src/block.zig:default_max_aggregation_children`.
+    max_aggregation_children: u32 = types.default_max_aggregation_children,
     /// Soft cap on concurrent aggregate workers (`BeamChain.aggregate_inflight`).
     aggregate_max_inflight: u32 = 4,
 };
@@ -150,6 +154,7 @@ pub const BeamNode = struct {
                 .is_aggregator = opts.is_aggregator,
                 .thread_pool = opts.thread_pool,
                 .min_aggregation_inputs = opts.min_aggregation_inputs,
+                .max_aggregation_children = opts.max_aggregation_children,
                 .aggregate_max_inflight = opts.aggregate_max_inflight,
             },
             network.connected_peers,

--- a/pkgs/types/src/block.zig
+++ b/pkgs/types/src/block.zig
@@ -48,6 +48,33 @@ const freeJsonValue = utils.freeJsonValue;
 /// latency for fewer sub-threshold aggregates on chatty subnets.
 pub const default_min_aggregation_inputs: u32 = 2;
 
+/// Default `max_aggregation_children` for the aggregator-role STARK budget.
+///
+/// Surfaced on the CLI as `--max-aggregation-children` (see
+/// `pkgs/cli/src/main.zig`) and consumed by `prepareAggregateAttData` after
+/// greedy + subset-prune select children for this `att_data`. Caps the
+/// number of child STARK proofs passed into `rec_xmss_aggregate`; excess
+/// children are dropped (sorted by descending validator coverage).
+///
+/// Default `0`: aggregator worker NEVER takes the recursive code path,
+/// always proves flat over the raw signature set. Peer-published aggregates
+/// for the same `att_data` remain in `latest_known_aggregated_payloads`
+/// (gossip already propagated them; not re-publishing is information-
+/// preserving on the wire), and the block proposer's `compactAttestations`
+/// step can still merge them at block-proposal time. This keeps the
+/// worker's per-call latency bounded by flat-prove cost (~3.6 ms/sig on
+/// 16-core Hetzner per lean-bench `aggregate.flat_*_r2` at log_inv_rate=2,
+/// so well under 1 s for committee-sized inputs) instead of paying ~4.5 s
+/// for a recursive merge.
+///
+/// `1`: allow at most one peer child to be merged with raws — useful when
+/// operators want broader on-the-wire coverage from a single aggregator
+/// publish, accepting ~1.5 s per recursive prove. Higher values approach
+/// the pre-cap behaviour and reintroduce the multi-second tail (#940
+/// devnet snapshot: `num_children=3-4` proves averaged ~4.5 s, dominated
+/// the p95).
+pub const default_max_aggregation_children: u32 = 0;
+
 // signatures_map types for aggregation
 
 /// Stored signatures_map entry: per-validator signature + slot metadata.
@@ -517,6 +544,7 @@ pub const AggregatedAttestationsResult = struct {
         known_payloads: ?*const AggregatedPayloadsMap,
         slot_filter: ?[]const Slot,
         thread_pool: *ThreadPool,
+        max_aggregation_children: u32,
     ) !void {
         const allocator = self.allocator;
 
@@ -566,6 +594,7 @@ pub const AggregatedAttestationsResult = struct {
                 new_payloads,
                 known_payloads,
                 data,
+                max_aggregation_children,
             );
         }
         observeAggregateAttDataPrepPhase(prep_start_ns);
@@ -804,6 +833,11 @@ pub const SingleAggregatedSignature = CompactGroupResult;
 
 /// Single `att_data` aggregation: serial prep then one XMSS prove (ethlambda
 /// `aggregate_job` shape). Used by the aggregator per-job loop.
+///
+/// `max_aggregation_children` caps the number of child STARK proofs merged
+/// with raw signatures by the recursive prover (#940 follow-up). See
+/// `default_max_aggregation_children` for the rationale; threaded from
+/// `ForkChoice.max_aggregation_children` through `aggregateUnlocked`.
 pub fn computeSingleAggregatedSignature(
     allocator: Allocator,
     validators: *const Validators,
@@ -811,6 +845,7 @@ pub fn computeSingleAggregatedSignature(
     new_payloads: ?*const AggregatedPayloadsMap,
     known_payloads: ?*const AggregatedPayloadsMap,
     data: attestation.AttestationData,
+    max_aggregation_children: u32,
 ) !?SingleAggregatedSignature {
     var prep = try prepareAggregateAttData(
         allocator,
@@ -819,6 +854,7 @@ pub fn computeSingleAggregatedSignature(
         new_payloads,
         known_payloads,
         data,
+        max_aggregation_children,
     );
     defer prep.deinit(allocator);
 
@@ -898,6 +934,7 @@ fn prepareAggregateAttData(
     new_payloads: ?*const AggregatedPayloadsMap,
     known_payloads: ?*const AggregatedPayloadsMap,
     data: attestation.AttestationData,
+    max_aggregation_children: u32,
 ) !AggregateAttDataPrep {
     const epoch: u64 = data.slot;
     var message_hash: [32]u8 = undefined;
@@ -1042,6 +1079,61 @@ fn prepareAggregateAttData(
                 },
             },
         };
+    }
+
+    // Cap the number of children passed to the recursive STARK at
+    // `max_aggregation_children`. Greedy + prune left only proofs that each
+    // add validator coverage raws don't have, but every additional child is
+    // a ~1.3 s adder to `rec_xmss_aggregate` (#940 devnet snapshot:
+    // num_children=1 proves averaged ~1.5 s, num_children=3-4 averaged
+    // ~4.8 s). Operators who would rather bound worker latency than publish
+    // a maximally-covering aggregate per tick set this to 0 — peers' own
+    // gossipped aggregates remain in `latest_known_aggregated_payloads` for
+    // the block proposer to compact at proposal time. Children are dropped
+    // lowest-coverage first so the retained set keeps the most validators
+    // per remaining child.
+    //
+    // Placement: AFTER the `!has_gossip and len==1` fast-path above, so the
+    // cheap clone-only case still fires for cap=0. The cap is strictly a
+    // STARK-cost guard; the fast-path doesn't invoke `rec_xmss_aggregate`,
+    // so capping it would lose validator coverage for no latency benefit.
+    if (selected_children.items.len > @as(usize, max_aggregation_children)) {
+        const PopCountIndex = struct {
+            popcount: usize,
+            index: usize,
+        };
+        var rankings = try allocator.alloc(PopCountIndex, selected_children.items.len);
+        defer allocator.free(rankings);
+        for (selected_children.items, 0..) |*child, i| {
+            var count: usize = 0;
+            const bits = child.participants;
+            var bit_idx: usize = 0;
+            while (bit_idx < bits.len()) : (bit_idx += 1) {
+                if (bits.get(bit_idx) catch false) count += 1;
+            }
+            rankings[i] = .{ .popcount = count, .index = i };
+        }
+        const lessThan = struct {
+            fn cmp(_: void, a: PopCountIndex, b: PopCountIndex) bool {
+                if (a.popcount != b.popcount) return a.popcount > b.popcount; // desc
+                return a.index < b.index; // stable tie-break
+            }
+        }.cmp;
+        std.mem.sort(PopCountIndex, rankings, {}, lessThan);
+
+        var keep = try allocator.alloc(bool, selected_children.items.len);
+        defer allocator.free(keep);
+        @memset(keep, false);
+        for (rankings[0..@as(usize, max_aggregation_children)]) |entry| keep[entry.index] = true;
+
+        var idx_back = selected_children.items.len;
+        while (idx_back > 0) {
+            idx_back -= 1;
+            if (!keep[idx_back]) {
+                selected_children.items[idx_back].deinit();
+                _ = selected_children.swapRemove(idx_back);
+            }
+        }
     }
 
     var xmss_participants: ?attestation.AggregationBits = null;
@@ -1708,7 +1800,7 @@ test "computeAggregatedSignatures filters attestation data by slot list" {
     defer thread_pool.deinit();
 
     const allowed_slots = [_]Slot{10};
-    try result.computeAggregatedSignatures(&validators, &signatures, &payloads, null, allowed_slots[0..], thread_pool);
+    try result.computeAggregatedSignatures(&validators, &signatures, &payloads, null, allowed_slots[0..], thread_pool, default_max_aggregation_children);
 
     try std.testing.expectEqual(@as(usize, 1), result.attestations.len());
     const aggregated = try result.attestations.get(0);
@@ -1740,12 +1832,12 @@ test "computeAggregatedSignatures slot filter matches unfiltered for same-slot i
 
     const thread_pool = try setupTestPrimitives(allocator);
     defer thread_pool.deinit();
-    try unfiltered.computeAggregatedSignatures(&validators, &signatures_a, &payloads_a, null, null, thread_pool);
+    try unfiltered.computeAggregatedSignatures(&validators, &signatures_a, &payloads_a, null, null, thread_pool, default_max_aggregation_children);
 
     var filtered = try AggregatedAttestationsResult.init(allocator);
     defer filtered.deinit();
     const allowed_slots = [_]Slot{12};
-    try filtered.computeAggregatedSignatures(&validators, &signatures_b, &payloads_b, null, allowed_slots[0..], thread_pool);
+    try filtered.computeAggregatedSignatures(&validators, &signatures_b, &payloads_b, null, allowed_slots[0..], thread_pool, default_max_aggregation_children);
 
     try std.testing.expectEqual(unfiltered.attestations.len(), filtered.attestations.len());
     try std.testing.expectEqual(unfiltered.attestation_signatures.len(), filtered.attestation_signatures.len());
@@ -1774,7 +1866,7 @@ test "computeAggregatedSignatures empty slot filter result is clean" {
     const allowed_slots = [_]Slot{14};
     const thread_pool = try setupTestPrimitives(allocator);
     defer thread_pool.deinit();
-    try result.computeAggregatedSignatures(&validators, &signatures, &payloads, null, allowed_slots[0..], thread_pool);
+    try result.computeAggregatedSignatures(&validators, &signatures, &payloads, null, allowed_slots[0..], thread_pool, default_max_aggregation_children);
 
     try std.testing.expectEqual(@as(usize, 0), result.attestations.len());
     try std.testing.expectEqual(@as(usize, 0), result.attestation_signatures.len());
@@ -2008,6 +2100,7 @@ test "computeSingleAggregatedSignature: single-child passthrough survives prep d
         &payloads,
         null,
         att_data,
+        default_max_aggregation_children,
     );
     var result = maybe_result orelse return error.TestExpectedSome;
     defer {

--- a/pkgs/types/src/lib.zig
+++ b/pkgs/types/src/lib.zig
@@ -36,6 +36,7 @@ pub const AggregatedPayloadsList = block.AggregatedPayloadsList;
 pub const AggregatedPayloadsMap = block.AggregatedPayloadsMap;
 pub const compactAttestations = block.compactAttestations;
 pub const default_min_aggregation_inputs = block.default_min_aggregation_inputs;
+pub const default_max_aggregation_children = block.default_max_aggregation_children;
 pub const SingleAggregatedSignature = block.SingleAggregatedSignature;
 pub const computeSingleAggregatedSignature = block.computeSingleAggregatedSignature;
 pub const attestationDataLessThan = block.attestationDataLessThan;


### PR DESCRIPTION
**Stacked on top of PR #941.** This branch is `perf/issue-940-num-raw-metric` (#941 head) + one commit. Once #941 merges into `main` this PR will reduce to its single commit. Reviewing the diff against `main` will show both PRs — read this one's single commit (`cli, node, types: cap aggregator-worker children per call`) for the actual change.

## Why

The #941 phase-metric data on `0xpartha/zeam:local` showed deferred aggregation eliminated the eager-delete-raws structural cost, but ~40% of proves still go through the recursive code path and one bucket (`num_raw=16-31`, `num_children=3-4`) carries ~45% of total prove time on its own at ~4.8 s mean. Those are *legitimate* cross-aggregator merges — our node holds raws for ~16 validators, peer aggregates in `latest_known_aggregated_payloads` cover different validators we never received raws for, and merging is what publishes a unified proof per `att_data`. There is no algorithmic shortcut that avoids the recursive STARK once we opt into the merge.

This PR makes opting in a per-operator choice.

## What

New CLI flag `--max-aggregation-children` (default `0`). Caps the number of child STARK proofs `prepareAggregateAttData` passes into `rec_xmss_aggregate`; when greedy + subset-prune produce more children than the cap, excess children are dropped by descending validator coverage (popcount) so the retained set keeps the most validators per remaining child.

Default `0` means the aggregator-worker path is **flat-only**:
- Peer aggregates remain in `latest_known_aggregated_payloads` for the block proposer's `compactAttestations` step at proposal time.
- The local worker never pays the recursive STARK cost.
- Per the lean-bench extrapolation for `log_inv_rate=2` on 16-core Hetzner (~3.6 ms/sig, near-zero intercept), flat-only worker proves stay well under 1 s for committee-sized inputs.

Operators who want broader on-the-wire coverage per single aggregator publish can raise to `1` (one peer child merged, ~1.5 s/call observed) or higher.

## Placement detail

The cap fires **after** the existing `!has_gossip and selected_children.len == 1` fast-path in `prepareAggregateAttData`, **before** the FFI prep. The fast path is a clone, not a STARK; capping it would lose coverage with zero latency benefit. The cap is strictly a STARK-cost guard.

## Threading

```
--max-aggregation-children                  pkgs/cli/src/main.zig
  → NodeOptions.max_aggregation_children   pkgs/cli/src/node.zig
  → BeamNodeParams                          pkgs/node/src/node.zig
  → BeamChainParams                         pkgs/node/src/chain.zig
  → ForkChoiceParams                        pkgs/node/src/forkchoice.zig
  → ForkChoice.max_aggregation_children
  → computeSingleAggregatedSignature(.., max_aggregation_children)
  → prepareAggregateAttData(.., max_aggregation_children)   pkgs/types/src/block.zig
```

Mirrors the existing `--min-aggregation-inputs` plumbing in shape and naming. `default_max_aggregation_children` re-exported via `types/lib.zig`.

## Predicted effect

Extrapolating from #941 devnet data (84 samples, 16 vCPU Hetzner):

| Bucket | Pre-cap | Post-cap (default 0) |
|--------|--------:|---------------------:|
| flat, all `num_raw` | 51 samples, ~426 ms mean | 51 → ~84 samples (all proves become flat) |
| recursive, all buckets | 33 samples, ~3511 ms mean | 0 samples |
| **Overall mean** | **1638 ms** | **~426 ms** |
| **p95** | ~4.8 s | **well under 1 s** |

Will verify on the next devnet redeploy alongside #941.

## Test plan

- [x] `zig build -Dprover=dummy` — clean
- [x] `zig build test -Dprover=dummy` — 310 tests pass (including the existing `computeSingleAggregatedSignature: single-child passthrough survives prep deinit` test that asserts the fast-path is preserved at default cap=0)
- [ ] Deploy `0xpartha/zeam:local` (rebuilt from this branch); verify:
  - `zeam_xmss_rec_aggregate_prove_by_input_seconds_count{num_children!="0"}` → 0
  - `lean_pq_sig_aggregated_signatures_building_time_seconds_sum / _count` → ~0.4–0.5 s
  - p95 well under 1 s
  - Validator coverage in published aggregates remains acceptable (operators can raise cap if not)

## Out of scope

- Per-`att_data` cap tuning. Knob is global. If different topics need different caps, that's a follow-up.
- Upstream leanMultisig recursive STARK cost reduction. Still the real ceiling for operators who set cap > 0; tracked separately.
- The `snappy.error.Corrupt` block-gossip stall observed during devnet validation of #941 — filed as #942.