### PR TITLE
ci(devnet5): run simtest at 12s slots with the real prover (drop mock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,17 +408,15 @@ jobs:
 
     - name: Run all sim tests
       # simtest validates consensus / networking / finalization, not prover throughput. On CI's
-      # weak CPU the real multi-second XMSS Type-2 merge overruns the 4s slot, so blocks publish
-      # late and the chain can't bootstrap → timeout. Mock the proposal block-building time to a
-      # fixed sub-slot value (default 400ms) via ZEAM_MOCK_BLOCK_PROOF so simtest finalizes
-      # deterministically. Real proving is covered by the unit tests, build-all-provers, and
-      # spectest. All-zeam sim, so the placeholder proofs are self-consistent.
-      env:
-        ZEAM_MOCK_BLOCK_PROOF: "1"
+      # weak CPU the real multi-second XMSS Type-2 merge overruns the default 4s slot, so blocks
+      # publish late and the chain can't bootstrap → timeout. Instead of mocking the prover, widen
+      # the slot to 12s (-Dseconds-per-slot=12): the real merge then fits within a slot and the
+      # ~2.4s interval absorbs the shared-loop drain (#863), so simtest finalizes with the REAL
+      # prover. The harness scales its deadlines by SECONDS_PER_SLOT. Prod stays at the 4s preset.
       run: |
         max_attempts=3
         for attempt in $(seq 1 $max_attempts); do
-          if zig build simtest --summary all; then
+          if zig build simtest -Dseconds-per-slot=12 --summary all; then
             echo "Successfully ran sim tests on attempt $attempt"
             exit 0
           fi

--- a/build.zig
+++ b/build.zig
@@ -161,6 +161,11 @@ pub fn build(b: *Builder) !void {
     build_options.addOption(bool, "has_openvm", prover == .openvm or prover == .all);
     // Absolute path to test-keys for pre-generated validator keys
     build_options.addOption([]const u8, "test_keys_path", b.pathFromRoot("test-keys/hash-sig-keys"));
+    // Test/sim-only override for SECONDS_PER_SLOT (default: preset value). Widens the slot so the
+    // real XMSS Type-2 merge fits within a slot on weak CI CPU (e.g. `zig build simtest
+    // -Dseconds-per-slot=12`); prod builds omit it and use the preset's 4s. See pkgs/params/src/lib.zig.
+    const seconds_per_slot_override = b.option(u64, "seconds-per-slot", "Override SECONDS_PER_SLOT (test/sim only; default = preset 4s)");
+    build_options.addOption(?u64, "seconds_per_slot_override", seconds_per_slot_override);
     const build_options_module = build_options.createModule();
 
     // add zeam-utils
@@ -179,6 +184,7 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
         .root_source_file = b.path("pkgs/params/src/lib.zig"),
     });
+    zeam_params.addImport("build_options", build_options_module);
 
     // add zeam-metrics (core metrics definitions)
     const zeam_metrics = b.addModule("@zeam/metrics", .{
@@ -581,6 +587,9 @@ pub fn build(b: *Builder) !void {
     const integration_build_options_module = integration_build_options.createModule();
     cli_integration_tests.root_module.addImport("build_options", integration_build_options_module);
     cli_integration_tests.root_module.addImport("@zeam/utils", zeam_utils);
+    // @zeam/params so the harness can scale its chain-progress deadlines by SECONDS_PER_SLOT
+    // (a -Dseconds-per-slot override widens the slot, so the wall-clock waits must widen too).
+    cli_integration_tests.root_module.addImport("@zeam/params", zeam_params);
 
     // Add CLI constants module to integration tests
     const cli_constants = b.addModule("cli_constants", .{

--- a/pkgs/cli/test/integration.zig
+++ b/pkgs/cli/test/integration.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const process = std.process;
 const net = std.Io.net;
 const zeam_utils = @import("@zeam/utils");
+const params = @import("@zeam/params");
 const build_options = @import("build_options");
 const constants = @import("cli_constants");
 const error_handler = @import("error_handler");
@@ -633,7 +634,9 @@ test "admin aggregator endpoint - GET returns seed, POST toggles at runtime" {
     // The API server comes up before the chain is wired in (503 until
     // `setChain` is called inside main.zig after validator key generation).
     // Poll until the chain is ready, then assert the baseline.
-    const chain_ready_deadline_ms: i64 = 60_000;
+    // Scales with slot time: a -Dseconds-per-slot override widens the slot, so first-block / chain
+    // readiness takes proportionally longer in wall-clock (60s at 4s slots, 180s at 12s).
+    const chain_ready_deadline_ms: i64 = 60_000 * @as(i64, @intCast(params.SECONDS_PER_SLOT)) / 4;
     const poll_start = zeam_utils.unixTimestampMillis();
     var get_before = try zeam_request.getAggregator();
     while (get_before.status != .ok) {
@@ -717,7 +720,9 @@ test "SSE events integration test - wait for justification and finalization" {
     //   - node3 emits its own new_finalization, or
     //   - global finalization advances beyond the first finalized slot, or
     //   - new_head events keep arriving after node3's delayed start (chain still progressing).
-    const timeout_ms: u64 = 480000; // 480 seconds timeout
+    // Scales with slot time (480s at the 4s preset, 1440s at -Dseconds-per-slot=12). The loop exits
+    // as soon as justification+finalization+node3-sync are observed, so this is just a headroom cap.
+    const timeout_ms: u64 = 480000 * params.SECONDS_PER_SLOT / 4;
     const start_ns = zeam_utils.monotonicTimestampNs();
     const deadline_ns = start_ns + timeout_ms * std.time.ns_per_ms;
     var got_justification = false;

--- a/pkgs/params/src/lib.zig
+++ b/pkgs/params/src/lib.zig
@@ -1,6 +1,7 @@
 // figure out a way to dynamically load these constants based on env
 const std = @import("std");
 const mainnetPreset = @import("./presets/mainnet.zig");
+const build_options = @import("build_options");
 pub const Preset = enum {
     mainnet,
     minimal,
@@ -11,7 +12,10 @@ const presets = .{ .mainnet = mainnetPreset.preset };
 pub const activePreset = Preset.mainnet;
 const activePresetValues = @field(presets, @tagName(activePreset));
 
-pub const SECONDS_PER_SLOT = activePresetValues.SECONDS_PER_SLOT;
+// Preset default, optionally overridden at build time by `-Dseconds-per-slot` (test/sim only — lets
+// the simtest widen the slot so the real prover fits; prod omits the flag and uses the preset).
+// `build_options.seconds_per_slot_override` is comptime-known, so dependent timing math stays comptime.
+pub const SECONDS_PER_SLOT = build_options.seconds_per_slot_override orelse activePresetValues.SECONDS_PER_SLOT;
 
 // SSZ capacity constants
 pub const HISTORICAL_ROOTS_LIMIT = activePresetValues.HISTORICAL_ROOTS_LIMIT;
@@ -31,5 +35,9 @@ pub const MAX_ATTESTATIONS_DATA: usize = 8;
 pub const AGGREGATION_DEADLINE_MS: u64 = 750;
 
 test "test preset loading" {
-    try std.testing.expect(SECONDS_PER_SLOT == mainnetPreset.preset.SECONDS_PER_SLOT);
+    // Only assert the preset value when no -Dseconds-per-slot override is in effect (the override
+    // is test/sim-only and intentionally diverges from the preset).
+    if (build_options.seconds_per_slot_override == null) {
+        try std.testing.expect(SECONDS_PER_SLOT == mainnetPreset.preset.SECONDS_PER_SLOT);
+    }
 }


### PR DESCRIPTION
Stacked on #918 (base = `devnet-5-spec-impl`).

## What
Per @gajinder's suggestion: instead of `ZEAM_MOCK_BLOCK_PROOF`, widen the slot for the **simtest binary only** so the real XMSS Type-2 merge fits and CI exercises the real prover.

- New `-Dseconds-per-slot` build override (default = preset **4s**; prod builds omit the flag and are unchanged).
- `ci.yml` simtest step now runs `zig build simtest -Dseconds-per-slot=12` and **drops** the `ZEAM_MOCK_BLOCK_PROOF` env.
- The integration harness scales its chain-progress deadlines by `SECONDS_PER_SLOT` (480s→1440s at 12s).

## Why it works
At a 12s slot the real Type-2 merge (~2–5s for the few simtest components; `AGGREGATION_DEADLINE_MS=750` keeps the count bounded) completes within the slot → on-time publish; and the interval becomes 12/5 = 2.4s, which absorbs the ~2.5s shared-loop drain (#863) that caused the old justification flake.

## Local validation
`zig build simtest -Dseconds-per-slot=12` (real prover, no mock):
- `Found justification with slot 12` → `First finalization at slot 12`
- final `got_justification=true got_finalization=true got_node3_sync=true`
- `SUCCESS: All integration test checks passed`, `TIMEOUT=1440000` (deadline scaled), exit 0
- default `zig build` (4s, no override) green → prod unaffected