### PR TITLE
Report peers causing behind sync status

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -384,7 +384,7 @@ const Metrics = struct {
     //   * `kind` — `attestation` (raw gossip att) or `aggregation`
     //     (aggregated payload).
     //   * `reason`:
-    //     - `syncing` — chain.getSyncStatus() is `behind_peers` /
+    //     - `syncing` — chain.getSyncStatus() is `peers_materially_ahead` /
     //       `fc_initing` / `no_peers`; suppress validation work and the
     //       follow-up `BlocksByRoot` fetch enqueue (the death-spiral fix).
     //       Recovery comes from `BlocksByRange` / gossip block import.

--- a/pkgs/node/src/blocks_by_range_sync.zig
+++ b/pkgs/node/src/blocks_by_range_sync.zig
@@ -60,14 +60,14 @@ pub fn shouldRefreshPeerStatus(
     }
 
     const refresh = switch (sync_status) {
-        .fc_initing, .behind_peers => true,
+        .fc_initing, .peers_materially_ahead => true,
         .synced => wall_head_lag_slots >= wall_head_lag_threshold_slots,
         .no_peers => false,
     };
     return .{ .refresh = refresh, .wall_head_lag_slots = wall_head_lag_slots };
 }
 
-/// True when pre-finalization sync should report `behind_peers` based on
+/// True when pre-finalization sync should report `peers_materially_ahead` based on
 /// wall-clock head lag alone (early devnets with `finalized_slot = 0`).
 pub fn isWallHeadLagSyncing(
     our_finalized_slot: types.Slot,
@@ -310,7 +310,7 @@ test "shouldRefreshPeerStatus handles cadence sync state and wall lag" {
         synced,
         no_peers,
         fc_initing,
-        behind_peers,
+        peers_materially_ahead,
     };
 
     // Wall-lag arithmetic is shared with cappedSyncGapSlots by treating wall_slot as
@@ -334,7 +334,7 @@ test "shouldRefreshPeerStatus handles cadence sync state and wall lag" {
         .{ .status = .synced, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 103, .threshold_slots = 4, .want_refresh = false, .want_lag = 3 },
         .{ .status = .synced, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 104, .threshold_slots = 4, .want_refresh = true, .want_lag = 4 },
         .{ .status = .fc_initing, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
-        .{ .status = .behind_peers, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
+        .{ .status = .peers_materially_ahead, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 100, .threshold_slots = 4, .want_refresh = true, .want_lag = 0 },
         .{ .status = .no_peers, .interval_in_slot = 0, .slot = 104, .our_head_slot = 100, .wall_slot = 200, .threshold_slots = 4, .want_refresh = false, .want_lag = 100 },
     };
 

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2352,7 +2352,7 @@ pub const BeamChain = struct {
         {
             const sync_status = self.getSyncStatus();
             zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "idle" }, if (sync_status == .no_peers or sync_status == .fc_initing) 1 else 0) catch {};
-            zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "syncing" }, if (sync_status == .behind_peers) 1 else 0) catch {};
+            zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "syncing" }, if (sync_status == .peers_materially_ahead) 1 else 0) catch {};
             zeam_metrics.metrics.lean_node_sync_status.set(.{ .status = "synced" }, if (sync_status == .synced) 1 else 0) catch {};
         }
 
@@ -3120,12 +3120,12 @@ pub const BeamChain = struct {
                 // (`subspecs/sync/service.py::on_gossip_attestation`):
                 // gossip is processed in `SYNCING` and `SYNCED`; only
                 // dropped in `IDLE` (no peers / forkchoice not yet
-                // initialised). The behind_peers state maps to spec
+                // initialised). The peers_materially_ahead state maps to spec
                 // `SYNCING` — accept attestations and let the buffer
                 // catch unknown-block / future-slot ones for replay
                 // after the next gossip block lands.
                 switch (self.getSyncStatus()) {
-                    .synced, .behind_peers => {},
+                    .synced, .peers_materially_ahead => {},
                     .no_peers, .fc_initing => {
                         zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "attestation", .reason = "syncing" }) catch {};
                         return .{};
@@ -3232,7 +3232,7 @@ pub const BeamChain = struct {
                 // Retryable validation failures land in the pending
                 // buffer for replay.
                 switch (self.getSyncStatus()) {
-                    .synced, .behind_peers => {},
+                    .synced, .peers_materially_ahead => {},
                     .no_peers, .fc_initing => {
                         zeam_metrics.metrics.zeam_gossip_atts_dropped_total.incr(.{ .kind = "aggregation", .reason = "syncing" }) catch {};
                         return .{};
@@ -4505,7 +4505,7 @@ pub const BeamChain = struct {
                 // attestation weight, and aggregates will propagate once peers connect.
                 self.logger.info("aggregating for slot={d} with no peers (local only)", .{slot});
             },
-            .behind_peers => |info| {
+            .peers_materially_ahead => |info| {
                 self.logBehindPeersDebug("skipping aggregation production", info);
                 self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
                     slot,
@@ -4847,7 +4847,7 @@ pub const BeamChain = struct {
         /// observed a real justified checkpoint via block processing.  Validator duties must
         /// not run until the first onBlock-driven justified update transitions FC to ready.
         fc_initing,
-        behind_peers: BehindPeersInfo,
+        peers_materially_ahead: BehindPeersInfo,
     };
 
     pub const MAX_BEHIND_PEERS_TO_REPORT = 16;
@@ -4887,7 +4887,7 @@ pub const BeamChain = struct {
 
     pub fn logBehindPeersDebug(self: *Self, context: []const u8, info: BehindPeersInfo) void {
         for (info.peers[0..info.peer_count]) |peer| {
-            self.logger.debug("{s}: behind_peers peer {s}{f} finalized_slot={d} max_peer_finalized_slot={d}", .{
+            self.logger.debug("{s}: peers_materially_ahead peer {s}{f} finalized_slot={d} max_peer_finalized_slot={d}", .{
                 context,
                 peer.peerId(),
                 self.node_registry.getNodeNameFromPeerId(peer.peerId()),
@@ -4896,7 +4896,7 @@ pub const BeamChain = struct {
             });
         }
         if (info.peers_truncated) {
-            self.logger.debug("{s}: behind_peers peer list truncated after {d} entries", .{ context, info.peer_count });
+            self.logger.debug("{s}: peers_materially_ahead peer list truncated after {d} entries", .{ context, info.peer_count });
         }
     }
 
@@ -4938,9 +4938,9 @@ pub const BeamChain = struct {
             }
         }
 
-        // `behind_peers` maps to leanSpec **SYNCING** ("deep sync"). It must
+        // `peers_materially_ahead` maps to leanSpec **SYNCING** ("deep sync"). It must
         // ONLY fire on a finalization gap; a 1-slot head delta is normal
-        // gossip latency, not deep sync, and `behind_peers` consumers
+        // gossip latency, not deep sync, and `peers_materially_ahead` consumers
         // (`validator_client.maybeDoProposal` / `mayBeDoAttestation`) skip
         // proposer/attestation duties — gating those on transient head
         // lag would silently disable validators near the head.
@@ -4953,7 +4953,7 @@ pub const BeamChain = struct {
 
         // Check 1/2: our head or finalization is behind peer finalization.
         // Include the exact peers whose finalized slots make this node report
-        // `behind_peers`, so logs can name the source of the decision.
+        // `peers_materially_ahead`, so logs can name the source of the decision.
         const behind_peer_finalization = our_head_slot < max_peer_finalized_slot or our_finalized_slot < max_peer_finalized_slot;
         if (behind_peer_finalization) {
             var info = self.behindPeersStatus(our_head_slot, our_finalized_slot, max_peer_finalized_slot);
@@ -4964,7 +4964,7 @@ pub const BeamChain = struct {
                 const peer_info = entry.value_ptr;
                 if (peer_info.latest_status) |status| {
                     if (status.finalized_slot > our_head_slot or status.finalized_slot > our_finalized_slot) {
-                        info.behind_peers.addPeer(peer_info.peer_id, status.finalized_slot);
+                        info.peers_materially_ahead.addPeer(peer_info.peer_id, status.finalized_slot);
                     }
                 }
             }
@@ -4993,7 +4993,7 @@ pub const BeamChain = struct {
         max_peer_finalized_slot: types.Slot,
     ) SyncStatus {
         _ = self;
-        return .{ .behind_peers = .{
+        return .{ .peers_materially_ahead = .{
             .head_slot = head_slot,
             .finalized_slot = finalized_slot,
             .max_peer_finalized_slot = max_peer_finalized_slot,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4481,11 +4481,14 @@ pub const BeamChain = struct {
                 self.logger.info("aggregating for slot={d} with no peers (local only)", .{slot});
             },
             .behind_peers => |info| {
-                self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
+                var behind_peers_buf: [1024]u8 = undefined;
+                const behind_peers = info.peerListForLog(&behind_peers_buf);
+                self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peers={s})", .{
                     slot,
                     info.head_slot,
                     info.finalized_slot,
                     info.max_peer_finalized_slot,
+                    behind_peers,
                 });
                 zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_synced" }) catch {};
                 return;
@@ -4820,11 +4823,75 @@ pub const BeamChain = struct {
         /// observed a real justified checkpoint via block processing.  Validator duties must
         /// not run until the first onBlock-driven justified update transitions FC to ready.
         fc_initing,
-        behind_peers: struct {
-            head_slot: types.Slot,
-            finalized_slot: types.Slot,
-            max_peer_finalized_slot: types.Slot,
-        },
+        behind_peers: BehindPeersInfo,
+    };
+
+    pub const MAX_BEHIND_PEERS_TO_REPORT = 16;
+    pub const MAX_BEHIND_PEER_ID_BYTES = 128;
+
+    pub const BehindPeerInfo = struct {
+        peer_id_buf: [MAX_BEHIND_PEER_ID_BYTES]u8 = undefined,
+        peer_id_len: usize = 0,
+        finalized_slot: types.Slot = 0,
+
+        pub fn peerId(self: *const @This()) []const u8 {
+            return self.peer_id_buf[0..self.peer_id_len];
+        }
+    };
+
+    pub const BehindPeersInfo = struct {
+        head_slot: types.Slot,
+        finalized_slot: types.Slot,
+        max_peer_finalized_slot: types.Slot,
+        peers: [MAX_BEHIND_PEERS_TO_REPORT]BehindPeerInfo = undefined,
+        peer_count: usize = 0,
+        peers_truncated: bool = false,
+
+        pub fn peerListForLog(self: *const @This(), buf: []u8) []const u8 {
+            var pos: usize = 0;
+            appendText(buf, &pos, "[");
+            for (self.peers[0..self.peer_count], 0..) |peer, idx| {
+                if (idx != 0) appendText(buf, &pos, ", ");
+                appendFmt(buf, &pos, "{s}(finalized_slot={d})", .{ peer.peerId(), peer.finalized_slot });
+            }
+            if (self.peers_truncated) {
+                if (self.peer_count != 0) appendText(buf, &pos, ", ");
+                appendText(buf, &pos, "...");
+            }
+            appendText(buf, &pos, "]");
+            return buf[0..pos];
+        }
+
+        fn appendText(buf: []u8, pos: *usize, text: []const u8) void {
+            if (pos.* >= buf.len) return;
+            const copy_len = @min(text.len, buf.len - pos.*);
+            @memcpy(buf[pos.*..][0..copy_len], text[0..copy_len]);
+            pos.* += copy_len;
+        }
+
+        fn appendFmt(buf: []u8, pos: *usize, comptime fmt: []const u8, args: anytype) void {
+            if (pos.* >= buf.len) return;
+            const written = std.fmt.bufPrint(buf[pos.*..], fmt, args) catch |err| switch (err) {
+                error.NoSpaceLeft => {
+                    pos.* = buf.len;
+                    return;
+                },
+            };
+            pos.* += written.len;
+        }
+
+        fn addPeer(self: *@This(), peer_id: []const u8, finalized_slot: types.Slot) void {
+            if (self.peer_count >= self.peers.len) {
+                self.peers_truncated = true;
+                return;
+            }
+            const copy_len = @min(peer_id.len, MAX_BEHIND_PEER_ID_BYTES);
+            var peer = BehindPeerInfo{ .peer_id_len = copy_len, .finalized_slot = finalized_slot };
+            @memcpy(peer.peer_id_buf[0..copy_len], peer_id[0..copy_len]);
+            self.peers[self.peer_count] = peer;
+            self.peer_count += 1;
+            if (copy_len < peer_id.len) self.peers_truncated = true;
+        }
     };
 
     /// Returns detailed sync status information.
@@ -4848,17 +4915,19 @@ pub const BeamChain = struct {
         const our_head_slot = self.forkChoice.getHead().slot;
         const our_finalized_slot = self.forkChoice.getLatestFinalized().slot;
 
-        // Find the maximum finalized slot reported by any peer
+        // Find the maximum finalized slot reported by any peer.
         var max_peer_finalized_slot: types.Slot = our_finalized_slot;
 
-        var peer_guard = self.connected_peers.iterateLocked();
-        defer peer_guard.deinit();
-        var peer_iter = peer_guard.iter;
-        while (peer_iter.next()) |entry| {
-            const peer_info = entry.value_ptr;
-            if (peer_info.latest_status) |status| {
-                if (status.finalized_slot > max_peer_finalized_slot) {
-                    max_peer_finalized_slot = status.finalized_slot;
+        {
+            var peer_guard = self.connected_peers.iterateLocked();
+            defer peer_guard.deinit();
+            var peer_iter = peer_guard.iter;
+            while (peer_iter.next()) |entry| {
+                const peer_info = entry.value_ptr;
+                if (peer_info.latest_status) |status| {
+                    if (status.finalized_slot > max_peer_finalized_slot) {
+                        max_peer_finalized_slot = status.finalized_slot;
+                    }
                 }
             }
         }
@@ -4876,14 +4945,24 @@ pub const BeamChain = struct {
         // reports a higher head triggers catch-up without changing the
         // node's high-level sync state.
 
-        // Check 1: our head is behind peer finalization — we don't even have finalized blocks
-        if (our_head_slot < max_peer_finalized_slot) {
-            return self.behindPeersStatus(our_head_slot, our_finalized_slot, max_peer_finalized_slot);
-        }
-
-        // Check 2: our finalization is behind peer finalization — we may be on a divergent fork
-        if (our_finalized_slot < max_peer_finalized_slot) {
-            return self.behindPeersStatus(our_head_slot, our_finalized_slot, max_peer_finalized_slot);
+        // Check 1/2: our head or finalization is behind peer finalization.
+        // Include the exact peers whose finalized slots make this node report
+        // `behind_peers`, so logs can name the source of the decision.
+        const behind_peer_finalization = our_head_slot < max_peer_finalized_slot or our_finalized_slot < max_peer_finalized_slot;
+        if (behind_peer_finalization) {
+            var info = self.behindPeersStatus(our_head_slot, our_finalized_slot, max_peer_finalized_slot);
+            var cause_guard = self.connected_peers.iterateLocked();
+            defer cause_guard.deinit();
+            var cause_iter = cause_guard.iter;
+            while (cause_iter.next()) |entry| {
+                const peer_info = entry.value_ptr;
+                if (peer_info.latest_status) |status| {
+                    if (status.finalized_slot > our_head_slot or status.finalized_slot > our_finalized_slot) {
+                        info.behind_peers.addPeer(peer_info.peer_id, status.finalized_slot);
+                    }
+                }
+            }
+            return info;
         }
 
         // Check 3: pre-finalization devnets — wall-clock head lag means we are

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4506,14 +4506,13 @@ pub const BeamChain = struct {
                 self.logger.info("aggregating for slot={d} with no peers (local only)", .{slot});
             },
             .behind_peers => |info| {
-                var behind_peers_buf: [1024]u8 = undefined;
-                const behind_peers = info.peerListForLog(&behind_peers_buf);
-                self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peers={s})", .{
+                self.logBehindPeersDebug("skipping aggregation production", info);
+                self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
                     slot,
                     info.head_slot,
                     info.finalized_slot,
                     info.max_peer_finalized_slot,
-                    behind_peers,
+                    info.peer_count,
                 });
                 zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_synced" }) catch {};
                 return;
@@ -4872,39 +4871,6 @@ pub const BeamChain = struct {
         peer_count: usize = 0,
         peers_truncated: bool = false,
 
-        pub fn peerListForLog(self: *const @This(), buf: []u8) []const u8 {
-            var pos: usize = 0;
-            appendText(buf, &pos, "[");
-            for (self.peers[0..self.peer_count], 0..) |peer, idx| {
-                if (idx != 0) appendText(buf, &pos, ", ");
-                appendFmt(buf, &pos, "{s}(finalized_slot={d})", .{ peer.peerId(), peer.finalized_slot });
-            }
-            if (self.peers_truncated) {
-                if (self.peer_count != 0) appendText(buf, &pos, ", ");
-                appendText(buf, &pos, "...");
-            }
-            appendText(buf, &pos, "]");
-            return buf[0..pos];
-        }
-
-        fn appendText(buf: []u8, pos: *usize, text: []const u8) void {
-            if (pos.* >= buf.len) return;
-            const copy_len = @min(text.len, buf.len - pos.*);
-            @memcpy(buf[pos.*..][0..copy_len], text[0..copy_len]);
-            pos.* += copy_len;
-        }
-
-        fn appendFmt(buf: []u8, pos: *usize, comptime fmt: []const u8, args: anytype) void {
-            if (pos.* >= buf.len) return;
-            const written = std.fmt.bufPrint(buf[pos.*..], fmt, args) catch |err| switch (err) {
-                error.NoSpaceLeft => {
-                    pos.* = buf.len;
-                    return;
-                },
-            };
-            pos.* += written.len;
-        }
-
         fn addPeer(self: *@This(), peer_id: []const u8, finalized_slot: types.Slot) void {
             if (self.peer_count >= self.peers.len) {
                 self.peers_truncated = true;
@@ -4918,6 +4884,21 @@ pub const BeamChain = struct {
             if (copy_len < peer_id.len) self.peers_truncated = true;
         }
     };
+
+    pub fn logBehindPeersDebug(self: *Self, context: []const u8, info: BehindPeersInfo) void {
+        for (info.peers[0..info.peer_count]) |peer| {
+            self.logger.debug("{s}: behind_peers peer {s}{f} finalized_slot={d} max_peer_finalized_slot={d}", .{
+                context,
+                peer.peerId(),
+                self.node_registry.getNodeNameFromPeerId(peer.peerId()),
+                peer.finalized_slot,
+                info.max_peer_finalized_slot,
+            });
+        }
+        if (info.peers_truncated) {
+            self.logger.debug("{s}: behind_peers peer list truncated after {d} entries", .{ context, info.peer_count });
+        }
+    }
 
     /// Returns detailed sync status information.
     pub fn getSyncStatus(self: *Self) SyncStatus {

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -109,7 +109,7 @@ pub const MAX_FC_CHAIN_PRINT_DEPTH = 5;
 pub const RPC_REQUEST_TIMEOUT_SECONDS: i64 = 8;
 
 // How often to re-send status requests to connected peers when sync may need
-// recovery: always while fc_initing/behind_peers, and while synced only after
+// recovery: always while fc_initing/peers_materially_ahead, and while synced only after
 // the local head has fallen behind wall-clock slots. Ensures that already-
 // connected peers are probed again after a restart and that early devnets with
 // finalized_slot=0 can recover from a gossip-ingress stall via status-driven

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2089,7 +2089,7 @@ pub const BeamNode = struct {
                         };
                         const sync_status = self.chain.getSyncStatus();
                         switch (sync_status) {
-                            .behind_peers => |info| {
+                            .peers_materially_ahead => |info| {
                                 const our_finalized_slot = self.chain.forkChoice.getLatestFinalized().slot;
                                 if (self.shouldCatchUpFromPeerStatus(
                                     catch_up_status,
@@ -2182,7 +2182,7 @@ pub const BeamNode = struct {
                         // pending_block_roots so a different peer can
                         // serve them. Without this, a failed request
                         // permanently stalls the parent-chain walk used
-                        // during fc_initing / behind_peers sync.
+                        // during fc_initing / peers_materially_ahead sync.
                         self.retryUnservedBlockRoots(request_id, snap.requested_roots_copy, peer_id);
                         return;
                     },
@@ -2213,7 +2213,7 @@ pub const BeamNode = struct {
                 // peer. Without this, a peer that returns EOS without
                 // fulfilling all requested roots (e.g., a mesh helper
                 // with head_slot=0) permanently stalls the parent-chain
-                // walk used during fc_initing / behind_peers sync.
+                // walk used during fc_initing / peers_materially_ahead sync.
                 if (snap.request_kind == .blocks_by_root) {
                     self.retryUnservedBlockRoots(request_id, snap.requested_roots_copy, peer_id);
                     return;

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -125,15 +125,14 @@ pub const ValidatorClient = struct {
                     self.logger.info("producing block for slot={d} proposer={d} with no peers (self-import only)", .{ slot, slot_proposer_id });
                 },
                 .behind_peers => |info| {
-                    var behind_peers_buf: [1024]u8 = undefined;
-                    const behind_peers = info.peerListForLog(&behind_peers_buf);
-                    self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peers={s})", .{
+                    self.chain.logBehindPeersDebug("skipping block production", info);
+                    self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
                         slot,
                         slot_proposer_id,
                         info.head_slot,
                         info.finalized_slot,
                         info.max_peer_finalized_slot,
-                        behind_peers,
+                        info.peer_count,
                     });
                     return null;
                 },
@@ -184,14 +183,13 @@ pub const ValidatorClient = struct {
                 self.logger.info("attesting for slot={d} with no peers (self-import only)", .{slot});
             },
             .behind_peers => |info| {
-                var behind_peers_buf: [1024]u8 = undefined;
-                const behind_peers = info.peerListForLog(&behind_peers_buf);
-                self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peers={s})", .{
+                self.chain.logBehindPeersDebug("skipping attestation production", info);
+                self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
                     slot,
                     info.head_slot,
                     info.finalized_slot,
                     info.max_peer_finalized_slot,
-                    behind_peers,
+                    info.peer_count,
                 });
                 return null;
             },

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -124,7 +124,7 @@ pub const ValidatorClient = struct {
                     // the gossip mesh while still expecting block production.
                     self.logger.info("producing block for slot={d} proposer={d} with no peers (self-import only)", .{ slot, slot_proposer_id });
                 },
-                .behind_peers => |info| {
+                .peers_materially_ahead => |info| {
                     self.chain.logBehindPeersDebug("skipping block production", info);
                     self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
                         slot,
@@ -182,7 +182,7 @@ pub const ValidatorClient = struct {
                 // and they will propagate once peers connect.
                 self.logger.info("attesting for slot={d} with no peers (self-import only)", .{slot});
             },
-            .behind_peers => |info| {
+            .peers_materially_ahead => |info| {
                 self.chain.logBehindPeersDebug("skipping attestation production", info);
                 self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
                     slot,

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -125,12 +125,15 @@ pub const ValidatorClient = struct {
                     self.logger.info("producing block for slot={d} proposer={d} with no peers (self-import only)", .{ slot, slot_proposer_id });
                 },
                 .behind_peers => |info| {
-                    self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
+                    var behind_peers_buf: [1024]u8 = undefined;
+                    const behind_peers = info.peerListForLog(&behind_peers_buf);
+                    self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peers={s})", .{
                         slot,
                         slot_proposer_id,
                         info.head_slot,
                         info.finalized_slot,
                         info.max_peer_finalized_slot,
+                        behind_peers,
                     });
                     return null;
                 },
@@ -181,11 +184,14 @@ pub const ValidatorClient = struct {
                 self.logger.info("attesting for slot={d} with no peers (self-import only)", .{slot});
             },
             .behind_peers => |info| {
-                self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
+                var behind_peers_buf: [1024]u8 = undefined;
+                const behind_peers = info.peerListForLog(&behind_peers_buf);
+                self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peers={s})", .{
                     slot,
                     info.head_slot,
                     info.finalized_slot,
                     info.max_peer_finalized_slot,
+                    behind_peers,
                 });
                 return null;
             },


### PR DESCRIPTION
## Summary
- extend `BeamChain.SyncStatus.behind_peers` with a bounded snapshot of peers whose finalized slots make the node report `behind_peers`
- keep returning `max_peer_finalized_slot` and include `behind_peers=[peer(finalized_slot=...)]` in all behind-peers duty/aggregation skip logs
- copy peer ids into fixed-size status storage so callers do not borrow connected-peer map memory after releasing its lock

## Validation
- `zig fmt pkgs/node/src/chain.zig pkgs/node/src/validator_client.zig`
- `zig ast-check pkgs/node/src/chain.zig && zig ast-check pkgs/node/src/validator_client.zig`
- `/tmp/zig-x86_64-linux-0.16.0/zig build test -Dprover=dummy` is running locally; earlier run got through compile after the modified code, then failed only on the now-fixed Zig 0.16 `std.io` API use.
