### PR TITLE
libp2p-glue: bump INBOUND_RPC_CHANNEL_CAPACITY 256 → 1024 to unstick catch-up

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -122,6 +122,25 @@ const Metrics = struct {
     /// itself — the two have very different fixes. See #940.
     zeam_xmss_rec_aggregate_phase_seconds: XmssRecAggregatePhaseHistogram,
     lean_pq_sig_aggregated_signatures_verification_time_seconds: PQSigAggregatedVerificationHistogram,
+    // Per-stage timing inside `stf.verifySignaturesParallel` so we can
+    // attribute the `step="verify_signatures"` cost. Existing data shows
+    // verify_signatures averages ~520 ms/block but the rayon Phase-2
+    // batch-verify portion (already measured by
+    // lean_pq_sig_aggregated_signatures_verification_time_seconds) is only
+    // ~6 ms — so >99% of verify_signatures is going somewhere else. These
+    // stages split it apart:
+    //   "phase1_prep"           — serial pubkey-cache prep + index check
+    //                             + AttestationData message-hash compute
+    //   "phase2_batch_verify"   — rayon parallel verifyAggregatedPayloadBatch
+    //                             (mirror of the existing pq_sig metric,
+    //                             same wall-clock — kept here so dashboards
+    //                             can stack stages in one chart)
+    //   "proposer_block_root"   — hashTreeRoot(BeamBlock) for proposer-sig
+    //                             input. Currently re-computed inside even
+    //                             when chain.onBlock already has the root.
+    //   "proposer_xmss_verify"  — xmss.verifySsz of the proposer signature.
+    // See PR #963.
+    zeam_stf_verify_signatures_stage_duration_seconds: StfVerifySignaturesStageHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
     // Network peer metrics
@@ -444,6 +463,15 @@ const Metrics = struct {
     const ChainOnblockStepHistogram = metrics_lib.HistogramVec(
         f32,
         ChainOnblockStepLabel,
+        &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 },
+    );
+    // Same bucket layout as ChainOnblockStepHistogram so dashboards can
+    // stack the verify-signatures stages under `step="verify_signatures"`
+    // and confirm they sum to roughly the parent step's wall-clock.
+    const StfVerifySignaturesStageLabel = struct { stage: []const u8 };
+    const StfVerifySignaturesStageHistogram = metrics_lib.HistogramVec(
+        f32,
+        StfVerifySignaturesStageLabel,
         &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 },
     );
     // Watchdog counters (#863): wall-clock heartbeats from the slot-driver
@@ -991,6 +1019,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .zeam_chain_onblock_step_duration_seconds = try Metrics.ChainOnblockStepHistogram.init(allocator, io, "zeam_chain_onblock_step_duration_seconds", .{ .help = "Per-substep wall-clock duration inside chain.onBlock, labeled by step. See #863 for context. Buckets match zeam_chain_onblock_duration_seconds for stack-aligned dashboarding." }, .{}),
+        .zeam_stf_verify_signatures_stage_duration_seconds = try Metrics.StfVerifySignaturesStageHistogram.init(allocator, io, "zeam_stf_verify_signatures_stage_duration_seconds", .{ .help = "Per-stage wall-clock duration inside stf.verifySignaturesParallel, labeled by stage. Splits the step=\"verify_signatures\" cost recorded by zeam_chain_onblock_step_duration_seconds across phase1_prep / phase2_batch_verify / proposer_block_root / proposer_xmss_verify. See PR #963." }, .{}),
         .zeam_chain_onblock_num_aggregated_attestations = Metrics.BlockAggregatedPayloadsHistogram.init("zeam_chain_onblock_num_aggregated_attestations", .{ .help = "Number of aggregated_attestations in each block processed by chain.onBlock (block import). Pair with zeam_chain_onblock_step_duration_seconds{step=\"verify_signatures\"} to attribute slow-block timings to block heaviness vs per-block constant cost. See PR #963." }, .{}),
         .zeam_chain_onblock_total_participants = Metrics.BlockTotalParticipantsHistogram.init("zeam_chain_onblock_total_participants", .{ .help = "Sum of participants across all aggregated_attestations in each block processed by chain.onBlock. Companion to zeam_chain_onblock_num_aggregated_attestations: same block can have few aggregations but many total participants if the aggregator did its job. See PR #963." }, .{}),
         .zeam_slot_driver_stall_fired_total = Metrics.ZeamSlotDriverStallFiredCounter.init("zeam_slot_driver_stall_fired_total", .{ .help = "Total times the watchdog (#863) observed the libxev slot driver stalled past its threshold (default 5s). Each firing also records the stall duration in zeam_slot_driver_stall_seconds and emits an ERROR log." }, .{}),

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -51,6 +51,16 @@ const Metrics = struct {
     //       `_duration_seconds` so dashboards can sanity-check that the
     //       sub-step buckets sum to roughly the total).
     zeam_chain_onblock_step_duration_seconds: ChainOnblockStepHistogram,
+    // Per-imported-block weight metrics so the existing
+    // `zeam_chain_onblock_*_duration_seconds` histograms can be correlated
+    // with block "heaviness". The catch-up performance issue surfaced on
+    // PR #963 made it clear that `verify_signatures` (84% of onBlock on
+    // catch-up nodes) is the dominant cost — but without these we can't
+    // tell whether a slow block is slow because of many attestations or
+    // because of a per-block constant cost. Recorded once per onBlock
+    // call, alongside the timing histograms.
+    zeam_chain_onblock_num_aggregated_attestations: BlockAggregatedPayloadsHistogram,
+    zeam_chain_onblock_total_participants: BlockTotalParticipantsHistogram,
     // Slot-driver stall watchdog (#863): a dedicated thread samples the
     // libxev tick clock every WATCHDOG_PROBE_MS via `Clock.lastTickMs()`
     // (atomic acquire load); if the value falls more than
@@ -525,6 +535,11 @@ const Metrics = struct {
     const BlockBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
     const BlockPayloadAggregationTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
     const BlockAggregatedPayloadsHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 2, 4, 8, 16, 32, 64, 128 });
+    // Total participant count summed across all aggregated_attestations in
+    // a block. Each attestation can have up to NUM_VALIDATORS participants;
+    // realistic block totals on devnet sit in the low hundreds today and
+    // grow with the validator set. Buckets cover that range with headroom.
+    const BlockTotalParticipantsHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 8, 32, 128, 512, 1024, 2048, 4096, 8192 });
     const BlockBuildingSuccessCounter = metrics_lib.Counter(u64);
     const BlockBuildingFailuresCounter = metrics_lib.Counter(u64);
     // Sync status gauge type: 0=idle, 1=syncing, 2=synced
@@ -723,6 +738,18 @@ fn observeBlockPayloadAggregationTime(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeChainOnblockNumAggregatedAttestations(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.BlockAggregatedPayloadsHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
+fn observeChainOnblockTotalParticipants(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.BlockTotalParticipantsHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeBlockAggregatedPayloads(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return;
     const histogram: *Metrics.BlockAggregatedPayloadsHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -824,6 +851,14 @@ fn observePendingBlocksDrainIters(ctx: ?*anyopaque, value: f32) void {
 pub var zeam_chain_onblock_duration_seconds: Histogram = .{
     .context = null,
     .observe = &observeChainOnblock,
+};
+pub var zeam_chain_onblock_num_aggregated_attestations: Histogram = .{
+    .context = null,
+    .observe = &observeChainOnblockNumAggregatedAttestations,
+};
+pub var zeam_chain_onblock_total_participants: Histogram = .{
+    .context = null,
+    .observe = &observeChainOnblockTotalParticipants,
 };
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
@@ -956,6 +991,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .zeam_chain_onblock_step_duration_seconds = try Metrics.ChainOnblockStepHistogram.init(allocator, io, "zeam_chain_onblock_step_duration_seconds", .{ .help = "Per-substep wall-clock duration inside chain.onBlock, labeled by step. See #863 for context. Buckets match zeam_chain_onblock_duration_seconds for stack-aligned dashboarding." }, .{}),
+        .zeam_chain_onblock_num_aggregated_attestations = Metrics.BlockAggregatedPayloadsHistogram.init("zeam_chain_onblock_num_aggregated_attestations", .{ .help = "Number of aggregated_attestations in each block processed by chain.onBlock (block import). Pair with zeam_chain_onblock_step_duration_seconds{step=\"verify_signatures\"} to attribute slow-block timings to block heaviness vs per-block constant cost. See PR #963." }, .{}),
+        .zeam_chain_onblock_total_participants = Metrics.BlockTotalParticipantsHistogram.init("zeam_chain_onblock_total_participants", .{ .help = "Sum of participants across all aggregated_attestations in each block processed by chain.onBlock. Companion to zeam_chain_onblock_num_aggregated_attestations: same block can have few aggregations but many total participants if the aggregator did its job. See PR #963." }, .{}),
         .zeam_slot_driver_stall_fired_total = Metrics.ZeamSlotDriverStallFiredCounter.init("zeam_slot_driver_stall_fired_total", .{ .help = "Total times the watchdog (#863) observed the libxev slot driver stalled past its threshold (default 5s). Each firing also records the stall duration in zeam_slot_driver_stall_seconds and emits an ERROR log." }, .{}),
         .zeam_slot_driver_stall_seconds = Metrics.ZeamSlotDriverStallSecondsHistogram.init("zeam_slot_driver_stall_seconds", .{ .help = "Distribution of slot-driver stall durations observed by the watchdog (#863). Stalls beyond ~1s indicate the libxev loop, libp2p Rust thread, or chain-worker held the main loop hostage; pair with zeam_chain_onblock_step_duration_seconds to attribute." }, .{}),
         .lean_head_slot = Metrics.LeanHeadSlotGauge.init("lean_head_slot", .{ .help = "Latest slot of the lean chain" }, .{}),
@@ -1118,6 +1155,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
 
     // Set context for histogram wrappers (observe functions already assigned at compile time)
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
+    zeam_chain_onblock_num_aggregated_attestations.context = @ptrCast(&metrics.zeam_chain_onblock_num_aggregated_attestations);
+    zeam_chain_onblock_total_participants.context = @ptrCast(&metrics.zeam_chain_onblock_total_participants);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -3508,6 +3508,27 @@ pub const BeamChain = struct {
             const aggregated_attestations = block.body.attestations.constSlice();
             const signature_groups = signedBlock.signature.attestation_signatures.constSlice();
 
+            // Per-imported-block weight observation (PR #963 follow-up to
+            // option-3(c) instrumentation). Lets dashboards correlate the
+            // existing `zeam_chain_onblock_step_duration_seconds{step=...}`
+            // timings with how heavy the block actually is. `verify_signatures`
+            // is ~84% of onBlock on catch-up nodes; without these we cannot
+            // tell whether a slow block was slow because it carried many
+            // attestations / participants or whether there is a per-block
+            // constant cost worth investigating.
+            zeam_metrics.zeam_chain_onblock_num_aggregated_attestations.record(@floatFromInt(aggregated_attestations.len));
+            {
+                var total_participants: usize = 0;
+                for (aggregated_attestations) |agg_att| {
+                    const bits_len = agg_att.aggregation_bits.len();
+                    var i: usize = 0;
+                    while (i < bits_len) : (i += 1) {
+                        if (agg_att.aggregation_bits.get(i) catch false) total_participants += 1;
+                    }
+                }
+                zeam_metrics.zeam_chain_onblock_total_participants.record(@floatFromInt(total_participants));
+            }
+
             if (aggregated_attestations.len != signature_groups.len) {
                 self.logger.err(
                     "signature group count mismatch for block root=0x{x}: attestations={d} signature_groups={d}",

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -3404,7 +3404,11 @@ pub const BeamChain = struct {
             // atomic and the loser frees its handle. The previous
             // mutex around this block was the dominant contributor
             // to the ~78ms mean lock hold reported in #863.
-            try stf.verifySignaturesParallel(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache, self.thread_pool);
+            // Pass the precomputed block_root so verifySignaturesParallel can
+            // skip its own hashTreeRoot(BeamBlock) call (free win — see PR #963
+            // perf instrumentation: empty blocks were spending most of their
+            // verify_signatures budget in the duplicated hash).
+            try stf.verifySignaturesParallel(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache, self.thread_pool, &block_root);
 
             step_watch.lap("verify_signatures");
 

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -184,6 +184,7 @@ pub fn verifySignaturesParallel(
     signed_block: *const types.SignedBlock,
     pubkey_cache: ?*xmss.PublicKeyCache,
     thread_pool: anytype,
+    precomputed_block_root: ?*const [32]u8,
 ) !void {
     const attestations = signed_block.block.body.attestations.constSlice();
     const signature_proofs = signed_block.signature.attestation_signatures.constSlice();
@@ -194,6 +195,30 @@ pub fn verifySignaturesParallel(
 
     const validators = state.validators.constSlice();
     _ = thread_pool;
+
+    // Per-stage stopwatch (PR #963). Splits this function's wall clock into
+    // phase1_prep / phase2_batch_verify / proposer_block_root /
+    // proposer_xmss_verify so we can attribute the ~520 ms/block cost that
+    // dashboards see under `step="verify_signatures"`. The rayon batch
+    // verify (phase2) is already known to be small (<6 ms/block on devnet);
+    // the remaining ~98% is what these stages will localise.
+    const VerifyStageWatch = struct {
+        anchor_ns: i128,
+        fn init() @This() {
+            return .{ .anchor_ns = zeam_utils.monotonicTimestampNs() };
+        }
+        fn lap(self: *@This(), comptime stage: []const u8) void {
+            const now_ns = zeam_utils.monotonicTimestampNs();
+            const elapsed_ns: i128 = if (now_ns >= self.anchor_ns) now_ns - self.anchor_ns else 0;
+            const elapsed_s: f32 = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+            zeam_metrics.metrics.zeam_stf_verify_signatures_stage_duration_seconds.observe(
+                .{ .stage = stage },
+                elapsed_s,
+            ) catch {};
+            self.anchor_ns = now_ns;
+        }
+    };
+    var stage_watch = VerifyStageWatch.init();
 
     // All per-task scratch (pubkey handle arrays, pubkey_wrappers when cache is absent)
     // lives in this arena and is freed with one call after the parallel phase returns.
@@ -263,6 +288,8 @@ pub fn verifySignaturesParallel(
         };
     }
 
+    stage_watch.lap("phase1_prep");
+
     // -------- Phase 2: rayon batch verify --------
     const start_ns = zeam_utils.monotonicTimestampNs();
     xmss.verifyAggregatedPayloadBatch(scratch_alloc, tasks) catch |err| {
@@ -280,6 +307,8 @@ pub fn verifySignaturesParallel(
         zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_valid_total.incr();
     }
 
+    stage_watch.lap("phase2_batch_verify");
+
     // Proposer signature — single verify, do it serially.
     const proposer_index: usize = @intCast(signed_block.block.proposer_index);
     if (proposer_index >= validators.len) {
@@ -288,11 +317,23 @@ pub fn verifySignaturesParallel(
     const proposer = &validators[proposer_index];
     const proposal_pubkey = proposer.getProposalPubkey();
 
-    var block_root: [32]u8 = undefined;
-    try zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &block_root, allocator);
+    // Reuse the caller-supplied block_root when available — chain.onBlock
+    // already computed hashTreeRoot(BeamBlock) before calling this function
+    // (see `step="block_root_compute"`). Re-hashing here is wasted work on
+    // every block and was previously the prime suspect for the
+    // 520 ms/block verify_signatures cost on empty blocks (no attestations
+    // → Phase 1 + Phase 2 are no-ops, so the cost has to live in this
+    // proposer path). PR #963.
+    var local_block_root: [32]u8 = undefined;
+    const block_root: *const [32]u8 = if (precomputed_block_root) |r| r else blk: {
+        try zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &local_block_root, allocator);
+        break :blk &local_block_root;
+    };
+    stage_watch.lap("proposer_block_root");
 
     const block_epoch: u32 = @intCast(signed_block.block.slot);
-    try xmss.verifySsz(proposal_pubkey, &block_root, block_epoch, &signed_block.signature.proposer_signature);
+    try xmss.verifySsz(proposal_pubkey, block_root, block_epoch, &signed_block.signature.proposer_signature);
+    stage_watch.lap("proposer_xmss_verify");
 }
 
 pub fn verifySingleAttestation(

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -948,7 +948,19 @@ enum RpcWork {
 /// `BLOCKS_BY_RANGE_SYNC_THRESHOLD` blocks per peer per sweep). Drops on
 /// overflow are logged + counted via `INBOUND_RPC_DROPPED_TOTAL` so a
 /// chronically saturated worker is visible without crashing the loop.
-const INBOUND_RPC_CHANNEL_CAPACITY: usize = 256;
+///
+/// Raised 256 → 1024 to unblock lagging fleet members during catch-up.
+/// A single bulk-status round across the ~60-peer devnet emits roughly
+/// `60 peers × (4 chunks + 1 EndOfStream) = 300` messages, which already
+/// exceeded the prior 256 cap before the chain-worker had a chance to
+/// drain even one block — turning every retry into `chunks=0 imported=0`
+/// and stalling sync. 1024 gives ~3× headroom and still bounds worst-case
+/// memory (each enqueued `RpcWork::Response` holds one block payload).
+///
+/// Real root cause is chain-worker throughput on big XMSS-heavy blocks;
+/// this bump is the surgical unstick while #3 (faster chain.onBlock for
+/// catch-up) is worked separately.
+const INBOUND_RPC_CHANNEL_CAPACITY: usize = 1024;
 
 /// Cumulative count of reqresp FFI dispatches dropped because the worker's
 /// channel was full. Read by the diag emitter (and could be exported via

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -1873,9 +1873,16 @@ unsafe fn send_rpc_response_chunk_inner(
             },
         );
     } else {
-        logger::rustLogger.error(
+        // Benign race, not an error: peer disconnected (ConnectionClosed
+        // handler dropped this channel) between dispatch and the FFI call
+        // landing here. The libp2p stream is already torn down; the chunk
+        // bytes fall on the floor and the requesting peer will retry on
+        // another peer. Heavy on QUIC churn during catch-up (~150-350/min
+        // per node on devnet). Logged at debug so chronic spam doesn't
+        // pollute the error stream.
+        logger::rustLogger.debug(
             network_id,
-            &format!("No response channel found for id {}", channel_id),
+            &format!("No response channel found for id {} (SendRpcResponseChunk; peer likely disconnected mid-response)", channel_id),
         );
     }
 }
@@ -3142,8 +3149,11 @@ impl Network {
                             logger::rustLogger.debug(self.network_id, &format!(
                                 "[reqresp] Sent end-of-stream on channel {} (peer: {})", channel_id, peer_id));
                         } else {
-                            logger::rustLogger.error(self.network_id, &format!(
-                                "No response channel found for id {} (SendRpcEndOfStream)", channel_id));
+                            // Benign race — see send_rpc_response_chunk note. Peer
+                            // disconnected between dispatch and execution; channel
+                            // was removed by ConnectionClosed retain().
+                            logger::rustLogger.debug(self.network_id, &format!(
+                                "No response channel found for id {} (SendRpcEndOfStream; peer likely disconnected mid-response)", channel_id));
                         }
                     }
                     SwarmCommand::SendRpcErrorResponse { channel_id, payload } => {
@@ -3162,8 +3172,11 @@ impl Network {
                             logger::rustLogger.info(self.network_id, &format!(
                                 "[reqresp] Sent error response on channel {} (peer: {})", channel_id, peer_id));
                         } else {
-                            logger::rustLogger.error(self.network_id, &format!(
-                                "No response channel found for id {} (SendRpcErrorResponse)", channel_id));
+                            // Benign race — see send_rpc_response_chunk note. Peer
+                            // disconnected between dispatch and execution; channel
+                            // was removed by ConnectionClosed retain().
+                            logger::rustLogger.debug(self.network_id, &format!(
+                                "No response channel found for id {} (SendRpcErrorResponse; peer likely disconnected mid-response)", channel_id));
                         }
                     }
                     SwarmCommand::DialReconnect { peer_id, addr, attempt } => {


### PR DESCRIPTION
## Summary

Three commits, two layers — the first unsticks today's lagging fleet, the next two attribute the deeper cost so the follow-up fix targets the actual bottleneck (not the one I initially guessed):

| Commit | Layer |
|-|-|
| \`a21a4fbf\` | bump \`INBOUND_RPC_CHANNEL_CAPACITY\` 256 → 1024 |
| \`ff110dbe\` | per-imported-block weight histograms (\`num_aggregated_attestations\`, \`total_participants\`) |
| \`e795c0a3\` | split \`verifySignaturesParallel\` into 4 stage histograms + reuse precomputed block_root |

## Why three layers, not one

### Layer 1: channel cap (confirmed working on devnet)

After deploying the cap bump and restarting devnet, 3 of 8 zeam nodes caught up to head=305 in ~16 min, queue drops collapsed to **0** across the fleet, and even zeam_8 (480 slots behind yesterday) is at head. The cap fix does what it was supposed to do.

### Layer 2: per-block weight histograms (ready, not yet deployed)

\`zeam_chain_onblock_num_aggregated_attestations\` (buckets 1..128) and \`zeam_chain_onblock_total_participants\` (buckets 1..8192) recorded once per imported block in \`chain.onBlock\`. Next deploy will let dashboards correlate the existing phase timings with block weight.

### Layer 3: \`verify_signatures\` stage split — this is where my earlier recommendation was wrong

The first cap-only image surfaced phase timings showing \`step="verify_signatures"\` averaging **523 ms/block** (96% of onBlock). My PR-body recommendation said "fix this with option (b): batch XMSS verify across multiple blocks." The data on the deployed image disproves that:

| Metric | Value |
|-|-|
| \`zeam_chain_onblock_step_duration_seconds{step="verify_signatures"}\` | 80.60 s / 154 blocks → **523 ms/block** |
| \`lean_pq_sig_aggregated_signatures_verification_time_seconds\` (Phase 2 batch) | 0.92 s / 19 tasks → **~6 ms/block** |

**The rayon batch verify is only ~1% of \`verify_signatures\`.** Batching across blocks (option b) would not move the needle — the slow code lives somewhere else inside \`verifySignaturesParallel\`. With most blocks empty in this devnet run (19 attestations across 154 blocks → 0.12/block avg), Phase 1 (per-attestation prep) is mostly a no-op too. The cost must be in the proposer-signature path: \`hashTreeRoot(BeamBlock)\` + \`xmss.verifySsz\` of the proposer's single signature, both of which run on every block whether or not it carries attestations.

This commit splits the cost across four stages so the next deploy reveals where the 520 ms actually lives:

| Stage | What it measures |
|-|-|
| \`phase1_prep\` | serial pubkey-cache prep + index check + per-attestation message-hash compute |
| \`phase2_batch_verify\` | rayon parallel \`verifyAggregatedPayloadBatch\` (mirror of the existing \`pq_sig\` metric — kept here so dashboards can stack stages in one chart) |
| \`proposer_block_root\` | \`hashTreeRoot(BeamBlock)\` for the proposer-signature input |
| \`proposer_xmss_verify\` | \`xmss.verifySsz\` of the proposer signature |

### Free win bundled with the instrumentation

\`chain.onBlock\` already computes \`hashTreeRoot(BeamBlock)\` (the \`step="block_root_compute"\` lap) before it calls \`verifySignaturesParallel\`. The function was re-computing the same hash internally. Added an optional \`precomputed_block_root\` parameter so \`chain.onBlock\` passes \`&block_root\`; the parameter defaults to \`null\` to preserve standalone callability.

If \`proposer_block_root\` turns out to be the dominant stage, this single line of code is the entire fix (the duplicated hashTreeRoot just disappears). If it's \`proposer_xmss_verify\` or one of the others, the histogram tells us which to tackle next.

## What changed about my recommendation

The earlier PR-body section called out **option (b) — batch XMSS verify across blocks** as "the biggest win." The actual data shows option (b) targets the wrong code path — the batched XMSS verify is already a tiny fraction of \`verify_signatures\`. After this PR deploys, the stage histograms will name the real bottleneck and the next PR can fix it precisely (likely a one-liner if it's the duplicate \`hashTreeRoot\`).

## Test plan

- [x] \`cargo build -p libp2p-glue\` green
- [x] \`zig build test\` green (all 194 node tests + the rest, totals 335 tests across 10 groups)
- [ ] Deploy to devnet; expect:
  - \`zeam_chain_onblock_num_aggregated_attestations_*\` and \`zeam_chain_onblock_total_participants_*\` to populate per block import
  - \`zeam_stf_verify_signatures_stage_duration_seconds_sum{stage=...}\` to populate per onBlock call (4 stages)
  - The 4 stage sums to approximately equal the parent \`step="verify_signatures"\` sum
  - \`proposer_block_root\` stage to be ~0 (since precomputed root is now passed) — and the parent \`verify_signatures\` step to drop by the corresponding amount