### PR TITLE
node, libp2p-glue: downgrade per-chunk reqresp + per-attestation gossip logs to debug

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -3211,7 +3211,7 @@ pub const BeamChain = struct {
                         return err;
                     };
                 }
-                self.logger.info("processed gossip attestation for slot={d} validator={d}{f}", .{
+                self.logger.debug("processed gossip attestation for slot={d} validator={d}{f}", .{
                     slot,
                     validator_id,
                     validator_node_name,

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -460,7 +460,7 @@ pub const BeamNode = struct {
                 const validator_node_name = self.node_registry.getNodeNameFromValidatorIndex(validator_id);
 
                 const sender_node_name = self.node_registry.getNodeNameFromPeerId(sender_peer_id);
-                self.logger.info("received gossip attestation for slot={d} validator={d}{f} from peer={s}{f}", .{
+                self.logger.debug("received gossip attestation for slot={d} validator={d}{f} from peer={s}{f}", .{
                     slot,
                     validator_id,
                     validator_node_name,

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -3116,7 +3116,7 @@ impl Network {
                         let _ = RESPONSE_CHANNEL_MAP
                             .lock_recover()
                             .update_timeout(&channel_id, RESPONSE_CHANNEL_IDLE_TIMEOUT);
-                        logger::rustLogger.info(self.network_id, &format!(
+                        logger::rustLogger.debug(self.network_id, &format!(
                             "[reqresp] Sent response chunk on channel {} (peer: {})", channel_id, peer_id));
                     }
                     SwarmCommand::SendRpcEndOfStream { channel_id } => {
@@ -3127,7 +3127,7 @@ impl Network {
                             swarm.behaviour_mut().reqresp.finish_response_stream(
                                 peer_id, channel.connection_id, channel.stream_id,
                             );
-                            logger::rustLogger.info(self.network_id, &format!(
+                            logger::rustLogger.debug(self.network_id, &format!(
                                 "[reqresp] Sent end-of-stream on channel {} (peer: {})", channel_id, peer_id));
                         } else {
                             logger::rustLogger.error(self.network_id, &format!(


### PR DESCRIPTION
## Summary

Three log statements that fire many times per slot at info level were pushing useful info-level signal off the screen on busy devnet hosts. All three are routine per-event tracing — valuable for debugging but not for normal operation. Moved to debug:

- \`rust/libp2p-glue/src/lib.rs:3120\` — \`[reqresp] Sent response chunk on channel ...\` (fires once per response chunk; a single \`blocks_by_range\` reply can emit dozens)
- \`rust/libp2p-glue/src/lib.rs:3131\` — \`[reqresp] Sent end-of-stream on channel ...\` (paired with the chunk log; once per response stream)
- \`pkgs/node/src/node.zig:463\` — \`received gossip attestation for slot=... validator=...\` (once per attestation per validator per slot — the loudest line in node logs)

No behaviour change. Paired aggregation / published / processed lines were intentionally left at info per scope clarification.

## Test plan

- [x] \`zig build test\` — green
- [x] \`cargo build -p libp2p-glue\` — green
- [ ] Devnet smoke after deploy — confirm logs no longer flood with these three lines at info level