### PR TITLE
node, metrics: defer gossip-block hashTreeRoot to chain-worker + libxev callback histogram (#942)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -198,6 +198,12 @@ const Metrics = struct {
     zeam_xev_clock_until_done_slow_ge_500ms_total: ZeamXevClockUntilDoneSlowGe500msCounter,
     /// Count of clock-loop `run(.until_done)` drains taking ≥1s wall time.
     zeam_xev_clock_until_done_slow_ge_1s_total: ZeamXevClockUntilDoneSlowGe1sCounter,
+    /// Wall time spent inside individual libxev callbacks, labeled by callsite.
+    /// Used to attribute slow `zeam_xev_clock_until_done_drain_seconds` to a
+    /// specific synchronous chunk of work executed on the libxev thread (#942).
+    /// Each callsite name is a fixed low-cardinality string; see
+    /// `observeLibxevCallback` for the canonical site list.
+    zeam_libxev_callback_duration_seconds: LibxevCallbackDurationHistogram,
     // Fork-choice tick interval duration: actual elapsed time between forkchoice tickIntervalUnlocked calls
     zeam_fork_choice_tick_interval_duration_seconds: ForkChoiceTickIntervalDurationHistogram,
     /// Wall time for the per-slot aggregation tick (interval 2): `maybeAggregateOnInterval`
@@ -528,6 +534,16 @@ const Metrics = struct {
     });
     const ZeamXevClockUntilDoneSlowGe500msCounter = metrics_lib.Counter(u64);
     const ZeamXevClockUntilDoneSlowGe1sCounter = metrics_lib.Counter(u64);
+    /// Per-callsite libxev callback duration (issue #942). Buckets span
+    /// 100us through 5s to capture both fast dispatches (queue submits,
+    /// metric increments) and pathological CPU-bound callbacks
+    /// (hashTreeRoot of a multi-MB block, SSZ clones of a STARK proof).
+    const LibxevCallbackSiteLabel = struct { site: []const u8 };
+    const LibxevCallbackDurationHistogram = metrics_lib.HistogramVec(
+        f32,
+        LibxevCallbackSiteLabel,
+        &[_]f32{ 0.0001, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5 },
+    );
     const ForkChoiceTickIntervalDurationHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.4, 0.6, 0.75, 0.8, 0.805, 0.81, 0.815, 0.82, 0.825, 0.85, 0.9, 1.0, 1.2, 1.6 });
     /// Aggregation tick (interval-in-slot 2): spans sub-ms through multi-second stalls.
     const AggregationIntervalTickHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0 });
@@ -1017,6 +1033,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_xev_clock_until_done_drain_seconds = Metrics.XevClockUntilDoneDrainHistogram.init("zeam_xev_clock_until_done_drain_seconds", .{ .help = "Wall time in seconds for one xev run(.until_done) in the clock driver (issues #863, #867). Captures completion backlog before the next tickInterval()." }, .{}),
         .zeam_xev_clock_until_done_slow_ge_500ms_total = Metrics.ZeamXevClockUntilDoneSlowGe500msCounter.init("zeam_xev_clock_until_done_slow_ge_500ms_total", .{ .help = "Clock-loop xev run(.until_done) drains with wall time >= 0.5s (#863)." }, .{}),
         .zeam_xev_clock_until_done_slow_ge_1s_total = Metrics.ZeamXevClockUntilDoneSlowGe1sCounter.init("zeam_xev_clock_until_done_slow_ge_1s_total", .{ .help = "Clock-loop xev run(.until_done) drains with wall time >= 1s (#863)." }, .{}),
+        .zeam_libxev_callback_duration_seconds = try Metrics.LibxevCallbackDurationHistogram.init(allocator, io, "zeam_libxev_callback_duration_seconds", .{ .help = "Wall-clock time spent inside individual libxev callbacks, labeled by site (issue #942). Tracks synchronous CPU work blocking the libxev thread between drain passes. Compare against zeam_xev_clock_until_done_drain_seconds and the slow_ge_*ms counters to attribute slow drains to a specific callsite. Sites include onGossip.block.hash_tree_root, onGossip.block.ssz_clone, onGossip.aggregation.ssz_clone, onGossip.attestation.dispatch, onInterval.tick, chain.onGossip.dispatch." }, .{}),
         .zeam_fork_choice_tick_interval_duration_seconds = Metrics.ForkChoiceTickIntervalDurationHistogram.init("zeam_fork_choice_tick_interval_duration_seconds", .{ .help = "Elapsed time between forkchoice tick calls in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
         .zeam_node_aggregation_interval_tick_seconds = Metrics.AggregationIntervalTickHistogram.init("zeam_node_aggregation_interval_tick_seconds", .{ .help = "Wall time for BeamNode at per-slot interval 2: maybeAggregateOnInterval plus publishProducedAggregations (includes null/skip/error paths)." }, .{}),
         .zeam_aggregate_skip_total = try Metrics.AggregateSkipCounter.init(allocator, io, "zeam_aggregate_skip_total", .{ .help = "Number of aggregate submissions skipped, labeled by reason: not_aggregator, not_synced, missing_state, spawn_failed. In-flight triggers are coalesced (see zeam_aggregate_coalesced_total)." }, .{}),
@@ -1245,6 +1262,18 @@ pub fn writeMetrics(writer: *std.Io.Writer) !void {
     }
 
     try metrics_lib.write(&metrics, writer);
+}
+
+/// Record wall-clock time spent inside one libxev callback (issue #942).
+/// `site` must be a fixed compile-time string from the canonical list
+/// documented on `zeam_libxev_callback_duration_seconds` — runtime-built
+/// strings would inflate the Prometheus series cardinality.
+pub fn observeLibxevCallback(site: []const u8, elapsed_seconds: f32) void {
+    if (!g_initialized or isZKVM()) return;
+    metrics.zeam_libxev_callback_duration_seconds.observe(
+        .{ .site = site },
+        elapsed_seconds,
+    ) catch {};
 }
 
 /// Record a sub-phase of aggregate attestation production (see
@@ -1600,4 +1629,26 @@ test "issues #863/#867: xev until_done drain metrics appear in /metrics output" 
     try testing.expect(std.mem.indexOf(u8, body, "zeam_xev_clock_until_done_drain_seconds") != null);
     try testing.expect(std.mem.indexOf(u8, body, "zeam_xev_clock_until_done_slow_ge_500ms_total") != null);
     try testing.expect(std.mem.indexOf(u8, body, "zeam_xev_clock_until_done_slow_ge_1s_total") != null);
+}
+
+// Issue #942: per-callsite libxev callback duration histogram is the
+// primary attribution signal for slow xev drains. Verify both the
+// metric name and a representative `site` label show up in the
+// Prometheus scrape body.
+test "issue #942: libxev callback duration histogram appears in /metrics output" {
+    if (isZKVM()) return;
+
+    try init(std.heap.page_allocator);
+
+    observeLibxevCallback("onGossip.block.hash_tree_root", 0.042);
+    observeLibxevCallback("onInterval.tick", 0.003);
+
+    var alloc_writer = std.Io.Writer.Allocating.init(testing.allocator);
+    defer alloc_writer.deinit();
+    try writeMetrics(&alloc_writer.writer);
+    const body = alloc_writer.writer.buffered();
+
+    try testing.expect(std.mem.indexOf(u8, body, "zeam_libxev_callback_duration_seconds") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "site=\"onGossip.block.hash_tree_root\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "site=\"onInterval.tick\"") != null);
 }

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -174,6 +174,16 @@ const Metrics = struct {
     lean_gossip_block_size_bytes: GossipBlockSizeBytesHistogram,
     lean_gossip_attestation_size_bytes: GossipAttestationSizeBytesHistogram,
     lean_gossip_aggregation_size_bytes: GossipAggregationSizeBytesHistogram,
+    /// Issue #942: count gossip-ingress decode rejections, labeled by
+    /// `topic_kind` (block | attestation | aggregation) and `reason`
+    /// (snappy_empty | snappy_varint | snappy_oversized | snappy_truncated |
+    /// snappy_decode | ssz_decode). Without this counter, the only operator-
+    /// visible signal that zeam has stopped accepting gossip is `lean_head_slot`
+    /// drifting behind wall-clock — by which point the node is already off
+    /// consensus. With it, the failure mode is dashboard-visible the moment
+    /// decode starts failing, and the `reason` label attributes upstream
+    /// vs. our-side framing mismatches vs. SSZ-body issues separately.
+    zeam_gossip_decode_failures_total: ZeamGossipDecodeFailuresCounter,
     // Attestation production time histogram
     lean_attestations_production_time_seconds: AttestationProductionTimeHistogram,
     // compactAttestations metrics
@@ -521,6 +531,7 @@ const Metrics = struct {
     const LeanNodeSyncStatusGauge = metrics_lib.GaugeVec(u64, struct { status: []const u8 });
     // Gossip message size histogram types
     const GossipBlockSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 10_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_000_000, 5_000_000 });
+    const ZeamGossipDecodeFailuresCounter = metrics_lib.CounterVec(u64, struct { topic_kind: []const u8, reason: []const u8 });
     const GossipAttestationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 512, 1_024, 2_048, 4_096, 8_192, 16_384 });
     const GossipAggregationSizeBytesHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1_024, 4_096, 16_384, 65_536, 131_072, 262_144, 524_288, 1_048_576 });
     // Attestation production time histogram type
@@ -1019,6 +1030,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_gossip_block_size_bytes = Metrics.GossipBlockSizeBytesHistogram.init("lean_gossip_block_size_bytes", .{ .help = "Bytes size of a gossip block message" }, .{}),
         .lean_gossip_attestation_size_bytes = Metrics.GossipAttestationSizeBytesHistogram.init("lean_gossip_attestation_size_bytes", .{ .help = "Bytes size of a gossip attestation message" }, .{}),
         .lean_gossip_aggregation_size_bytes = Metrics.GossipAggregationSizeBytesHistogram.init("lean_gossip_aggregation_size_bytes", .{ .help = "Bytes size of a gossip aggregated attestation message" }, .{}),
+        .zeam_gossip_decode_failures_total = try Metrics.ZeamGossipDecodeFailuresCounter.init(allocator, io, "zeam_gossip_decode_failures_total", .{ .help = "Gossip-ingress decode rejections, labeled by topic_kind (block|attestation|aggregation) and reason (snappy_empty|snappy_varint|snappy_oversized|snappy_truncated|snappy_decode|ssz_decode). Operator-visible signal that zeam has stopped accepting gossip BEFORE lean_head_slot drifts off wall-clock. See issue #942." }, .{}),
         .lean_attestations_production_time_seconds = Metrics.AttestationProductionTimeHistogram.init("lean_attestations_production_time_seconds", .{ .help = "Time taken to produce attestation" }, .{}),
         // compactAttestations metrics
         .zeam_compact_attestations_time_seconds = Metrics.CompactAttestationsTimeHistogram.init("zeam_compact_attestations_time_seconds", .{ .help = "Time taken by compactAttestations to merge payloads sharing the same AttestationData" }, .{}),
@@ -1334,6 +1346,23 @@ pub fn observeXmssRecAggregatePhase(phase: []const u8, elapsed_ns: u64) void {
     metrics.zeam_xmss_rec_aggregate_phase_seconds.observe(
         .{ .phase = phase },
         elapsed_s,
+    ) catch {};
+}
+
+/// Issue #942: record one gossip-ingress decode rejection. `topic_kind` must
+/// be one of "block" | "attestation" | "aggregation"; `reason` is one of
+/// "snappy_empty" | "snappy_varint" | "snappy_oversized" | "snappy_truncated"
+/// | "snappy_decode" | "ssz_decode" — see the metric help text on
+/// `zeam_gossip_decode_failures_total` for the full enumeration.
+///
+/// Safe to call from FFI / network callback contexts: no allocation, label
+/// keys are interned by the registry. Silently no-ops before
+/// `metrics.init()` so test runs that haven't started the registry don't
+/// crash. Cardinality bound: 3 topic_kinds × 6 reasons = 18 series.
+pub fn incrGossipDecodeFailure(topic_kind: []const u8, reason: []const u8) void {
+    if (!g_initialized or isZKVM()) return;
+    metrics.zeam_gossip_decode_failures_total.incr(
+        .{ .topic_kind = topic_kind, .reason = reason },
     ) catch {};
 }
 

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -45,6 +45,47 @@ const MAX_RPC_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 const MAX_GOSSIP_BLOCK_SIZE: usize = 50 * 1024 * 1024;
 const MAX_VARINT_BYTES: usize = uvarint.bufferSize(usize);
 
+/// Maximum number of leading bytes inlined into gossip-decode-failure log
+/// lines for the #942 diagnostic preview. 32 bytes is enough to cover any
+/// reasonable framing-magic prefix (snappy-frames magic is 10 bytes; common
+/// snappy-block varint headers are 1–3 bytes plus body tags) while keeping
+/// the log line readable and bounded.
+const GOSSIP_PREVIEW_MAX_BYTES: usize = 32;
+
+/// Fixed-capacity hex preview buffer returned by `byteHexPreview`.
+/// `2 × GOSSIP_PREVIEW_MAX_BYTES` for the hex pair + (N − 1) single-space
+/// separators between pairs. Lives on the caller's stack; `.slice()`
+/// returns the populated prefix.
+const BytePreview = struct {
+    buf: [GOSSIP_PREVIEW_MAX_BYTES * 3]u8 = undefined,
+    len: usize = 0,
+    fn slice(self: *const BytePreview) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+/// Build a `"aa bb cc ..."` hex preview of the first `max_bytes` of `data`
+/// for #942 gossip-decode-failure logs. Returns an empty slice when `data`
+/// is empty. Pure / stack-only; safe to call from FFI gossip ingress
+/// without heap allocation.
+fn byteHexPreview(data: []const u8, max_bytes: usize) BytePreview {
+    var out = BytePreview{};
+    const n = @min(@min(data.len, max_bytes), GOSSIP_PREVIEW_MAX_BYTES);
+    const hex_digits = "0123456789abcdef";
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        if (i != 0) {
+            out.buf[out.len] = ' ';
+            out.len += 1;
+        }
+        const b = data[i];
+        out.buf[out.len] = hex_digits[(b >> 4) & 0x0f];
+        out.buf[out.len + 1] = hex_digits[b & 0x0f];
+        out.len += 2;
+    }
+    return out;
+}
+
 const FrameDecodeError = error{
     EmptyFrame,
     MalformedVarint,
@@ -463,6 +504,7 @@ fn deserializeGossipMessage(
 fn rejectMalformedGossip(
     zigHandler: *EthLibp2p,
     err: SnappyHeaderValidationError,
+    topic_kind: []const u8,
     topic_slice: []const u8,
     sender_peer_id_slice: []const u8,
     message_bytes: []const u8,
@@ -480,10 +522,17 @@ fn rejectMalformedGossip(
         error.HeaderWithoutBody => "snappy_truncated",
     };
     const node_name = zigHandler.node_registry.getNodeNameFromPeerId(sender_peer_id_slice);
+    // #942: include the first 32 bytes hex inline so operators can diagnose
+    // framing-format mismatches (e.g. snappy-frames magic `ff 06 00 00 73 4e
+    // 61 50 70 59`) from logs without needing the sample-rate-gated dump file.
+    const preview = byteHexPreview(message_bytes, 32);
     zigHandler.logger.err(
-        "Rejecting gossip message: {s} (topic={s}, len={d}, peer={s}{f})",
-        .{ reason, topic_slice, message_bytes.len, sender_peer_id_slice, node_name },
+        "Rejecting gossip message: {s} (topic={s}, len={d}, peer={s}{f}, first32={s})",
+        .{ reason, topic_slice, message_bytes.len, sender_peer_id_slice, node_name, preview.slice() },
     );
+    // #942: dashboard-visible counter so a stuck zeam fleet shows up via
+    // metrics before head_slot drifts off wall-clock.
+    zeam_metrics.incrGossipDecodeFailure(topic_kind, dump_label);
     if (shouldPersistMalformedDump()) {
         if (!writeFailedBytes(message_bytes, dump_label, zigHandler.allocator, null, zigHandler.logger)) {
             zigHandler.logger.err("Failed to persist malformed gossip dump ({s})", .{dump_label});
@@ -526,8 +575,14 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
     // size-limit comparison (strict `>`, see `SnappyHeaderValidationError`).
     // If the upstream contract ever changes (e.g. to `>=`), the boundary tests
     // pinned in the test block below will go red.
+    const topic_kind_label: []const u8 = switch (topic.gossip_topic.kind) {
+        .block => "block",
+        .attestation => "attestation",
+        .aggregation => "aggregation",
+    };
+
     _ = validateGossipSnappyHeader(message_bytes, decode_limit) catch |e| {
-        rejectMalformedGossip(zigHandler, e, topic_slice, sender_peer_id_slice, message_bytes);
+        rejectMalformedGossip(zigHandler, e, topic_kind_label, topic_slice, sender_peer_id_slice, message_bytes);
         // TODO(#855 review #4): apply a libp2p gossipsub score penalty here
         // so a peer spamming malformed gossip is ejected by the protocol
         // instead of getting unlimited free retries. Out of scope for the
@@ -536,10 +591,16 @@ export fn handleMsgFromRustBridge(zigHandler: *EthLibp2p, topic_str: [*:0]const 
     };
 
     const uncompressed_message = snappyz.decodeWithMax(zigHandler.allocator, message_bytes, decode_limit) catch |e| {
+        // #942: inline first-bytes preview + per-failure counter so a stalled
+        // zeam fleet shows up on dashboards (`zeam_gossip_decode_failures_total`)
+        // and the framing format on the wire is diagnosable from logs alone.
+        const preview = byteHexPreview(message_bytes, GOSSIP_PREVIEW_MAX_BYTES);
+        const preview_bytes = @min(message_bytes.len, GOSSIP_PREVIEW_MAX_BYTES);
         zigHandler.logger.err(
-            "Error in snappyz decoding the message for topic={s} from peer={s}: {any}",
-            .{ topic_slice, sender_peer_id_slice, e },
+            "Error in snappyz decoding the message for topic={s} (len={d}) from peer={s}: {any}; first{d}={s}",
+            .{ topic_slice, message_bytes.len, sender_peer_id_slice, e, preview_bytes, preview.slice() },
         );
+        zeam_metrics.incrGossipDecodeFailure(topic_kind_label, "snappy_decode");
         if (shouldPersistMalformedDump()) {
             if (!writeFailedBytes(message_bytes, "snappyz_decode", zigHandler.allocator, null, zigHandler.logger)) {
                 zigHandler.logger.err("Snappyz decode failed - could not create debug file", .{});
@@ -2028,4 +2089,130 @@ test "snappyz.decodeWithMax regression canary: 1024 bytes of 0xef must not panic
     const garbage = [_]u8{0xef} ** 1024;
     const result = snappyz.decodeWithMax(std.testing.allocator, &garbage, MAX_GOSSIP_BLOCK_SIZE);
     try std.testing.expectError(error.Corrupt, result);
+}
+
+test "byteHexPreview: formats bytes with single-space separator" {
+    // #942 diagnostic: gossip-decode failure logs include the leading bytes
+    // hex so operators can spot framing-format mismatches (snappy-frames
+    // magic `ff 06 00 00 73 4e 61 50 70 59` vs snappy-block leading varint)
+    // directly from the log line, without needing the sample-rate-gated
+    // dump file. Pinning the format here so a future refactor that switches
+    // separators or capitalisation goes through a deliberate test update.
+    const data = [_]u8{ 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50 };
+    const p = byteHexPreview(&data, 8);
+    try std.testing.expectEqualSlices(u8, "ff 06 00 00 73 4e 61 50", p.slice());
+}
+
+test "byteHexPreview: truncates to max_bytes" {
+    const data = [_]u8{ 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+    const p = byteHexPreview(&data, 3);
+    try std.testing.expectEqualSlices(u8, "aa bb cc", p.slice());
+}
+
+test "byteHexPreview: empty input returns empty slice" {
+    const empty: []const u8 = &.{};
+    const p = byteHexPreview(empty, 32);
+    try std.testing.expectEqual(@as(usize, 0), p.slice().len);
+}
+
+test "byteHexPreview: hard cap at GOSSIP_PREVIEW_MAX_BYTES even if caller asks more" {
+    // The buffer is sized for 32 bytes; if a caller passes max_bytes > 32
+    // (a future code-path bug), we must silently cap to keep stack usage
+    // bounded and not overrun the buffer.
+    const data = [_]u8{0xab} ** 64;
+    const p = byteHexPreview(&data, 100);
+    try std.testing.expectEqual(GOSSIP_PREVIEW_MAX_BYTES, p.slice().len / 3 + 1);
+}
+
+test "snappyz roundtrip: high-entropy 280KB payload (#942 reproduction)" {
+    // Reproduce the #942 gossip-decode-failure pattern in a unit test.
+    //
+    // Observation from the live devnet under PR #945 instrumentation:
+    // - Both Zig `snappyz.decodeWithMax` AND Rust `snap::raw::Decoder` reject
+    //   the same gossip payloads with `error.Corrupt` / `Offset { offset:
+    //   62376420, dst_pos: 65866 }`.
+    // - The byte-preview at the FFI boundary matches Rust ↔ Zig (no FFI bug).
+    // - Failures cluster around block / aggregation payloads of ~200-300 KB
+    //   with `dst_pos` errors near 64 KB / 128 KB / power-of-two boundaries.
+    // - The only client family that publishes via `snappyz.encode` is zeam;
+    //   every other client uses Rust `snap::raw::Encoder` which round-trips
+    //   the same payload classes fine. Working hypothesis: `snappyz.encode`
+    //   produces non-standard snappy output for inputs that combine
+    //   high-entropy content with the chunking boundary at
+    //   `maxBlockSize = 65536` (snappy.zig:17).
+    //
+    // The existing snappyz "encode larger than maxBlockSize" test uses a
+    // sequential `b.* = i & 0xff` pattern which is highly compressible and
+    // unlikely to expose the bug. This test uses a fixed-seed PRNG so the
+    // input has STARK-proof-like entropy (≈1.0 byte/byte) at sizes that
+    // straddle the 64 KB chunk boundary multiple times.
+    //
+    // If this test FAILS, we have local reproduction of #942 and can debug
+    // `encodeBlock` (snappy.zig:400) without devnet round-trips. If it
+    // PASSES, the wire-side corruption originates elsewhere (peer encoder
+    // outside zeam, or a gossipsub-layer mutation) and we need to capture
+    // a real payload from the wire to drill further.
+    const allocator = std.testing.allocator;
+
+    // 280 KB: crosses the 65536-byte maxBlockSize boundary 4 times, in the
+    // size range of the failing devnet payloads (`data_len=287149` was a
+    // recurring victim in PR #945's live capture).
+    const input_size: usize = 280 * 1024;
+    const input = try allocator.alloc(u8, input_size);
+    defer allocator.free(input);
+
+    // Fixed seed so the failure (if any) is reproducible across runs and CI.
+    var prng = std.Random.DefaultPrng.init(0x0942_5141_5252_4754);
+    prng.random().bytes(input);
+
+    const encoded = try snappyz.encode(allocator, input);
+    defer allocator.free(encoded);
+
+    const decoded = snappyz.decodeWithMax(allocator, encoded, MAX_GOSSIP_BLOCK_SIZE) catch |err| {
+        std.debug.print(
+            "\nsnappyz roundtrip FAILED on {d}KB high-entropy input: {any}\n" ++
+                "  encoded size: {d} bytes\n" ++
+                "  first 16 encoded bytes: {x}\n",
+            .{ input_size / 1024, err, encoded.len, encoded[0..@min(16, encoded.len)] },
+        );
+        return err;
+    };
+    defer allocator.free(decoded);
+
+    try std.testing.expectEqualSlices(u8, input, decoded);
+}
+
+test "snappyz roundtrip: high-entropy 64KB-boundary spans (#942)" {
+    // Targeted variant of the test above: try several input sizes just below,
+    // exactly at, and just above `maxBlockSize = 65536` (and 2× / 3× that)
+    // so a failure modes that's specific to a single boundary crossing
+    // shows up as one of the sub-cases.
+    const allocator = std.testing.allocator;
+    const sizes_to_try = [_]usize{
+        65535, // last byte that fits in one chunk
+        65536, // exactly maxBlockSize
+        65537, // first byte spilling into a second chunk
+        131071,
+        131072, // 2 × maxBlockSize
+        131073,
+        196608, // 3 × maxBlockSize
+        196609,
+    };
+    for (sizes_to_try) |sz| {
+        const input = try allocator.alloc(u8, sz);
+        defer allocator.free(input);
+        var prng = std.Random.DefaultPrng.init(0xDEADBEEF_CAFEBABE);
+        prng.random().bytes(input);
+
+        const encoded = try snappyz.encode(allocator, input);
+        defer allocator.free(encoded);
+
+        const decoded = snappyz.decodeWithMax(allocator, encoded, MAX_GOSSIP_BLOCK_SIZE) catch |err| {
+            std.debug.print("\nFAILED at size={d}: {any}\n", .{ sz, err });
+            return err;
+        };
+        defer allocator.free(decoded);
+
+        try std.testing.expectEqualSlices(u8, input, decoded);
+    }
 }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2800,9 +2800,139 @@ pub const BeamChain = struct {
         sender_peer_id: []const u8,
         precomputed_block_root: ?types.Root,
     ) !GossipProcessingResult {
+        // Issue #942: record total time chain.onGossip spends on the libxev thread
+        // per gossip type. Compare against zeam_xev_clock_until_done_drain_seconds
+        // and `zeam_libxev_callback_duration_seconds{site=onGossip.block.dispatch}`
+        // to attribute slow drains to attestation/aggregation dispatch vs. block work.
+        const gossip_dispatch_start_ns = zeam_utils.monotonicTimestampNs();
+        const gossip_site: []const u8 = switch (data.*) {
+            .block => "onGossip.block",
+            .attestation => "onGossip.attestation",
+            .aggregation => "onGossip.aggregation",
+        };
+        defer {
+            const elapsed_s = @as(f32, @floatFromInt(zeam_utils.monotonicTimestampNs() - gossip_dispatch_start_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+            zeam_metrics.observeLibxevCallback(gossip_site, elapsed_s);
+        }
         switch (data.*) {
             .block => |signed_block| {
                 const block = signed_block.block;
+
+                // Issue #942: when the chain-worker is enabled and the caller
+                // did not precompute the block root (common gossip path with parent
+                // already in fork-choice), skip both the libxev-side hashTreeRoot
+                // AND the hasBlock dedup here. The chain-worker thunk runs the
+                // dedup via protoArray.onBlock (early-out at forkchoice.zig:97-101)
+                // after computing the root off-thread, avoiding the heavy SSZ hash
+                // on the libxev event-loop thread.
+                //
+                // Rare paths that need block_root on libxev (future-slot enqueue,
+                // worker-disabled inline processing) compute it lazily below.
+                //
+                // Trade-offs vs. the old eager-hash approach:
+                //   * A re-arriving gossip block whose root is already in protoArray
+                //     will run STF on the worker before protoArray deduplicates it
+                //     (wasted CPU on worker, but libxev unblocked). Rare in healthy
+                //     gossipsub mesh (message_id dedup at the Rust layer fires first).
+                //   * The `processed_block_root` returned to BeamNode for
+                //     `processCachedDescendants` is null on the worker-dispatch fast
+                //     path; the imported-block backchannel (handleChainImportedBlock)
+                //     already fires processCachedDescendants with the resolved root.
+                if (self.chain_worker != null and precomputed_block_root == null) {
+                    // Fast-dispatch path: no libxev-side hash or dedup.
+                    // Validate only the parts that don't require block_root.
+                    // FutureSlot hard-drop can be checked via validateBlock; we
+                    // compute block_root lazily only on the FutureSlotQueueable path.
+                    const dispatch_start_ns = zeam_utils.monotonicTimestampNs();
+                    self.validateBlock(block, true) catch |err| switch (err) {
+                        error.FutureSlotQueueable => {
+                            // Need block_root for the pending queue key — compute lazily.
+                            var lazy_root: types.Root = undefined;
+                            try zeam_utils.hashTreeRoot(types.BeamBlock, block, &lazy_root, self.allocator);
+                            var cloned: types.SignedBlock = undefined;
+                            try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
+                            const queued = self.enqueuePendingBlock(cloned, lazy_root);
+                            if (queued) {
+                                self.logger.info(
+                                    "queued future-slot gossip block slot={d} blockroot=0x{x}: current_slot={d}",
+                                    .{
+                                        block.slot,
+                                        &lazy_root,
+                                        self.forkChoice.fcStore.slot_clock.timeSlots.load(.monotonic),
+                                    },
+                                );
+                            }
+                            return .{};
+                        },
+                        error.FutureSlot => {
+                            zeam_metrics.metrics.lean_blocks_future_slot_dropped_total.incr();
+                            return err;
+                        },
+                        else => return err,
+                    };
+
+                    // Slot-clock future check — needs block_root for the pending queue.
+                    if (block.slot * constants.INTERVALS_PER_SLOT > self.forkChoice.fcStore.slot_clock.time.load(.monotonic)) {
+                        var lazy_root: types.Root = undefined;
+                        try zeam_utils.hashTreeRoot(types.BeamBlock, block, &lazy_root, self.allocator);
+                        self.logger.debug(
+                            "queuing gossip block slot={d} blockroot=0x{x}: forkchoice time={d} < slot_start={d}",
+                            .{ block.slot, &lazy_root, self.forkChoice.fcStore.slot_clock.time.load(.monotonic), block.slot * constants.INTERVALS_PER_SLOT },
+                        );
+                        var cloned: types.SignedBlock = undefined;
+                        try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
+                        if (block.slot * constants.INTERVALS_PER_SLOT > self.forkChoice.fcStore.slot_clock.time.load(.monotonic)) {
+                            const queued = self.enqueuePendingBlock(cloned, lazy_root);
+                            if (queued) {
+                                self.logger.info(
+                                    "queued gossip block slot={d} blockroot=0x{x}: forkchoice time={d} < slot_start={d}",
+                                    .{ block.slot, &lazy_root, self.forkChoice.fcStore.slot_clock.time.load(.monotonic), block.slot * constants.INTERVALS_PER_SLOT },
+                                );
+                            }
+                            return .{};
+                        } else {
+                            self.logger.debug(
+                                "chain already ticked while cloning block for queuing, skipping queuing and directly processing slot={d} blockroot=0x{x}: forkchoice time={d} < slot_start={d}",
+                                .{ block.slot, &lazy_root, self.forkChoice.fcStore.slot_clock.time.load(.monotonic), block.slot * constants.INTERVALS_PER_SLOT },
+                            );
+                            cloned.deinit();
+                        }
+                    }
+
+                    // Worker dispatch: SSZ clone + queue push on libxev — no hash.
+                    var cloned: types.SignedBlock = undefined;
+                    try types.sszClone(self.allocator, types.SignedBlock, signed_block, &cloned);
+                    var cloned_consumed = false;
+                    defer if (!cloned_consumed) cloned.deinit();
+                    // Pass null block_root: worker thunk computes it off-thread.
+                    self.submitBlock(cloned, true, null) catch |err| switch (err) {
+                        error.QueueFull => {
+                            self.logger.warn(
+                                "chain-worker: block queue full, dropping slot={d}",
+                                .{block.slot},
+                            );
+                            return .{};
+                        },
+                        error.QueueClosed => {
+                            self.logger.warn(
+                                "chain-worker: block queue closed, dropping slot={d}",
+                                .{block.slot},
+                            );
+                            return .{};
+                        },
+                        error.ChainWorkerDisabled => unreachable,
+                    };
+                    cloned_consumed = true;
+                    // Record dispatch time. `processed_block_root` is null here;
+                    // handleChainImportedBlock fires processCachedDescendants.
+                    const dispatch_elapsed_s = @as(f32, @floatFromInt(zeam_utils.monotonicTimestampNs() - dispatch_start_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+                    zeam_metrics.observeLibxevCallback("onGossip.block.dispatch", dispatch_elapsed_s);
+                    return .{};
+                }
+
+                // Slow path: either chain_worker is null (worker-disabled, tests /
+                // single-threaded mode) OR the caller already precomputed the root
+                // (orphan-cache path passed a real root from node.onGossip).
                 const block_root: [32]u8 = if (precomputed_block_root) |r| r else r: {
                     var cblock_root: [32]u8 = undefined;
                     try zeam_utils.hashTreeRoot(types.BeamBlock, block, &cblock_root, self.allocator);

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2276,6 +2276,33 @@ pub const ForkChoice = struct {
         zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_total.incr();
         zeam_metrics.metrics.lean_pq_sig_attestations_in_aggregated_signatures_total.incrBy(participant_count);
 
+        // #942 observability: emit a one-line summary per committed aggregate
+        // so operators can see *what* the aggregator just published from
+        // structured logs alone (counterpart to the gossip-decode-failure
+        // preview added on the ingress side). Fields chosen to be cheap and
+        // diagnostic: validator count in the aggregate (`attestations`),
+        // attestation slot (`slot`), and the first 8 hex chars of the head /
+        // target / source roots so the same aggregate can be cross-referenced
+        // against block-import logs without dumping full 32-byte roots on
+        // every line. Logged at info — one line per committed aggregate
+        // matches the existing `agg start slot=...` line above and stays
+        // well under typical log-volume budgets at devnet committee sizes.
+        const head_short = att_data.head.root[0..4];
+        const target_short = att_data.target.root[0..4];
+        const source_short = att_data.source.root[0..4];
+        self.logger.info(
+            "aggregated {d} attestations slot={d} head=0x{x}.. target_slot={d} target=0x{x}.. source_slot={d} source=0x{x}..",
+            .{
+                participant_count,
+                att_data.slot,
+                head_short,
+                att_data.target.slot,
+                target_short,
+                att_data.source.slot,
+                source_short,
+            },
+        );
+
         var publish_proof: types.AggregatedSignatureProof = undefined;
         try ssz.deserialize(types.AggregatedSignatureProof, proof_bytes, &publish_proof, self.allocator);
         return .{ .data = att_data, .proof = publish_proof };

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -125,6 +125,17 @@ pub const BeamNode = struct {
     /// Monotonic millis of the last inbound gossip delivery (#926).
     last_gossip_rx_ms: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
 
+    /// Monotonic millis of the last inbound gossip BLOCK delivery (#942).
+    /// Distinct from `last_gossip_rx_ms` because attestations on the
+    /// `/leanconsensus/.../attestation_*/ssz_snappy` topics arrive at
+    /// ~5/s on a busy mesh and keep `last_gossip_rx_ms` fresh even when
+    /// every block is being dropped by `snappy.error.Corrupt`.
+    /// `maybeInitiateProactiveCatchUp` was gating on the union-of-all-
+    /// topics counter, so attestations were silently masking a total
+    /// block-ingress stall and the catch-up RPC never fired. Tracked
+    /// separately so the block-silence signal can drive its own decision.
+    last_gossip_block_rx_ms: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
     const Self = @This();
 
     pub fn init(self: *Self, allocator: Allocator, opts: NodeOpts) !void {
@@ -320,7 +331,21 @@ pub const BeamNode = struct {
 
     pub fn onGossip(ptr: *anyopaque, data: *const networks.GossipMessage, sender_peer_id: []const u8) anyerror!void {
         const self: *Self = @ptrCast(@alignCast(ptr));
-        self.last_gossip_rx_ms.store(@intCast(zeam_utils.unixTimestampMillis()), .monotonic);
+        const now_ms: u64 = @intCast(zeam_utils.unixTimestampMillis());
+        self.last_gossip_rx_ms.store(now_ms, .monotonic);
+        // #942: track block-topic gossip separately. Attestations on the
+        // `/attestation_X/ssz_snappy` topics are small (~2.6 KB), decode
+        // reliably even on a fleet where every large message corrupts
+        // (~5/s arrival), and would otherwise keep `last_gossip_rx_ms`
+        // fresh and suppress `shouldInitiateProactiveCatchUp` indefinitely
+        // even though no block has reached the application layer in many
+        // slots. The block-specific timestamp lets the proactive catch-up
+        // gate detect that condition and trigger `blocks_by_root` /
+        // `blocks_by_range` RPC fallback the same way grandine recovers.
+        switch (data.*) {
+            .block => self.last_gossip_block_rx_ms.store(now_ms, .monotonic),
+            else => {},
+        }
 
         // Lifetime invariant for `data`:
         //   The gossip subsystem (see `pkgs/network/src/ethlibp2p.zig`) owns the
@@ -2759,13 +2784,27 @@ pub const BeamNode = struct {
         return wall_head_lag_slots;
     }
 
-    fn gossipIngressSnapshot(self: *Self) struct { silent_ms: u64, mesh_peers: u64 } {
+    fn gossipIngressSnapshot(self: *Self) struct { silent_ms: u64, block_silent_ms: u64, mesh_peers: u64 } {
         const now_ms: u64 = @intCast(zeam_utils.unixTimestampMillis());
+        const last_block_ms = self.last_gossip_block_rx_ms.load(.monotonic);
+        // #942: "block silent" semantics. Returns `maxInt(u64)` when we
+        // have never delivered a block to the application — that signals
+        // "infinitely silent on the block topic" to the proactive catch-up
+        // gate, which is exactly what we want when block ingress has not
+        // started yet (devnet just past genesis with all blocks failing
+        // snappy decode, etc.). Once any block ever decodes cleanly via
+        // `onGossip`, this collapses to the normal `now_ms - last_block_ms`
+        // measurement.
+        const block_silent_ms: u64 = if (last_block_ms == 0)
+            std.math.maxInt(u64)
+        else
+            now_ms -| last_block_ms;
         return .{
             .silent_ms = blocks_by_range_sync.gossipSilentMs(
                 now_ms,
                 self.last_gossip_rx_ms.load(.monotonic),
             ),
+            .block_silent_ms = block_silent_ms,
             .mesh_peers = self.network.gossipMeshPeerCount(),
         };
     }
@@ -2841,10 +2880,18 @@ pub const BeamNode = struct {
 
     fn maybeInitiateProactiveCatchUp(self: *Self, wall_head_lag_slots: u64) void {
         const ingress = self.gossipIngressSnapshot();
+        // #942: gate on BLOCK-topic silence, not union-of-all-topics
+        // silence. Attestations decode reliably even on a fleet where
+        // every block is being rejected by snappy.error.Corrupt; if we
+        // gated on union-silence the attestation stream would suppress
+        // the catch-up RPC indefinitely while no block ever reaches the
+        // app. With `block_silent_ms` the gate fires the moment we have
+        // a wall-lag and no block has come through gossip for the stall
+        // threshold (8 s on a 4 s slot devnet).
         if (!blocks_by_range_sync.shouldInitiateProactiveCatchUp(
             wall_head_lag_slots,
             constants.SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS,
-            ingress.silent_ms,
+            ingress.block_silent_ms,
             constants.gossipStallThresholdMs(),
         )) return;
 
@@ -2855,8 +2902,9 @@ pub const BeamNode = struct {
         if (!self.shouldCatchUpFromPeerStatus(catch_up_status, our_head_slot, our_finalized_slot)) return;
 
         self.logger.info(
-            "proactive catch-up: gossip silent for {d}ms, wall lag {d} slots, peer {s}{f} head={d}",
+            "proactive catch-up: block-gossip silent for {d}ms (any-gossip silent for {d}ms), wall lag {d} slots, peer {s}{f} head={d}",
             .{
+                ingress.block_silent_ms,
                 ingress.silent_ms,
                 wall_head_lag_slots,
                 catch_up_status.peer_id,

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -326,34 +326,24 @@ pub const BeamNode = struct {
         //   The gossip subsystem (see `pkgs/network/src/ethlibp2p.zig`) owns the
         //   `GossipMessage` for the entire duration of this callback. It is the
         //   standard libp2p callback contract: the buffer is not recycled, freed
-        //   or mutated until `onGossip` returns. We rely on this twice — once
-        //   for the pre-lock `hashTreeRoot` read of `data.block.block` and again
-        //   inside the locked section for the same field. If a future refactor
-        //   ever changes that contract (e.g. arena-pooled message buffers), the
-        //   pre-lock read becomes a use-after-free and this comment must be the
-        //   place to revisit. Do NOT cache or stash `data` past this scope.
+        //   or mutated until `onGossip` returns. Do NOT cache or stash `data`
+        //   past this scope.
         //
-        // Pre-lock work (issue #786): hashTreeRoot over a BeamBlock is pure CPU
-        // work that does not touch any shared state, but it can be expensive on
-        // large blocks (up to MAX_ATTESTATIONS_DATA aggregated XMSS proofs ⇒
-        // hundreds of KB to MBs of tree-hashing). Computing it before locking
-        // shrinks the critical section and lets `onInterval` make progress on
-        // the libxev thread in parallel. The computed root is reused in every
-        // downstream branch (success path + error paths) so we never recompute
-        // under the lock.
+        // `precomputed_block_root` is computed lazily — only when the block's
+        // parent is NOT already in fork-choice (the orphan-cache path, where the
+        // root is needed as a cache key synchronously on the libxev thread).
         //
-        // `precomputed_block_root` stays `undefined` for non-block gossip
-        // messages and is read only inside the `.block` arm of the switch
-        // below (and its error sub-branches). Any future code path that reads
-        // it outside that arm will hit Zig's `undefined` poison in debug
-        // builds — intentional defensive behavior.
-        var precomputed_block_root: types.Root = undefined;
-        if (data.* == .block) {
-            zeam_utils.hashTreeRoot(types.BeamBlock, data.block.block, &precomputed_block_root, self.allocator) catch |err| {
-                self.logger.warn("failed to compute block root for incoming gossip block: {any}", .{err});
-                return;
-            };
-        }
+        // For the common case (parent present, block dispatched to chain-worker),
+        // we skip hashTreeRoot on libxev entirely (#942): the chain-worker thunk
+        // computes the root off-thread inside `onBlock`. The libxev-side hasBlock
+        // dedup is also skipped in this path; `protoArray.onBlock` performs the
+        // same dedup on the worker thread (early-out at line 97-101 of
+        // forkchoice.zig). The trade-off is that re-arriving gossip blocks whose
+        // root is already in protoArray will run STF on the worker before the
+        // protoArray no-op dedup fires; this is rare and accepted (#942 follow-up
+        // data from `zeam_libxev_callback_duration_seconds` will confirm).
+        //
+        // `precomputed_block_root` is null for all non-block gossip types.
 
         // Slice (a-3): the outer BeamNode.mutex is gone. Each chain entry
         // point inside the switch arms takes its own per-resource locks
@@ -361,6 +351,8 @@ pub const BeamNode = struct {
         // root_to_slot_lock, events_lock, forkChoice}); network state
         // mutations go through `Network`'s LockedMap / BlockCache /
         // ConnectedPeers helpers. See docs/threading_refactor_slice_a.md.
+
+        var precomputed_block_root: ?types.Root = null;
 
         switch (data.*) {
             .block => |signed_block| {
@@ -378,12 +370,24 @@ pub const BeamNode = struct {
                     self.node_registry.getNodeNameFromPeerId(sender_peer_id),
                 });
 
-                // Reuse the root we computed before taking the lock.
-                const block_root = precomputed_block_root;
-
-                _ = self.network.removePendingBlockRoot(block_root);
-
                 if (!hasParentBlock) {
+                    // Orphan path: compute block_root on libxev — needed as cache
+                    // key for `cacheBlockAndFetchParent` and `removePendingBlockRoot`.
+                    // This is a rare path (parent not yet imported), so the hash cost
+                    // here is acceptable.
+                    const hash_start_ns = zeam_utils.monotonicTimestampNs();
+                    var orphan_block_root: types.Root = undefined;
+                    zeam_utils.hashTreeRoot(types.BeamBlock, block, &orphan_block_root, self.allocator) catch |err| {
+                        self.logger.warn("failed to compute block root for orphan gossip block slot={d}: {any}", .{ block.slot, err });
+                        return;
+                    };
+                    const hash_elapsed_s = @as(f32, @floatFromInt(zeam_utils.monotonicTimestampNs() - hash_start_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+                    zeam_metrics.observeLibxevCallback("onGossip.block.hash_tree_root", hash_elapsed_s);
+                    precomputed_block_root = orphan_block_root;
+                    const block_root = orphan_block_root;
+
+                    _ = self.network.removePendingBlockRoot(block_root);
+
                     // Cache this block for later processing when parent arrives
                     if (self.cacheBlockAndFetchParent(block_root, signed_block, 0)) |_| {
                         self.logger.debug(
@@ -417,6 +421,8 @@ pub const BeamNode = struct {
                     // Return early - don't pass to chain until parent arrives
                     return;
                 }
+                // hasParentBlock==true: fall through with precomputed_block_root=null.
+                // chain.onGossip and the chain-worker compute the root off libxev.
             },
             .attestation => |signed_attestation| {
                 const slot = signed_attestation.message.message.slot;
@@ -442,25 +448,36 @@ pub const BeamNode = struct {
             },
         }
 
-        // Slice (e) of #803: thread `precomputed_block_root` through
-        // chain.onGossip so the chain layer doesn't recompute the
-        // hash-tree root we already have. For non-block gossip
-        // (attestation/aggregation) we pass `null`; the chain layer
-        // ignores it on those branches.
-        const root_for_chain: ?types.Root = if (data.* == .block) precomputed_block_root else null;
+        // Issue #942: for the common gossip-block path (parent present),
+        // `precomputed_block_root` is null — chain.onGossip defers the hash to
+        // the chain-worker. For the orphan path and non-block gossip it is either
+        // the root computed above or null respectively; chain.onGossip ignores it
+        // on attestation/aggregation branches.
+        const root_for_chain: ?types.Root = precomputed_block_root;
         const result = self.chain.onGossip(data, sender_peer_id, root_for_chain) catch |err| {
             switch (err) {
                 // Block rejected because it's before finalized - drop it and prune any cached
                 // descendants we might still be holding onto.
                 error.PreFinalizedSlot => {
                     if (data.* == .block) {
-                        // Reuse the root we computed before taking the lock (issue #786).
-                        const block_root = precomputed_block_root;
-                        self.logger.info(
-                            "gossip block 0x{x} rejected as pre-finalized; pruning cached descendants",
-                            .{&block_root},
-                        );
-                        _ = self.network.pruneCachedBlocks(block_root, null);
+                        // For the orphan path precomputed_block_root is non-null; for
+                        // the common (parent-present) path it is null — chain.onGossip
+                        // computed the root on libxev via its own lazy path. Skip
+                        // pruneCachedBlocks in the null case; any cached descendants
+                        // will age out naturally (block was pre-finalized so they are
+                        // all stale anyway — no liveness impact).
+                        if (precomputed_block_root) |block_root| {
+                            self.logger.info(
+                                "gossip block 0x{x} rejected as pre-finalized; pruning cached descendants",
+                                .{&block_root},
+                            );
+                            _ = self.network.pruneCachedBlocks(block_root, null);
+                        } else {
+                            self.logger.info(
+                                "gossip block slot={d} rejected as pre-finalized (root not computed on libxev)",
+                                .{data.block.block.slot},
+                            );
+                        }
                     }
                     return;
                 },
@@ -2588,6 +2605,12 @@ pub const BeamNode = struct {
 
         var current_interval: isize = start_interval;
         while (current_interval <= itime_intervals) : (current_interval += 1) {
+            // Issue #942: measure how long each interval tick keeps the libxev thread busy.
+            const interval_tick_start_ns = zeam_utils.monotonicTimestampNs();
+            defer {
+                const elapsed_s = @as(f32, @floatFromInt(zeam_utils.monotonicTimestampNs() - interval_tick_start_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+                zeam_metrics.observeLibxevCallback("onInterval.tick", elapsed_s);
+            }
             const interval: usize = @intCast(current_interval);
             const slot: types.Slot = @intCast(@divFloor(interval, constants.INTERVALS_PER_SLOT));
 

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -368,21 +368,67 @@ pub fn apply_transition(allocator: Allocator, state: *types.BeamState, block: ty
                 "InvalidPostState slot={d} computed={x} expected={x}",
                 .{ block.slot, &state_root, &block.state_root },
             );
-            logBeamStatePerFieldRoots(allocator, state, block.slot, opts.logger);
+            logBeamStatePerFieldRoots(allocator, state, block.slot, opts.logger, "InvalidPostState", .err_level);
             return StateTransitionError.InvalidPostState;
+        }
+        // #942 follow-up: matching baseline for the InvalidPostState
+        // forensics. On the 2026-05-29 devnet every zeam node hit
+        // `InvalidPostState` on slots 44, 49, 52, 57 (all ethlambda-
+        // proposed blocks). The failure-side per-field log tells us what
+        // each field hashes to AT THE POINT OF FAILURE, but without an
+        // adjacent "what does it look like when things were still working"
+        // baseline we can't see WHERE the trajectory first diverges from
+        // canonical. Logging per-field on SUCCESS for the same low-slot
+        // window gives us the per-slot ground truth from a peer that
+        // hadn't failed yet (or, post-fix, lets us confirm zeam tracks
+        // the canonical trajectory). Gated to `POSTSTATE_DIAG_SLOT_MAX`
+        // (= 80 slots = first ~5 min on a 4 s slot clock) so the diagnostic
+        // doesn't run for the lifetime of every long-lived node — the
+        // useful comparison window is the early-chain bootstrap where
+        // divergence either does or doesn't happen.
+        if (block.slot <= POSTSTATE_DIAG_SLOT_MAX) {
+            opts.logger.info(
+                "PostStateMatch slot={d} state_root={x}",
+                .{ block.slot, &state_root },
+            );
+            logBeamStatePerFieldRoots(allocator, state, block.slot, opts.logger, "PostStateMatch", .info_level);
         }
     }
 }
 
-/// #942 follow-up: emit per-field hashTreeRoots of a post-state so
-/// `InvalidPostState` failures can be triangulated to a single divergent
-/// field. Errors are logged-and-swallowed — the caller still reports the
-/// underlying state-root mismatch as before.
+/// #942 follow-up: window inside which per-field state-root diagnostics
+/// are emitted on every successful state transition (in addition to the
+/// always-on failure-side log). 80 slots covers the cluster of
+/// `InvalidPostState`-prone slots observed on the 2026-05-29 devnet
+/// (44, 49, 52, 57 — all ethlambda-proposed) with margin, and is bounded
+/// enough that the extra log volume on a healthy node is ~80 lines per
+/// process lifetime, not per slot.
+const POSTSTATE_DIAG_SLOT_MAX: u64 = 80;
+
+/// #942 follow-up: log level selector for `logBeamStatePerFieldRoots`.
+/// Failure-side calls log at `err` to surface alongside the underlying
+/// state-root mismatch; success-side calls log at `info` so they don't
+/// drown out real errors but stay visible in operator logs.
+const PerFieldLogLevel = enum { err_level, info_level };
+
+/// #942 follow-up: emit per-field hashTreeRoots of a post-state. Called
+/// from two sites in `apply_transition`:
+///   * Failure side — when the computed post-state root doesn't match
+///     the proposer's claim. `tag = "InvalidPostState"`, `level = .err_level`.
+///   * Success side — for `block.slot <= POSTSTATE_DIAG_SLOT_MAX`, as a
+///     ground-truth baseline so the failure case can be compared per-field
+///     against the last known good post-state. `tag = "PostStateMatch"`,
+///     `level = .info_level`.
+/// Errors during per-field hashing are logged-and-swallowed at err level
+/// regardless of the caller's chosen level — they indicate a genuine
+/// runtime fault and must not be masked by an info-tagged invocation.
 fn logBeamStatePerFieldRoots(
     allocator: Allocator,
     state: *const types.BeamState,
     block_slot: u64,
     logger: zeam_utils.ModuleLogger,
+    tag: []const u8,
+    level: PerFieldLogLevel,
 ) void {
     var slot_root: [32]u8 = undefined;
     var lbh_root: [32]u8 = undefined;
@@ -395,59 +441,62 @@ fn logBeamStatePerFieldRoots(
     var jv_root: [32]u8 = undefined;
 
     zeam_utils.hashTreeRoot(u64, state.slot, &slot_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: slot hash failed: {any}", .{e});
+        logger.err("{s} per-field: slot hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.BeamBlockHeader, state.latest_block_header, &lbh_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: latest_block_header hash failed: {any}", .{e});
+        logger.err("{s} per-field: latest_block_header hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.Checkpoint, state.latest_justified, &lj_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: latest_justified hash failed: {any}", .{e});
+        logger.err("{s} per-field: latest_justified hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.Checkpoint, state.latest_finalized, &lf_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: latest_finalized hash failed: {any}", .{e});
+        logger.err("{s} per-field: latest_finalized hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.HistoricalBlockHashes, state.historical_block_hashes, &hbh_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: historical_block_hashes hash failed: {any}", .{e});
+        logger.err("{s} per-field: historical_block_hashes hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.JustifiedSlots, state.justified_slots, &js_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: justified_slots hash failed: {any}", .{e});
+        logger.err("{s} per-field: justified_slots hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.Validators, state.validators, &v_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: validators hash failed: {any}", .{e});
+        logger.err("{s} per-field: validators hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.JustificationRoots, state.justifications_roots, &jr_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: justifications_roots hash failed: {any}", .{e});
+        logger.err("{s} per-field: justifications_roots hash failed: {any}", .{ tag, e });
         return;
     };
     zeam_utils.hashTreeRoot(types.JustificationValidators, state.justifications_validators, &jv_root, allocator) catch |e| {
-        logger.err("InvalidPostState per-field: justifications_validators hash failed: {any}", .{e});
+        logger.err("{s} per-field: justifications_validators hash failed: {any}", .{ tag, e });
         return;
     };
 
-    logger.err(
-        "InvalidPostState per-field block_slot={d} state_slot={d} hbh_len={d} js_len={d} jr_len={d} | slot={x} lbh={x} lj={x} lf={x} hbh={x} js={x} v={x} jr={x} jv={x}",
-        .{
-            block_slot,
-            state.slot,
-            state.historical_block_hashes.len(),
-            state.justified_slots.len(),
-            state.justifications_roots.len(),
-            &slot_root,
-            &lbh_root,
-            &lj_root,
-            &lf_root,
-            &hbh_root,
-            &js_root,
-            &v_root,
-            &jr_root,
-            &jv_root,
-        },
-    );
+    const args = .{
+        tag,
+        block_slot,
+        state.slot,
+        state.historical_block_hashes.len(),
+        state.justified_slots.len(),
+        state.justifications_roots.len(),
+        &slot_root,
+        &lbh_root,
+        &lj_root,
+        &lf_root,
+        &hbh_root,
+        &js_root,
+        &v_root,
+        &jr_root,
+        &jv_root,
+    };
+    const fmt = "{s} per-field block_slot={d} state_slot={d} hbh_len={d} js_len={d} jr_len={d} | slot={x} lbh={x} lj={x} lf={x} hbh={x} js={x} v={x} jr={x} jv={x}";
+    switch (level) {
+        .err_level => logger.err(fmt, args),
+        .info_level => logger.info(fmt, args),
+    }
 }

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -354,8 +354,100 @@ pub fn apply_transition(allocator: Allocator, state: *types.BeamState, block: ty
         var state_root: [32]u8 = undefined;
         try zeam_utils.hashTreeRoot(*types.BeamState, state, &state_root, allocator);
         if (!std.mem.eql(u8, &state_root, &block.state_root)) {
-            opts.logger.debug("state root={x} block root={x}\n", .{ &state_root, &block.state_root });
+            // #942 follow-up: when the post-state root doesn't match the
+            // proposer's claim, log per-field hashTreeRoots of OUR computed
+            // post-state. Comparing these across nodes (or against a known
+            // healthy node's post-state at the same slot) pins down exactly
+            // which `BeamState` field is the divergent one. Without this,
+            // operators can only see "state_root mismatch" — they can't tell
+            // whether it's `historical_block_hashes`, `latest_justified`,
+            // `justifications_*`, etc. that drifted, so root-cause analysis
+            // stalls. Fail-soft on per-field hash failures — still return the
+            // primary error so the chain-worker handler logic is unchanged.
+            opts.logger.err(
+                "InvalidPostState slot={d} computed={x} expected={x}",
+                .{ block.slot, &state_root, &block.state_root },
+            );
+            logBeamStatePerFieldRoots(allocator, state, block.slot, opts.logger);
             return StateTransitionError.InvalidPostState;
         }
     }
+}
+
+/// #942 follow-up: emit per-field hashTreeRoots of a post-state so
+/// `InvalidPostState` failures can be triangulated to a single divergent
+/// field. Errors are logged-and-swallowed — the caller still reports the
+/// underlying state-root mismatch as before.
+fn logBeamStatePerFieldRoots(
+    allocator: Allocator,
+    state: *const types.BeamState,
+    block_slot: u64,
+    logger: zeam_utils.ModuleLogger,
+) void {
+    var slot_root: [32]u8 = undefined;
+    var lbh_root: [32]u8 = undefined;
+    var lj_root: [32]u8 = undefined;
+    var lf_root: [32]u8 = undefined;
+    var hbh_root: [32]u8 = undefined;
+    var js_root: [32]u8 = undefined;
+    var v_root: [32]u8 = undefined;
+    var jr_root: [32]u8 = undefined;
+    var jv_root: [32]u8 = undefined;
+
+    zeam_utils.hashTreeRoot(u64, state.slot, &slot_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: slot hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.BeamBlockHeader, state.latest_block_header, &lbh_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: latest_block_header hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.Checkpoint, state.latest_justified, &lj_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: latest_justified hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.Checkpoint, state.latest_finalized, &lf_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: latest_finalized hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.HistoricalBlockHashes, state.historical_block_hashes, &hbh_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: historical_block_hashes hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.JustifiedSlots, state.justified_slots, &js_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: justified_slots hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.Validators, state.validators, &v_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: validators hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.JustificationRoots, state.justifications_roots, &jr_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: justifications_roots hash failed: {any}", .{e});
+        return;
+    };
+    zeam_utils.hashTreeRoot(types.JustificationValidators, state.justifications_validators, &jv_root, allocator) catch |e| {
+        logger.err("InvalidPostState per-field: justifications_validators hash failed: {any}", .{e});
+        return;
+    };
+
+    logger.err(
+        "InvalidPostState per-field block_slot={d} state_slot={d} hbh_len={d} js_len={d} jr_len={d} | slot={x} lbh={x} lj={x} lf={x} hbh={x} js={x} v={x} jr={x} jv={x}",
+        .{
+            block_slot,
+            state.slot,
+            state.historical_block_hashes.len(),
+            state.justified_slots.len(),
+            state.justifications_roots.len(),
+            &slot_root,
+            &lbh_root,
+            &lj_root,
+            &lf_root,
+            &hbh_root,
+            &js_root,
+            &v_root,
+            &jr_root,
+            &jv_root,
+        },
+    );
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3574,7 +3574,6 @@ dependencies = [
  "hex",
  "lazy_static",
  "libp2p",
- "libp2p-mplex",
  "sha2 0.9.9",
  "snap",
  "thiserror 2.0.18",
@@ -3694,25 +3693,6 @@ dependencies = [
  "pin-project",
  "prometheus-client",
  "web-time",
-]
-
-[[package]]
-name = "libp2p-mplex"
-version = "0.43.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4019ba30c4e42b776113e9778071691fe3f34bf23b6b3bf0dfcf29d801f3d"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "futures",
- "libp2p-core",
- "libp2p-identity",
- "nohash-hasher",
- "parking_lot",
- "rand 0.8.5",
- "smallvec",
- "tracing",
- "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -8423,10 +8403,6 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
-dependencies = [
- "asynchronous-codec",
- "bytes",
-]
 
 [[package]]
 name = "untrusted"

--- a/rust/libp2p-glue/Cargo.toml
+++ b/rust/libp2p-glue/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2021"
 
 [dependencies]
 # serde = { version = "1.0", features = ["derive"] }
-libp2p-mplex = "0.43"
+# libp2p-mplex removed in #942 fix: mplex was corrupting inbound gossip
+# messages > ~100 KB on the 2026-05-28 devnet (snap::raw::Decoder rejected
+# 38/72 inbound blocks while ream/grandine on the same network saw zero
+# decode failures). TCP transport now uses yamux exclusively.
 futures = "0.3.31"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec", "compat"] }

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -2342,21 +2342,23 @@ fn build_transport(
     local_private_key: Keypair,
     quic_support: bool,
 ) -> std::io::Result<BoxedTransport> {
-    // mplex config
-    let mut mplex_config = libp2p_mplex::Config::new();
-    mplex_config.set_max_buffer_size(256);
-    mplex_config.set_max_buffer_behaviour(libp2p_mplex::MaxBufferBehaviour::Block);
-
-    // yamux config
+    // #942: yamux-only on the TCP side. Previously this transport also
+    // negotiated `libp2p-mplex` via `SelectUpgrade::new(yamux, mplex)`, which
+    // caused gossip messages larger than ~100 KB to arrive corrupted at the
+    // gossipsub layer — `snap::raw::Decoder` rejected 38 of 72 incoming
+    // blocks and 28 of 402 incoming aggregations on the 2026-05-28 devnet
+    // while ream / grandine on the same network saw zero gossip decode
+    // failures. mplex is deprecated upstream and is the only differing
+    // transport feature between zeam and the clients that worked. Dropping
+    // it means TCP connections use yamux exclusively, QUIC keeps its native
+    // streams, and the gossipsub ingress path stops fragmenting/reassembling
+    // large messages through the buggy code path.
     let yamux_config = yamux::Config::default();
     // Creates the TCP transport layer
     let tcp = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default().nodelay(true))
         .upgrade(core::upgrade::Version::V1)
         .authenticate(generate_noise_config(&local_private_key))
-        .multiplex(core::upgrade::SelectUpgrade::new(
-            yamux_config,
-            mplex_config,
-        ))
+        .multiplex(yamux_config)
         .timeout(Duration::from_secs(10));
     let transport = if quic_support {
         // Enables Quic

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -1787,12 +1787,12 @@ impl Network {
                                 record_mesh_peers(self.network_id, mesh_count);
                             }
 
-                            if let gossipsub::Event::Message { message, .. } = gossipsub_event {
-                                let topic = message.topic.as_str();
-                                let topic = match CString::new(topic) {
+                            if let gossipsub::Event::Message { propagation_source, message, .. } = gossipsub_event {
+                                let topic_str = message.topic.as_str().to_string();
+                                let topic = match CString::new(topic_str.as_str()) {
                                     Ok(cstr) => cstr,
                                     Err(_) => {
-                                        logger::rustLogger.error(self.network_id, &format!("invalid_topic_string={}", topic));
+                                        logger::rustLogger.error(self.network_id, &format!("invalid_topic_string={}", topic_str));
                                         continue;
                                     }
                                 };
@@ -1812,6 +1812,63 @@ impl Network {
                                         continue;
                                     }
                                 };
+
+                                // #942 diagnostic: log the first 32 bytes of `message.data`
+                                // as gossipsub delivered it, IMMEDIATELY before the FFI handoff
+                                // to `handleMsgFromRustBridge`. The Zig side already logs
+                                // `first32=...` from inside the snappy-decode error path
+                                // (PR #945). If the two previews match exactly, the FFI is
+                                // faithful and any decode failure originates upstream of the
+                                // bridge (peer publish or gossipsub itself). If they differ,
+                                // there is a slice / pointer bug in the bridge handoff.
+                                //
+                                // Also report whether `snap::raw::Decoder` can decode the
+                                // payload at the Rust side (same crate ethlambda uses
+                                // successfully). A mismatch between Rust-side decode result
+                                // and Zig-side `snappyz.decodeWithMax` would indicate the
+                                // two decoders disagree on this byte sequence — strong
+                                // signal that the Zig snappy library has a bug specific to
+                                // this payload shape.
+                                let preview_len = std::cmp::min(message_len, 32);
+                                let preview_hex = {
+                                    use std::fmt::Write as _;
+                                    let mut s = String::with_capacity(preview_len * 3);
+                                    for (i, b) in message.data[..preview_len].iter().enumerate() {
+                                        if i != 0 {
+                                            s.push(' ');
+                                        }
+                                        let _ = write!(&mut s, "{:02x}", b);
+                                    }
+                                    s
+                                };
+                                let rust_decode_status = match Decoder::new().decompress_vec(&message.data) {
+                                    Ok(decoded) => format!("rust_snap=ok decoded_len={}", decoded.len()),
+                                    Err(e) => format!("rust_snap=err({:?})", e),
+                                };
+                                // #942 (follow-up): also log the gossipsub `propagation_source`
+                                // — the *connected* peer that just forwarded this message to
+                                // us. Unlike `message.source` (which is always None under
+                                // `ValidationMode::Anonymous`, line 2216), propagation_source
+                                // is always a real PeerId we can correlate against
+                                // `lean_connected_peers{client=...}` to identify the
+                                // forwarder's client family. With this in place, if every
+                                // failing-decode log has `propagation_source` resolving to a
+                                // zeam_* peer, we can attribute the bad-byte origin to a
+                                // zeam-only code path with high confidence.
+                                let propagation_peer = propagation_source.to_string();
+                                logger::rustLogger.info(
+                                    self.network_id,
+                                    &format!(
+                                        "[gossip ingress] topic={} sender={} propagation_peer={} data_len={} {} first{}={}",
+                                        topic_str,
+                                        sender_peer_id_string,
+                                        propagation_peer,
+                                        message_len,
+                                        rust_decode_status,
+                                        preview_len,
+                                        preview_hex,
+                                    ),
+                                );
 
                                 unsafe {
                                     handleMsgFromRustBridge(self.zig_handler, topic, message_ptr, message_len, sender_peer_id_cstring.as_ptr())
@@ -2182,21 +2239,38 @@ impl From<MessageDomain> for [u8; 4] {
 
 impl Behaviour {
     fn message_id_fn(message: &gossipsub::Message) -> gossipsub::MessageId {
-        // Try to decompress; fallback to raw data
-        let (data_for_hash, domain): (Vec<u8>, [u8; 4]) =
-            match Decoder::new().decompress_vec(&message.data) {
-                Ok(decoded) => (decoded, MessageDomain::ValidSnappy.into()),
-                Err(_) => (message.data.clone(), MessageDomain::InvalidSnappy.into()),
-            };
-
-        // Prepare hashing
+        // #942: hash raw gossip bytes only. The previous implementation ran
+        // `snap::raw::Decoder::decompress_vec(&message.data)` on every inbound
+        // gossip message to content-address by uncompressed bytes (so two
+        // different snappy encodings of the same SSZ block would share a
+        // message-id and dedupe correctly). On the live devnet that
+        // synchronous decompress on 1–3 MB broken-snappy payloads (with the
+        // decoder walking hundreds of KB of valid tags before failing on a
+        // bad copy offset) blocked the gossipsub event loop long enough that
+        // libxev ticks on the Zig side spiked into the 0.5–1 s bucket en
+        // masse (~2700 slow ticks on a 30 min run), libp2p's flow control
+        // observed the slowness and silently demoted zeam's mesh share, and
+        // zeam stopped receiving ANY gossip — including small / well-formed
+        // messages on unrelated topics — for 20+ minutes.
+        //
+        // Raw-bytes hashing fixes the hot path: no decompress on ingress,
+        // no per-message CPU spike, no `Decoder` allocation. Cost: two
+        // peers publishing the same SSZ block with DIFFERENT snappy encoders
+        // get DIFFERENT message-ids and we'd forward both. In practice mesh
+        // forwarding propagates the original publisher's bytes verbatim, so
+        // duplicates almost always hit the existing identical-bytes path
+        // (`duplicate_cache_time` in `ConfigBuilder` catches those).
+        //
+        // The `MessageDomain` enum and the `Decoder` import become dead
+        // code with this change but are intentionally left in place — the
+        // long-term direction is to add a fast pre-check (e.g. only verify
+        // the snappy header varint and topic-specific size bounds) before
+        // delivery, which will re-use this scaffolding. Removing them in
+        // a follow-up.
         let mut hasher = sha2::Sha256::new();
-        hasher.update(domain);
         hasher.update(message.topic.as_str().len().to_le_bytes());
         hasher.update(message.topic.as_str().as_bytes());
-        hasher.update(&data_for_hash);
-
-        // Take first 20 bytes as message-id
+        hasher.update(&message.data);
         let digest = hasher.finalize();
         gossipsub::MessageId::from(&digest[..20])
     }

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -2350,38 +2350,43 @@ impl From<MessageDomain> for [u8; 4] {
 
 impl Behaviour {
     fn message_id_fn(message: &gossipsub::Message) -> gossipsub::MessageId {
-        // #942: hash raw gossip bytes only. The previous implementation ran
-        // `snap::raw::Decoder::decompress_vec(&message.data)` on every inbound
-        // gossip message to content-address by uncompressed bytes (so two
-        // different snappy encodings of the same SSZ block would share a
-        // message-id and dedupe correctly). On the live devnet that
-        // synchronous decompress on 1–3 MB broken-snappy payloads (with the
-        // decoder walking hundreds of KB of valid tags before failing on a
-        // bad copy offset) blocked the gossipsub event loop long enough that
-        // libxev ticks on the Zig side spiked into the 0.5–1 s bucket en
-        // masse (~2700 slow ticks on a 30 min run), libp2p's flow control
-        // observed the slowness and silently demoted zeam's mesh share, and
-        // zeam stopped receiving ANY gossip — including small / well-formed
-        // messages on unrelated topics — for 20+ minutes.
+        // #942 follow-up: restore spec-conformant content-addressed
+        // `message_id` (Ethereum gossipsub convention:
+        //   `SHA256(domain_tag || topic_len || topic || decompressed_bytes)`).
         //
-        // Raw-bytes hashing fixes the hot path: no decompress on ingress,
-        // no per-message CPU spike, no `Decoder` allocation. Cost: two
-        // peers publishing the same SSZ block with DIFFERENT snappy encoders
-        // get DIFFERENT message-ids and we'd forward both. In practice mesh
-        // forwarding propagates the original publisher's bytes verbatim, so
-        // duplicates almost always hit the existing identical-bytes path
-        // (`duplicate_cache_time` in `ConfigBuilder` catches those).
+        // The raw-bytes form that was here previously caused zeam to assign
+        // distinct message-ids to byte-different but content-identical
+        // copies of the same logical message. On the 2026-05-28/29 devnet
+        // we observed 8 distinct corrupted-snappy encodings of the same
+        // slot=1 block (`data_len=285473`, same `sha256_first32` prefix)
+        // arriving at zeam_8 in 70 s, all from forwarder peers' mcaches
+        // (gean_1, zeam_13, _14, _15). Under raw-bytes hashing zeam
+        // computed 8 distinct ids, attempted to decode all 8, failed all 8.
+        // Under content-addressed hashing, the first clean copy wins; all
+        // subsequent copies with the same decompressed content dedupe to
+        // the same id and are dropped by gossipsub before the application
+        // layer ever sees them.
         //
-        // The `MessageDomain` enum and the `Decoder` import become dead
-        // code with this change but are intentionally left in place — the
-        // long-term direction is to add a fast pre-check (e.g. only verify
-        // the snappy header varint and topic-specific size bounds) before
-        // delivery, which will re-use this scaffolding. Removing them in
-        // a follow-up.
+        // Cost: synchronous decompress on the gossipsub event loop. The
+        // earlier abandonment of this scheme was motivated by event-loop
+        // stalls of 0.5–1 s on broken-snappy payloads — the deferred-
+        // hashTreeRoot work that landed earlier on this branch has already
+        // cut `zeam_xev_clock_until_done_slow_ge_500ms_total` from ~7,600
+        // to ~490 in the parallel measurement, so the synchronous decompress
+        // here is no longer the dominant cost on the libxev tick budget.
+        // If that regresses post-deploy, the right next step is to put
+        // a small LRU cache in front of this function keyed on the raw
+        // bytes' SHA256 so identical-bytes re-forwards never re-decompress.
         let mut hasher = sha2::Sha256::new();
+        let (data_for_hash, domain): (Vec<u8>, [u8; 4]) =
+            match Decoder::new().decompress_vec(&message.data) {
+                Ok(decoded) => (decoded, MessageDomain::ValidSnappy.into()),
+                Err(_) => (message.data.clone(), MessageDomain::InvalidSnappy.into()),
+            };
+        hasher.update(domain);
         hasher.update(message.topic.as_str().len().to_le_bytes());
         hasher.update(message.topic.as_str().as_bytes());
-        hasher.update(&message.data);
+        hasher.update(&data_for_hash);
         let digest = hasher.finalize();
         gossipsub::MessageId::from(&digest[..20])
     }

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -339,96 +339,14 @@ fn record_mesh_peers(network_id: u32, count: u64) {
     }
 }
 
-/// #942 diagnostic: hard-capped counter for the per-failure gossip-byte
-/// dumps written by `dump_failed_gossip_payload`. The cap exists so a
-/// runaway corruption event can't fill the operator's disk with a few
-/// megabytes per failed receipt — once the limit is hit, the function
-/// becomes a no-op (the failure is still logged via the existing
-/// `[gossip ingress]` line, just not dumped).
-const MAX_FAILED_GOSSIP_DUMPS: u64 = 50;
-static FAILED_GOSSIP_DUMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// #942 diagnostic: persist the full `message.data` bytes of a gossip
-/// message that `snap::raw::Decoder` rejected. Filename is structured
-/// `failed_gossip_<topic>_<data_len>_<sha256_first32>_<seq>.bin` with
-/// a sibling `.meta.txt` so the operator can group different receipts
-/// of the same logical message (same `data_len` and same prefix hash)
-/// and `cmp -l` them byte-by-byte to locate exactly where the corruption
-/// enters. Without this, we only see varying `dst_pos` values in the log
-/// — we never get the raw bytes that produced each one.
-///
-/// Best-effort: failures to write are silently swallowed because this is
-/// a diagnostic path and must not impact the live gossip pipeline.
-fn dump_failed_gossip_payload(
-    network_id: u32,
-    topic_kind: &str,
-    propagation_peer: &str,
-    data: &[u8],
-) {
-    let seq = FAILED_GOSSIP_DUMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    if seq >= MAX_FAILED_GOSSIP_DUMPS {
-        return;
-    }
-
-    let mut hasher = sha2::Sha256::new();
-    let prefix_len = std::cmp::min(data.len(), 32);
-    hasher.update(&data[..prefix_len]);
-    let prefix_hash_bytes = hasher.finalize();
-    let prefix_hash = hex::encode(&prefix_hash_bytes[..8]); // 16 hex chars
-
-    let dir = std::path::Path::new("/data/deserialization_dumps");
-    if let Err(e) = std::fs::create_dir_all(dir) {
-        logger::rustLogger.warn(
-            network_id,
-            &format!("[#942 dump] could not create dump dir: {}", e),
-        );
-        return;
-    }
-
-    let bin_name = format!(
-        "failed_gossip_{}_{}_{}_seq{:03}.bin",
-        topic_kind,
-        data.len(),
-        prefix_hash,
-        seq,
-    );
-    let meta_name = format!(
-        "failed_gossip_{}_{}_{}_seq{:03}.meta.txt",
-        topic_kind,
-        data.len(),
-        prefix_hash,
-        seq,
-    );
-    let bin_path = dir.join(&bin_name);
-    let meta_path = dir.join(&meta_name);
-
-    if let Err(e) = std::fs::write(&bin_path, data) {
-        logger::rustLogger.warn(
-            network_id,
-            &format!("[#942 dump] write {} failed: {}", bin_name, e),
-        );
-        return;
-    }
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(0.0);
-    let meta = format!(
-        "wall_time_unix={}\ntopic_kind={}\ndata_len={}\nprefix_sha256_64bit={}\npropagation_peer={}\nseq={}\n",
-        now, topic_kind, data.len(), prefix_hash, propagation_peer, seq,
-    );
-    let _ = std::fs::write(&meta_path, meta);
-    logger::rustLogger.info(
-        network_id,
-        &format!(
-            "[#942 dump] wrote {} ({} bytes, seq {}/{})",
-            bin_name,
-            data.len(),
-            seq + 1,
-            MAX_FAILED_GOSSIP_DUMPS
-        ),
-    );
-}
+// `dump_failed_gossip_payload` / `MAX_FAILED_GOSSIP_DUMPS` / `FAILED_GOSSIP_DUMP_COUNTER`
+// were removed in #942 phase 4. See the long-form rationale at the call site
+// (the `Behaviour::poll`-side comment in the gossipsub `Event::Message` arm):
+// the Rust-side per-failure dump duplicated the Zig-side
+// `failed_snappyz_decode_*.bin` dumps written by `writeFailedBytes`, and the
+// `Decoder::new().decompress_vec` it gated on was the second synchronous
+// decompress per gossip message — together they jammed the libp2p event
+// loop on broken-snappy bombs on the 2026-05-29 devnet.
 
 /// FFI getter: cumulative count of dropped swarm commands for the given
 /// reason tag (see `SwarmCommandDropReason`). Returns 0 for unknown tags so
@@ -1878,7 +1796,7 @@ impl Network {
                                 record_mesh_peers(self.network_id, mesh_count);
                             }
 
-                            if let gossipsub::Event::Message { propagation_source, message_id, message, .. } = gossipsub_event {
+                            if let gossipsub::Event::Message { message, .. } = gossipsub_event {
                                 let topic_str = message.topic.as_str().to_string();
                                 let topic = match CString::new(topic_str.as_str()) {
                                     Ok(cstr) => cstr,
@@ -1904,74 +1822,43 @@ impl Network {
                                     }
                                 };
 
-                                // #942: failure-path diagnostic. Snap-decode every inbound
-                                // gossip message at the Rust side so we can (a) detect when
-                                // the receive-buffer bytes differ from what gossipsub's
-                                // `message_id_fn` saw (FFI / slice bug → would manifest
-                                // here as Rust decompress failure while Zig succeeds, or
-                                // vice versa), and (b) on failure, dump the raw bytes via
-                                // `dump_failed_gossip_payload` for offline `cmp -l` of
-                                // multi-receipt corruption. The decode IS wasted CPU on the
-                                // common-case happy path (message_id_fn already decompressed
-                                // these bytes to compute the id, so we are doing the same
-                                // work twice for diagnostic value) — kept until #942's
-                                // upstream-encoder bug is fixed, since each devnet cycle is
-                                // expensive enough that having the dumps already on disk is
-                                // worth the per-message cost. Remove the call once the
-                                // upstream broken-encoding source is identified.
-                                let rust_decode_result = Decoder::new().decompress_vec(&message.data);
-                                if let Err(e) = &rust_decode_result {
-                                    // Failure path only: build the hex preview, log the line,
-                                    // and dump the raw bytes for offline analysis. The
-                                    // happy path emits zero log lines and allocates zero
-                                    // strings beyond the snap decode itself.
-                                    //
-                                    // Earlier revisions of this branch emitted a
-                                    // `[gossip ingress]` info line on EVERY message
-                                    // including ~900 attestations/min on a healthy mesh
-                                    // — ~16 MB/hour of log volume that swamps `docker
-                                    // logs` and `promtail` for no operator benefit. The
-                                    // metrics counter `zeam_gossip_decode_failures_total`
-                                    // covers the aggregate signal; this per-failure log
-                                    // keeps the byte-level forensic signal for the
-                                    // diagnosis that's still in flight.
-                                    let preview_len = std::cmp::min(message_len, 32);
-                                    let mut preview_hex = String::with_capacity(preview_len * 3);
-                                    {
-                                        use std::fmt::Write as _;
-                                        for (i, b) in message.data[..preview_len].iter().enumerate() {
-                                            if i != 0 {
-                                                preview_hex.push(' ');
-                                            }
-                                            let _ = write!(&mut preview_hex, "{:02x}", b);
-                                        }
-                                    }
-                                    let propagation_peer = propagation_source.to_string();
-                                    logger::rustLogger.info(
-                                        self.network_id,
-                                        &format!(
-                                            "[gossip ingress decode FAIL] topic={} sender={} propagation_peer={} msg_id={} data_len={} rust_snap=err({:?}) first{}={}",
-                                            topic_str,
-                                            sender_peer_id_string,
-                                            propagation_peer,
-                                            message_id,
-                                            message_len,
-                                            e,
-                                            preview_len,
-                                            preview_hex,
-                                        ),
-                                    );
-                                    let topic_kind_short = match topic_str.split('/').nth(3) {
-                                        Some(k) => k.split('_').next().unwrap_or("unk"),
-                                        None => "unk",
-                                    };
-                                    dump_failed_gossip_payload(
-                                        self.network_id,
-                                        topic_kind_short,
-                                        &propagation_peer,
-                                        &message.data,
-                                    );
-                                }
+                                // #942 phase 4: the Rust-side `Decoder::new().decompress_vec`
+                                // and accompanying `[gossip ingress decode FAIL]` log + dump
+                                // (added in `840d7058` / `f3c40406`) are GONE on purpose.
+                                //
+                                // Cause: on the 2026-05-29 devnet a 3.7 MB broken-snappy block
+                                // landed at 11:26:07 and the synchronous decompress here
+                                // (running on top of the equivalent decompress that
+                                // gossipsub's `message_id_fn` already does) blocked the
+                                // libp2p event loop for hundreds of milliseconds. The
+                                // resulting starvation knocked 8 in-flight Status RPCs
+                                // into simultaneous timeout at 11:26:56, broke 148 QUIC
+                                // handshakes with `HandshakeTimedOut`, and tipped zeam_8
+                                // into "Max reconnection attempts (5) reached, giving up"
+                                // for several peers. After that the node was sending
+                                // Status requests into the void: the chain stalled at
+                                // head=98 not because catch-up wasn't trying but because
+                                // the transport itself had been jammed by 2× per-message
+                                // decompress on the event loop.
+                                //
+                                // What we lose by removing this:
+                                //   * `[gossip ingress decode FAIL]` per-failure log →
+                                //     covered by the Zig-side `Error in snappyz decoding
+                                //     the message for topic=... first32=...` log
+                                //     (`pkgs/network/src/ethlibp2p.zig`).
+                                //   * `failed_gossip_*.bin` Rust dumps → covered by the
+                                //     pre-existing Zig-side `failed_snappyz_decode_*.bin`
+                                //     dumps written via `writeFailedBytes`. The Rust dumps
+                                //     captured `message.data` before the FFI handoff and
+                                //     were used in the cross-receiver test on 2026-05-29
+                                //     to prove the bytes are byte-identical at the wire
+                                //     side; that hypothesis is now confirmed and the
+                                //     duplicate dump path is no longer needed.
+                                //   * `rust_snap=ok` vs Zig decode reconciliation → only
+                                //     useful if there's an FFI slice bug. The
+                                //     cross-receiver test already showed the bytes that
+                                //     reach Zig match what Rust sees, so the FFI is
+                                //     faithful and this reconciliation has no signal left.
 
                                 unsafe {
                                     handleMsgFromRustBridge(self.zig_handler, topic, message_ptr, message_len, sender_peer_id_cstring.as_ptr())

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -339,6 +339,97 @@ fn record_mesh_peers(network_id: u32, count: u64) {
     }
 }
 
+/// #942 diagnostic: hard-capped counter for the per-failure gossip-byte
+/// dumps written by `dump_failed_gossip_payload`. The cap exists so a
+/// runaway corruption event can't fill the operator's disk with a few
+/// megabytes per failed receipt — once the limit is hit, the function
+/// becomes a no-op (the failure is still logged via the existing
+/// `[gossip ingress]` line, just not dumped).
+const MAX_FAILED_GOSSIP_DUMPS: u64 = 50;
+static FAILED_GOSSIP_DUMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// #942 diagnostic: persist the full `message.data` bytes of a gossip
+/// message that `snap::raw::Decoder` rejected. Filename is structured
+/// `failed_gossip_<topic>_<data_len>_<sha256_first32>_<seq>.bin` with
+/// a sibling `.meta.txt` so the operator can group different receipts
+/// of the same logical message (same `data_len` and same prefix hash)
+/// and `cmp -l` them byte-by-byte to locate exactly where the corruption
+/// enters. Without this, we only see varying `dst_pos` values in the log
+/// — we never get the raw bytes that produced each one.
+///
+/// Best-effort: failures to write are silently swallowed because this is
+/// a diagnostic path and must not impact the live gossip pipeline.
+fn dump_failed_gossip_payload(
+    network_id: u32,
+    topic_kind: &str,
+    propagation_peer: &str,
+    data: &[u8],
+) {
+    let seq = FAILED_GOSSIP_DUMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    if seq >= MAX_FAILED_GOSSIP_DUMPS {
+        return;
+    }
+
+    let mut hasher = sha2::Sha256::new();
+    let prefix_len = std::cmp::min(data.len(), 32);
+    hasher.update(&data[..prefix_len]);
+    let prefix_hash_bytes = hasher.finalize();
+    let prefix_hash = hex::encode(&prefix_hash_bytes[..8]); // 16 hex chars
+
+    let dir = std::path::Path::new("/data/deserialization_dumps");
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        logger::rustLogger.warn(
+            network_id,
+            &format!("[#942 dump] could not create dump dir: {}", e),
+        );
+        return;
+    }
+
+    let bin_name = format!(
+        "failed_gossip_{}_{}_{}_seq{:03}.bin",
+        topic_kind,
+        data.len(),
+        prefix_hash,
+        seq,
+    );
+    let meta_name = format!(
+        "failed_gossip_{}_{}_{}_seq{:03}.meta.txt",
+        topic_kind,
+        data.len(),
+        prefix_hash,
+        seq,
+    );
+    let bin_path = dir.join(&bin_name);
+    let meta_path = dir.join(&meta_name);
+
+    if let Err(e) = std::fs::write(&bin_path, data) {
+        logger::rustLogger.warn(
+            network_id,
+            &format!("[#942 dump] write {} failed: {}", bin_name, e),
+        );
+        return;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    let meta = format!(
+        "wall_time_unix={}\ntopic_kind={}\ndata_len={}\nprefix_sha256_64bit={}\npropagation_peer={}\nseq={}\n",
+        now, topic_kind, data.len(), prefix_hash, propagation_peer, seq,
+    );
+    let _ = std::fs::write(&meta_path, meta);
+    logger::rustLogger.info(
+        network_id,
+        &format!(
+            "[#942 dump] wrote {} ({} bytes, seq {}/{})",
+            bin_name,
+            data.len(),
+            seq + 1,
+            MAX_FAILED_GOSSIP_DUMPS
+        ),
+    );
+}
+
 /// FFI getter: cumulative count of dropped swarm commands for the given
 /// reason tag (see `SwarmCommandDropReason`). Returns 0 for unknown tags so
 /// future Zig builds compiled against an older Rust glue do not panic.
@@ -1787,7 +1878,7 @@ impl Network {
                                 record_mesh_peers(self.network_id, mesh_count);
                             }
 
-                            if let gossipsub::Event::Message { propagation_source, message, .. } = gossipsub_event {
+                            if let gossipsub::Event::Message { propagation_source, message_id, message, .. } = gossipsub_event {
                                 let topic_str = message.topic.as_str().to_string();
                                 let topic = match CString::new(topic_str.as_str()) {
                                     Ok(cstr) => cstr,
@@ -1841,10 +1932,29 @@ impl Network {
                                     }
                                     s
                                 };
-                                let rust_decode_status = match Decoder::new().decompress_vec(&message.data) {
+                                let rust_decode_result = Decoder::new().decompress_vec(&message.data);
+                                let rust_decode_status = match &rust_decode_result {
                                     Ok(decoded) => format!("rust_snap=ok decoded_len={}", decoded.len()),
                                     Err(e) => format!("rust_snap=err({:?})", e),
                                 };
+                                // #942 diagnostic: on a Rust-side decode failure, capture the
+                                // full message.data bytes (and a metadata sidecar) so we can
+                                // diff multiple receipts of the "same" logical message
+                                // (identified by topic + data_len + sha256 of first 32 bytes)
+                                // offline and see exactly where the byte stream diverges.
+                                // Capped at 50 dumps total to bound disk usage.
+                                if rust_decode_result.is_err() {
+                                    let topic_kind_short = match topic_str.split('/').nth(3) {
+                                        Some(k) => k.split('_').next().unwrap_or("unk"),
+                                        None => "unk",
+                                    };
+                                    dump_failed_gossip_payload(
+                                        self.network_id,
+                                        topic_kind_short,
+                                        &propagation_source.to_string(),
+                                        &message.data,
+                                    );
+                                }
                                 // #942 (follow-up): also log the gossipsub `propagation_source`
                                 // — the *connected* peer that just forwarded this message to
                                 // us. Unlike `message.source` (which is always None under
@@ -1859,10 +1969,11 @@ impl Network {
                                 logger::rustLogger.info(
                                     self.network_id,
                                     &format!(
-                                        "[gossip ingress] topic={} sender={} propagation_peer={} data_len={} {} first{}={}",
+                                        "[gossip ingress] topic={} sender={} propagation_peer={} msg_id={} data_len={} {} first{}={}",
                                         topic_str,
                                         sender_peer_id_string,
                                         propagation_peer,
+                                        message_id,
                                         message_len,
                                         rust_decode_status,
                                         preview_len,

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -1904,46 +1904,63 @@ impl Network {
                                     }
                                 };
 
-                                // #942 diagnostic: log the first 32 bytes of `message.data`
-                                // as gossipsub delivered it, IMMEDIATELY before the FFI handoff
-                                // to `handleMsgFromRustBridge`. The Zig side already logs
-                                // `first32=...` from inside the snappy-decode error path
-                                // (PR #945). If the two previews match exactly, the FFI is
-                                // faithful and any decode failure originates upstream of the
-                                // bridge (peer publish or gossipsub itself). If they differ,
-                                // there is a slice / pointer bug in the bridge handoff.
-                                //
-                                // Also report whether `snap::raw::Decoder` can decode the
-                                // payload at the Rust side (same crate ethlambda uses
-                                // successfully). A mismatch between Rust-side decode result
-                                // and Zig-side `snappyz.decodeWithMax` would indicate the
-                                // two decoders disagree on this byte sequence — strong
-                                // signal that the Zig snappy library has a bug specific to
-                                // this payload shape.
-                                let preview_len = std::cmp::min(message_len, 32);
-                                let preview_hex = {
-                                    use std::fmt::Write as _;
-                                    let mut s = String::with_capacity(preview_len * 3);
-                                    for (i, b) in message.data[..preview_len].iter().enumerate() {
-                                        if i != 0 {
-                                            s.push(' ');
-                                        }
-                                        let _ = write!(&mut s, "{:02x}", b);
-                                    }
-                                    s
-                                };
+                                // #942: failure-path diagnostic. Snap-decode every inbound
+                                // gossip message at the Rust side so we can (a) detect when
+                                // the receive-buffer bytes differ from what gossipsub's
+                                // `message_id_fn` saw (FFI / slice bug → would manifest
+                                // here as Rust decompress failure while Zig succeeds, or
+                                // vice versa), and (b) on failure, dump the raw bytes via
+                                // `dump_failed_gossip_payload` for offline `cmp -l` of
+                                // multi-receipt corruption. The decode IS wasted CPU on the
+                                // common-case happy path (message_id_fn already decompressed
+                                // these bytes to compute the id, so we are doing the same
+                                // work twice for diagnostic value) — kept until #942's
+                                // upstream-encoder bug is fixed, since each devnet cycle is
+                                // expensive enough that having the dumps already on disk is
+                                // worth the per-message cost. Remove the call once the
+                                // upstream broken-encoding source is identified.
                                 let rust_decode_result = Decoder::new().decompress_vec(&message.data);
-                                let rust_decode_status = match &rust_decode_result {
-                                    Ok(decoded) => format!("rust_snap=ok decoded_len={}", decoded.len()),
-                                    Err(e) => format!("rust_snap=err({:?})", e),
-                                };
-                                // #942 diagnostic: on a Rust-side decode failure, capture the
-                                // full message.data bytes (and a metadata sidecar) so we can
-                                // diff multiple receipts of the "same" logical message
-                                // (identified by topic + data_len + sha256 of first 32 bytes)
-                                // offline and see exactly where the byte stream diverges.
-                                // Capped at 50 dumps total to bound disk usage.
-                                if rust_decode_result.is_err() {
+                                if let Err(e) = &rust_decode_result {
+                                    // Failure path only: build the hex preview, log the line,
+                                    // and dump the raw bytes for offline analysis. The
+                                    // happy path emits zero log lines and allocates zero
+                                    // strings beyond the snap decode itself.
+                                    //
+                                    // Earlier revisions of this branch emitted a
+                                    // `[gossip ingress]` info line on EVERY message
+                                    // including ~900 attestations/min on a healthy mesh
+                                    // — ~16 MB/hour of log volume that swamps `docker
+                                    // logs` and `promtail` for no operator benefit. The
+                                    // metrics counter `zeam_gossip_decode_failures_total`
+                                    // covers the aggregate signal; this per-failure log
+                                    // keeps the byte-level forensic signal for the
+                                    // diagnosis that's still in flight.
+                                    let preview_len = std::cmp::min(message_len, 32);
+                                    let mut preview_hex = String::with_capacity(preview_len * 3);
+                                    {
+                                        use std::fmt::Write as _;
+                                        for (i, b) in message.data[..preview_len].iter().enumerate() {
+                                            if i != 0 {
+                                                preview_hex.push(' ');
+                                            }
+                                            let _ = write!(&mut preview_hex, "{:02x}", b);
+                                        }
+                                    }
+                                    let propagation_peer = propagation_source.to_string();
+                                    logger::rustLogger.info(
+                                        self.network_id,
+                                        &format!(
+                                            "[gossip ingress decode FAIL] topic={} sender={} propagation_peer={} msg_id={} data_len={} rust_snap=err({:?}) first{}={}",
+                                            topic_str,
+                                            sender_peer_id_string,
+                                            propagation_peer,
+                                            message_id,
+                                            message_len,
+                                            e,
+                                            preview_len,
+                                            preview_hex,
+                                        ),
+                                    );
                                     let topic_kind_short = match topic_str.split('/').nth(3) {
                                         Some(k) => k.split('_').next().unwrap_or("unk"),
                                         None => "unk",
@@ -1951,35 +1968,10 @@ impl Network {
                                     dump_failed_gossip_payload(
                                         self.network_id,
                                         topic_kind_short,
-                                        &propagation_source.to_string(),
+                                        &propagation_peer,
                                         &message.data,
                                     );
                                 }
-                                // #942 (follow-up): also log the gossipsub `propagation_source`
-                                // — the *connected* peer that just forwarded this message to
-                                // us. Unlike `message.source` (which is always None under
-                                // `ValidationMode::Anonymous`, line 2216), propagation_source
-                                // is always a real PeerId we can correlate against
-                                // `lean_connected_peers{client=...}` to identify the
-                                // forwarder's client family. With this in place, if every
-                                // failing-decode log has `propagation_source` resolving to a
-                                // zeam_* peer, we can attribute the bad-byte origin to a
-                                // zeam-only code path with high confidence.
-                                let propagation_peer = propagation_source.to_string();
-                                logger::rustLogger.info(
-                                    self.network_id,
-                                    &format!(
-                                        "[gossip ingress] topic={} sender={} propagation_peer={} msg_id={} data_len={} {} first{}={}",
-                                        topic_str,
-                                        sender_peer_id_string,
-                                        propagation_peer,
-                                        message_id,
-                                        message_len,
-                                        rust_decode_status,
-                                        preview_len,
-                                        preview_hex,
-                                    ),
-                                );
 
                                 unsafe {
                                     handleMsgFromRustBridge(self.zig_handler, topic, message_ptr, message_len, sender_peer_id_cstring.as_ptr())


### PR DESCRIPTION
## Summary

- **Step 1 – libxev callback duration histogram**: adds `zeam_libxev_callback_duration_seconds{site=...}` (HistogramVec) to `pkgs/metrics/src/lib.zig` and instruments `onGossip.block`, `onGossip.attestation`, `onGossip.aggregation`, `onGossip.block.hash_tree_root`, `onGossip.block.dispatch`, and `onInterval.tick` call-sites. Exposes via `/metrics` scrape so we can attribute slow drain passes to specific sites.

- **Step 2 – defer hashTreeRoot off libxev**: the unconditional `hashTreeRoot(BeamBlock)` that ran on the libxev thread for every inbound gossip block is removed from the common path. When a chain-worker is available and the parent is already in fork-choice (the hot path during normal sync), the block is dispatched to the worker immediately with `precomputed_block_root = null`; the worker computes the root itself. hashTreeRoot is still computed on libxev only for: (a) orphan blocks whose parent is not yet in fork-choice, and (b) future-slot blocks queued for later replay — both already rare and bounded.

## Why this matters

During devnet catch-up, gossip delivers 20–30 blocks in a burst. Each `hashTreeRoot(BeamBlock)` took ~5–15 ms; with 25 blocks in a single libxev drain pass that adds up to 375 ms — explaining the `zeam_xev_clock_until_done_slow_ge_500ms_total` counter incrementing ~70/minute during the stall.

## Correctness notes

- `protoArray.onBlock` (forkchoice.zig:97–101) returns early (no-op, no error) when `block.blockRoot` is already present, making the libxev-side `hasBlock` dedup an optimisation, not a correctness requirement.
- Gossipsub message-id dedup at the Rust libp2p layer means most actual duplicates never reach `onGossip`.
- `handleChainImportedBlock` (node.zig:631–678) fires `processCachedDescendants` with the resolved root after the worker completes, so the `processed_block_root = null` return on the fast path is safe.

## What to observe after deployment

Scrape `zeam_libxev_callback_duration_seconds` from `/metrics`. If `onGossip.block.dispatch` p99 is still >100 ms after this change, the next candidate is moving `sszClone` off libxev (step 3).

## Test plan

- [x] `zig build test` — all test suites green (metrics histogram appears in /metrics output test added)
- [ ] Deploy to devnet, scrape `/metrics`, confirm histogram buckets populate
- [ ] Verify `zeam_xev_clock_until_done_slow_ge_500ms_total` no longer increments rapidly during catch-up