### PR TITLE
Release devnet4 v0.4.31

### DIFF
--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -1335,6 +1335,16 @@ fn downloadAndStoreCheckpointBlock(
     };
     defer batch.deinit();
     batch.putBlockSerialized(database.DbBlocksNamespace, expected_root, ssz_data.items);
+    // Also index the checkpoint block in the finalized slot index so that
+    // blocks_by_range can serve it.  Without this, `onReqRespRequest`'s
+    // finalized-range path (slot <= finalized_slot) finds no entry in
+    // DbFinalizedSlotsNamespace and the unfinalized-range walk is skipped
+    // (its guard is `end_slot_exclusive > finalized_slot + 1`, which is false
+    // when start_slot == finalized_slot == checkpoint_slot).  The result is an
+    // empty blocks_by_range response for the checkpoint slot even though the
+    // block is present in DbBlocksNamespace and is served correctly via
+    // blocks_by_root.
+    batch.putFinalizedSlotIndex(database.DbFinalizedSlotsNamespace, block.block.slot, expected_root);
     db.commit(&batch) catch |err| {
         logger.warn("checkpoint block fetch: DB commit failed: {}", .{err});
         return;

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -2761,6 +2761,11 @@ fn setupTestPrimitives() !*ThreadPool {
     return @import("./testing.zig").setupTestPrimitives(std.testing.allocator);
 }
 
+/// Alias for setupTestPrimitives for backward compatibility with existing tests.
+fn initTestThreadPool() !*ThreadPool {
+    return setupTestPrimitives();
+}
+
 // TODO: Enable and update this test once the keymanager file-reading PR is added
 // JSON parsing for chain config needs to support validator_attestation_pubkeys instead of num_validators
 test "forkchoice block tree" {


### PR DESCRIPTION
Release PR for Devnet4 per RELEASE.md.

Labels:
- `release`
- `0.4.31`
- `devnet4`

Merging this PR will trigger the auto-release workflow to recreate the `Devnet4` GitHub tag/release, push Docker images including `docker.io/blockblaz/zeam:devnet4`, and update the `devnet4` branch.