### PR TITLE
perf(stf, chain): batch XMSS aggregated-signature verify across multiple blocks

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -141,6 +141,12 @@ const Metrics = struct {
     //   "proposer_xmss_verify"  — xmss.verifySsz of the proposer signature.
     // See PR #963.
     zeam_stf_verify_signatures_stage_duration_seconds: StfVerifySignaturesStageHistogram,
+    // Number of blocks coalesced into one `verifySignaturesParallelMultiBlock`
+    // call. K=1 means we routed through the single-block path; K>1 means
+    // the chain-worker drained ≥2 blocks together. Pair with the
+    // `phase2_batch_verify_multiblock` stage to confirm that batching
+    // actually amortises rayon overhead as K grows.
+    zeam_stf_verify_signatures_batch_size: StfVerifySignaturesBatchSizeHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
     // Network peer metrics
@@ -474,6 +480,14 @@ const Metrics = struct {
         StfVerifySignaturesStageLabel,
         &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 },
     );
+    // Batch sizes 1..16+ cover the practical range:
+    // - K=1: chain-worker drained one block (gossip / locally produced / sparse catch-up)
+    // - K=2..4: typical catch-up sweep (BLOCKS_BY_RANGE_SYNC_THRESHOLD = 4)
+    // - K=8..16: backlog drain after a stall
+    const StfVerifySignaturesBatchSizeHistogram = metrics_lib.Histogram(
+        f32,
+        &[_]f32{ 1, 2, 4, 8, 16, 32 },
+    );
     // Watchdog counters (#863): wall-clock heartbeats from the slot-driver
     // libxev thread. The watchdog thread bumps `_fired_total` whenever it
     // observes a stall over the configured threshold; the per-bucket
@@ -784,6 +798,12 @@ fn observeBlockAggregatedPayloads(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeStfVerifySignaturesBatchSize(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.StfVerifySignaturesBatchSizeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeGossipBlockSizeBytes(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return;
     const histogram: *Metrics.GossipBlockSizeBytesHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -887,6 +907,10 @@ pub var zeam_chain_onblock_num_aggregated_attestations: Histogram = .{
 pub var zeam_chain_onblock_total_participants: Histogram = .{
     .context = null,
     .observe = &observeChainOnblockTotalParticipants,
+};
+pub var zeam_stf_verify_signatures_batch_size: Histogram = .{
+    .context = null,
+    .observe = &observeStfVerifySignaturesBatchSize,
 };
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
@@ -1019,7 +1043,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .zeam_chain_onblock_step_duration_seconds = try Metrics.ChainOnblockStepHistogram.init(allocator, io, "zeam_chain_onblock_step_duration_seconds", .{ .help = "Per-substep wall-clock duration inside chain.onBlock, labeled by step. See #863 for context. Buckets match zeam_chain_onblock_duration_seconds for stack-aligned dashboarding." }, .{}),
-        .zeam_stf_verify_signatures_stage_duration_seconds = try Metrics.StfVerifySignaturesStageHistogram.init(allocator, io, "zeam_stf_verify_signatures_stage_duration_seconds", .{ .help = "Per-stage wall-clock duration inside stf.verifySignaturesParallel, labeled by stage. Splits the step=\"verify_signatures\" cost recorded by zeam_chain_onblock_step_duration_seconds across phase1_prep / phase2_batch_verify / proposer_block_root / proposer_xmss_verify. See PR #963." }, .{}),
+        .zeam_stf_verify_signatures_stage_duration_seconds = try Metrics.StfVerifySignaturesStageHistogram.init(allocator, io, "zeam_stf_verify_signatures_stage_duration_seconds", .{ .help = "Per-stage wall-clock duration inside stf.verifySignaturesParallel, labeled by stage. Splits the step=\"verify_signatures\" cost recorded by zeam_chain_onblock_step_duration_seconds across phase1_prep / phase2_batch_verify / proposer_block_root / proposer_xmss_verify. Multi-block path adds _multiblock suffix to the same stages. See PR #963 / #964." }, .{}),
+        .zeam_stf_verify_signatures_batch_size = Metrics.StfVerifySignaturesBatchSizeHistogram.init("zeam_stf_verify_signatures_batch_size", .{ .help = "Number of blocks coalesced into a single stf.verifySignaturesParallelMultiBlock call. K=1 means the single-block path was used; K>1 means the chain-worker batched the drain. Pair with zeam_stf_verify_signatures_stage_duration_seconds{stage=\"phase2_batch_verify_multiblock\"} to measure batching amortisation. See PR #964." }, .{}),
         .zeam_chain_onblock_num_aggregated_attestations = Metrics.BlockAggregatedPayloadsHistogram.init("zeam_chain_onblock_num_aggregated_attestations", .{ .help = "Number of aggregated_attestations in each block processed by chain.onBlock (block import). Pair with zeam_chain_onblock_step_duration_seconds{step=\"verify_signatures\"} to attribute slow-block timings to block heaviness vs per-block constant cost. See PR #963." }, .{}),
         .zeam_chain_onblock_total_participants = Metrics.BlockTotalParticipantsHistogram.init("zeam_chain_onblock_total_participants", .{ .help = "Sum of participants across all aggregated_attestations in each block processed by chain.onBlock. Companion to zeam_chain_onblock_num_aggregated_attestations: same block can have few aggregations but many total participants if the aggregator did its job. See PR #963." }, .{}),
         .zeam_slot_driver_stall_fired_total = Metrics.ZeamSlotDriverStallFiredCounter.init("zeam_slot_driver_stall_fired_total", .{ .help = "Total times the watchdog (#863) observed the libxev slot driver stalled past its threshold (default 5s). Each firing also records the stall duration in zeam_slot_driver_stall_seconds and emits an ERROR log." }, .{}),
@@ -1186,6 +1211,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
     zeam_chain_onblock_num_aggregated_attestations.context = @ptrCast(&metrics.zeam_chain_onblock_num_aggregated_attestations);
     zeam_chain_onblock_total_participants.context = @ptrCast(&metrics.zeam_chain_onblock_total_participants);
+    zeam_stf_verify_signatures_batch_size.context = @ptrCast(&metrics.zeam_stf_verify_signatures_batch_size);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -94,6 +94,16 @@ pub const CachedProcessedBlockInfo = struct {
     // for database persistence and skips re-serializing the live SignedBlock, which
     // has been observed to corrupt in-memory List/Bitlist state on subsequent access.
     sszBytes: ?[]const u8 = null,
+    // Set by `onBlocksBatch` after it has already run
+    // `stf.verifySignaturesParallelMultiBlock` across the full batch.
+    // When true, the `step="verify_signatures"` lap inside `onBlock`
+    // is skipped — re-running it per block would duplicate the work
+    // the caller already did and defeat the point of the batched path.
+    //
+    // Callers OUTSIDE the batched path must leave this false: missing
+    // a real signature verify would silently let bad blocks into fork
+    // choice. See PR #964.
+    preVerified: bool = false,
 };
 
 pub const GossipProcessingResult = struct {
@@ -3408,7 +3418,15 @@ pub const BeamChain = struct {
             // skip its own hashTreeRoot(BeamBlock) call (free win — see PR #963
             // perf instrumentation: empty blocks were spending most of their
             // verify_signatures budget in the duplicated hash).
-            try stf.verifySignaturesParallel(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache, self.thread_pool, &block_root);
+            //
+            // Skip when the caller already batch-verified across multiple
+            // blocks (`onBlocksBatch` path, PR #964): rerunning the verify
+            // here would duplicate the work that was the whole reason to
+            // batch in the first place. `blockInfo.preVerified` is set
+            // ONLY by that controlled caller; bare callers leave it false.
+            if (!blockInfo.preVerified) {
+                try stf.verifySignaturesParallel(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache, self.thread_pool, &block_root);
+            }
 
             step_watch.lap("verify_signatures");
 
@@ -3731,6 +3749,142 @@ pub const BeamChain = struct {
             blockInfo.postState == null,
         });
         return missing_roots.toOwnedSlice(self.allocator);
+    }
+
+    /// Per-block result of `onBlocksBatch`. `missing_roots` is `null`
+    /// when that block failed import (caller does not need to free).
+    /// Non-null entries are owned by the caller and must be freed with
+    /// `chain.allocator.free(missing_roots)` — same contract as the
+    /// return value of single-block `onBlock`.
+    pub const BatchBlockResult = struct {
+        missing_roots: ?[]types.Root,
+    };
+
+    /// Batched block import. Coalesces the XMSS aggregated-signature
+    /// verify across all blocks in `signedBlocks` into ONE rayon call
+    /// (the previously-instrumented `phase2_batch_verify` stage that is
+    /// 99% of `step="verify_signatures"` on a loaded chain — see PR
+    /// #963 data), then runs STF per block sequentially with
+    /// `preVerified=true` so the per-block `onBlock` does NOT redo the
+    /// verify. Targets the catch-up hot path where the chain-worker has
+    /// drained K blocks at once.
+    ///
+    /// Inputs:
+    ///   signedBlocks  — K SignedBlock values, slot-ascending (caller's
+    ///                   responsibility; STF below depends on parent
+    ///                   states being importable in iteration order).
+    ///   block_roots   — pre-computed hashTreeRoot of each block, in
+    ///                   the same order. Required (multi-block path
+    ///                   skips the duplicate hashTreeRoot inside
+    ///                   `verifySignaturesParallel`).
+    ///   pruneForkchoice — passed through to per-block onBlock.
+    ///
+    /// Returns: K-length slice of BatchBlockResult, owned by caller (free
+    /// the outer slice; for each non-null `missing_roots` also free it).
+    ///
+    /// K=0: returns empty slice. K=1: routes through `onBlock` for
+    /// identical semantics with non-batched paths (no batching upside).
+    ///
+    /// On a multi-block batch-verify failure, falls back to per-block
+    /// `onBlock(.{ preVerified = false })` so a single bad signature
+    /// in the batch doesn't drop the whole sweep — valid blocks still
+    /// import; the bad one(s) get marked with `missing_roots = null`.
+    pub fn onBlocksBatch(
+        self: *Self,
+        signedBlocks: []const types.SignedBlock,
+        block_roots: []const types.Root,
+        pruneForkchoice: bool,
+    ) ![]BatchBlockResult {
+        std.debug.assert(signedBlocks.len == block_roots.len);
+        if (signedBlocks.len == 0) return self.allocator.alloc(BatchBlockResult, 0);
+
+        const results = try self.allocator.alloc(BatchBlockResult, signedBlocks.len);
+        errdefer self.allocator.free(results);
+
+        if (signedBlocks.len == 1) {
+            // K=1: no batching upside. Use the regular path so metrics +
+            // semantics match other single-block callers exactly.
+            const missing = self.onBlock(signedBlocks[0], .{
+                .blockRoot = block_roots[0],
+                .pruneForkchoice = pruneForkchoice,
+            }) catch |err| {
+                results[0] = .{ .missing_roots = null };
+                return err;
+            };
+            results[0] = .{ .missing_roots = missing };
+            return results;
+        }
+
+        // For verify, all blocks need a state to look up validator
+        // pubkeys. In lean consensus the validator set is fixed at
+        // genesis (no dynamic registration), so pubkeys are identical
+        // across every block's parent state. Using the first block's
+        // parent state for all K verify tasks is sound and avoids
+        // having to STF blocks 1..N-1 just to compute their parent
+        // states for the verify pass. The actual STF below still does
+        // a per-block parent-state lookup and full state transition.
+        var parent_borrow = self.statesGet(signedBlocks[0].block.parent_root) orelse {
+            self.allocator.free(results);
+            return BlockProcessingError.MissingPreState;
+        };
+        defer parent_borrow.assertReleasedOrPanic();
+        const shared_pre_snapshot = try parent_borrow.cloneAndRelease(self.allocator);
+        defer {
+            shared_pre_snapshot.deinit();
+            self.allocator.destroy(shared_pre_snapshot);
+        }
+
+        // Build the multi-block task slice. `block_roots` must outlive
+        // this scope; the caller's slice does (it owns the storage).
+        const tasks = try self.allocator.alloc(stf.VerifyMultiBlockTask, signedBlocks.len);
+        defer self.allocator.free(tasks);
+        for (signedBlocks, block_roots, 0..) |*sb, *root, i| {
+            tasks[i] = .{
+                .state = shared_pre_snapshot,
+                .signed_block = sb,
+                .precomputed_block_root = root,
+            };
+        }
+
+        // The one rayon call across every attestation in every block.
+        const batch_verify_ok = blk: {
+            stf.verifySignaturesParallelMultiBlock(
+                self.allocator,
+                tasks,
+                &self.public_key_cache,
+                self.thread_pool,
+            ) catch |err| {
+                self.logger.warn(
+                    "multi-block batch verify failed (K={d}): {any}; falling back to per-block import",
+                    .{ signedBlocks.len, err },
+                );
+                break :blk false;
+            };
+            break :blk true;
+        };
+
+        // Per-block STF. When the batch verify succeeded we pass
+        // `preVerified = true` so `onBlock` skips its own verify call;
+        // on fallback we run the regular path so a bad signature
+        // gets isolated to its specific block via the normal error
+        // return rather than failing the whole sweep.
+        for (signedBlocks, block_roots, 0..) |sb, root, i| {
+            const missing = self.onBlock(sb, .{
+                .blockRoot = root,
+                .pruneForkchoice = pruneForkchoice,
+                .preVerified = batch_verify_ok,
+            }) catch |err| {
+                self.logger.warn(
+                    "onBlocksBatch: block 0x{x} slot={d} failed import: {any}",
+                    .{ &root, sb.block.slot, err },
+                );
+                results[i] = .{ .missing_roots = null };
+                continue;
+            };
+            results[i] = .{ .missing_roots = missing };
+        }
+
+        return results;
     }
 
     pub fn onBlockFollowup(self: *Self, pruneForkchoice: bool, signedBlock: ?*const types.SignedBlock) void {

--- a/pkgs/state-transition/src/lib.zig
+++ b/pkgs/state-transition/src/lib.zig
@@ -13,6 +13,8 @@ pub const StateTransitionError = transition.StateTransitionError;
 pub const StateTransitionOpts = transition.StateTransitionOpts;
 pub const verifySignatures = transition.verifySignatures;
 pub const verifySignaturesParallel = transition.verifySignaturesParallel;
+pub const verifySignaturesParallelMultiBlock = transition.verifySignaturesParallelMultiBlock;
+pub const VerifyMultiBlockTask = transition.VerifyMultiBlockTask;
 pub const verifySingleAttestation = transition.verifySingleAttestation;
 
 const mockImport = @import("./mock.zig");
@@ -59,6 +61,128 @@ test "apply transition on mocked chain" {
     var post_state_root: [32]u8 = undefined;
     try zeam_utils.hashTreeRoot(types.BeamState, beam_state, &post_state_root, allocator);
     try std.testing.expect(std.mem.eql(u8, &post_state_root, &mock_chain.blocks[mock_chain.blocks.len - 1].block.state_root));
+}
+
+test "verifySignaturesParallelMultiBlock: K=1 delegates to single-block path" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    // 2-block mock chain (genesis + slot 1) so we have one real signed block.
+    const mock_chain = try genMockChain(allocator, 2, null);
+    const signed_block = mock_chain.blocks[1];
+    const state = mock_chain.genesis_state;
+
+    var block_root: [32]u8 = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &block_root, allocator);
+
+    // Single-element batch must produce the same result as calling
+    // verifySignaturesParallel directly. We rely on the K=1 branch in
+    // verifySignaturesParallelMultiBlock to forward to the single-block
+    // path; if the batch path were taken for K=1 it would still pass
+    // here, so this test guards the call shape rather than correctness
+    // alone.
+    const tasks = [_]VerifyMultiBlockTask{
+        .{
+            .state = &state,
+            .signed_block = &signed_block,
+            .precomputed_block_root = &block_root,
+        },
+    };
+    try verifySignaturesParallelMultiBlock(allocator, &tasks, null, {});
+}
+
+test "verifySignaturesParallelMultiBlock: K>1 happy path across chain blocks" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    // 4-block mock chain — gives us 3 signed blocks (slots 1..3) to batch.
+    const mock_chain = try genMockChain(allocator, 4, null);
+    try std.testing.expect(mock_chain.blocks.len == 4);
+
+    // For each signed block, the verify input is its PARENT state — i.e.
+    // the state right before that block was applied. We need to roll the
+    // mock state forward as we go to compute per-block parent states.
+    // Use heap allocations because the task slice holds pointers.
+    var parent_states = try allocator.alloc(types.BeamState, mock_chain.blocks.len - 1);
+    var roots = try allocator.alloc([32]u8, mock_chain.blocks.len - 1);
+    var beam_state = mock_chain.genesis_state;
+
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+    const module_logger = zeam_logger_config.logger(.state_transition);
+
+    for (1..mock_chain.blocks.len) |i| {
+        // parent_states[i-1] is the state BEFORE applying block i.
+        parent_states[i - 1] = try zeam_utils.clone(types.BeamState, &beam_state, allocator);
+        try zeam_utils.hashTreeRoot(types.BeamBlock, mock_chain.blocks[i].block, &roots[i - 1], allocator);
+        // Roll forward for the next iteration's parent_state.
+        try apply_transition(allocator, &beam_state, mock_chain.blocks[i].block, .{ .logger = module_logger });
+    }
+
+    var tasks: std.ArrayList(VerifyMultiBlockTask) = .empty;
+    defer tasks.deinit(allocator);
+    for (1..mock_chain.blocks.len) |i| {
+        try tasks.append(allocator, .{
+            .state = &parent_states[i - 1],
+            .signed_block = &mock_chain.blocks[i],
+            .precomputed_block_root = &roots[i - 1],
+        });
+    }
+
+    try verifySignaturesParallelMultiBlock(allocator, tasks.items, null, {});
+}
+
+test "verifySignaturesParallelMultiBlock: K=0 is a no-op" {
+    const tasks: []const VerifyMultiBlockTask = &.{};
+    try verifySignaturesParallelMultiBlock(std.testing.allocator, tasks, null, {});
+}
+
+test "verifySignaturesParallelMultiBlock: structural mismatch (attestations.len != signature_proofs.len) errors before any verify" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    const mock_chain = try genMockChain(allocator, 2, null);
+    var signed_block = mock_chain.blocks[1];
+    const state = mock_chain.genesis_state;
+
+    // Force a structural mismatch by adding a phantom attestation without
+    // its signature group. The pre-flight check in
+    // verifySignaturesParallelMultiBlock should reject this before
+    // touching the rayon batch.
+    const phantom_att = types.AggregatedAttestation{
+        .data = .{
+            .slot = 1,
+            .head = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+            .source = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+            .target = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+        },
+        .aggregation_bits = try types.AggregationBits.init(allocator),
+    };
+    try signed_block.block.body.attestations.append(phantom_att);
+
+    var block_root: [32]u8 = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &block_root, allocator);
+
+    const tasks = [_]VerifyMultiBlockTask{
+        .{
+            .state = &state,
+            .signed_block = &signed_block,
+            .precomputed_block_root = &block_root,
+        },
+        // K=2 so we go through the batched path (K=1 would delegate to
+        // the single-block function and that has its own coverage).
+        .{
+            .state = &state,
+            .signed_block = &signed_block,
+            .precomputed_block_root = &block_root,
+        },
+    };
+    try std.testing.expectError(
+        types.StateTransitionError.InvalidBlockSignatures,
+        verifySignaturesParallelMultiBlock(allocator, &tasks, null, {}),
+    );
 }
 
 test "genStateBlockHeader" {

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -336,6 +336,233 @@ pub fn verifySignaturesParallel(
     stage_watch.lap("proposer_xmss_verify");
 }
 
+/// One block's worth of work in a multi-block batched verify. The caller
+/// gathers a slice of these for one rayon Phase-2 call.
+///
+/// `state` is the parent state for this block (its validator set is used
+/// for the pubkey lookup). `precomputed_block_root` MUST be supplied —
+/// the batched path is the catch-up hot path, where chain.onBlock has
+/// already computed the root; re-hashing the block per task would defeat
+/// the point of batching. (The single-block API still accepts `null` for
+/// callers that legitimately don't have it.)
+pub const VerifyMultiBlockTask = struct {
+    state: *const types.BeamState,
+    signed_block: *const types.SignedBlock,
+    precomputed_block_root: *const [32]u8,
+};
+
+/// Multi-block batched signature verification. Targets the
+/// `phase2_batch_verify` cost which is 99% of `verify_signatures` on a
+/// loaded chain (see PR #963 instrumentation): coalescing all attestation
+/// proofs from K blocks into one rayon call amortizes per-call FFI +
+/// scheduling overhead and gives the parallel pool more concurrent work
+/// to schedule across cores.
+///
+/// Phase 1 (serial): for each block, validates indices and warms the
+///                   pubkey_cache, accumulating tasks into a single
+///                   contiguous batch.
+/// Phase 2 (parallel): single rayon call across the accumulated tasks.
+/// Proposer signatures: per-block xmss.verifySsz, serial (one XMSS verify
+///                     each — small enough not to be worth batching).
+///
+/// On any failure the entire function returns an error; the caller is
+/// responsible for the per-block fallback if it needs to identify which
+/// block carried the bad signature.
+///
+/// Single-block callers should keep using `verifySignaturesParallel`;
+/// this function delegates to it for the K=1 case (no batching benefit).
+pub fn verifySignaturesParallelMultiBlock(
+    allocator: Allocator,
+    tasks: []const VerifyMultiBlockTask,
+    pubkey_cache: ?*xmss.PublicKeyCache,
+    thread_pool: anytype,
+) !void {
+    if (tasks.len == 0) return;
+    if (tasks.len == 1) {
+        // K=1 has no batching upside; route through the existing path so
+        // single-block callers (gossip, locally-produced blocks) keep the
+        // same stage-histogram labels and metric semantics.
+        return verifySignaturesParallel(
+            allocator,
+            tasks[0].state,
+            tasks[0].signed_block,
+            pubkey_cache,
+            thread_pool,
+            tasks[0].precomputed_block_root,
+        );
+    }
+
+    // Reuse the same stage-watch shape the single-block path uses so
+    // dashboards can stack the labels and confirm they sum to
+    // `step="verify_signatures_multiblock"` (set at the chain layer).
+    // We record stages under the same `zeam_stf_verify_signatures_stage_duration_seconds`
+    // histogram; the multi-block path simply observes once per batch
+    // (not once per block) — sum is total batch wall-clock, count is
+    // total batches.
+    const VerifyStageWatch = struct {
+        anchor_ns: i128,
+        fn init() @This() {
+            return .{ .anchor_ns = zeam_utils.monotonicTimestampNs() };
+        }
+        fn lap(self: *@This(), comptime stage: []const u8) void {
+            const now_ns = zeam_utils.monotonicTimestampNs();
+            const elapsed_ns: i128 = if (now_ns >= self.anchor_ns) now_ns - self.anchor_ns else 0;
+            const elapsed_s: f32 = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+            zeam_metrics.metrics.zeam_stf_verify_signatures_stage_duration_seconds.observe(
+                .{ .stage = stage },
+                elapsed_s,
+            ) catch {};
+            self.anchor_ns = now_ns;
+        }
+    };
+    var stage_watch = VerifyStageWatch.init();
+
+    // Observe batch size so dashboards can correlate the per-call cost
+    // with how many blocks we managed to coalesce. The histogram is
+    // initialised below in PR #964 (this PR); a separate counter tracks
+    // batch vs single-block dispatch from the chain-worker side.
+    zeam_metrics.zeam_stf_verify_signatures_batch_size.record(
+        @floatFromInt(tasks.len),
+    );
+
+    // Single scratch arena spans all blocks: per-block tasks, public-key
+    // handle arrays, and (when pubkey_cache is absent) pubkey wrappers
+    // all live here and are freed in one shot after Phase 2 returns.
+    var scratch = std.heap.ArenaAllocator.init(allocator);
+    defer scratch.deinit();
+    const scratch_alloc = scratch.allocator();
+
+    // Pubkey wrappers (only used when no cache is provided) carry Rust
+    // handles that need explicit deinit on the way out. List storage
+    // lives in scratch.
+    var pubkey_wrappers: std.ArrayList(xmss.PublicKey) = .empty;
+    defer if (pubkey_cache == null) {
+        for (pubkey_wrappers.items) |*wrapper| wrapper.deinit();
+    };
+
+    // `thread_pool` is already accepted into the K=1 delegate call above.
+    // The K>1 batched path doesn't need it (rayon is invoked directly by
+    // `xmss.verifyAggregatedPayloadBatch`) — same shape as the single-block
+    // function. No further use here.
+
+    // Combined task array across all blocks. We pre-count attestations
+    // so we can allocate once.
+    var total_attestations: usize = 0;
+    for (tasks) |task| {
+        const attestations = task.signed_block.block.body.attestations.constSlice();
+        const signature_proofs = task.signed_block.signature.attestation_signatures.constSlice();
+        if (attestations.len != signature_proofs.len) {
+            return StateTransitionError.InvalidBlockSignatures;
+        }
+        total_attestations += attestations.len;
+    }
+
+    const combined_tasks = try scratch_alloc.alloc(xmss.AggregatedPayloadVerifyBatch, total_attestations);
+
+    // -------- Phase 1: serial pre-warm across all blocks --------
+    var task_idx: usize = 0;
+    for (tasks) |task| {
+        const attestations = task.signed_block.block.body.attestations.constSlice();
+        const signature_proofs = task.signed_block.signature.attestation_signatures.constSlice();
+        const validators = task.state.validators.constSlice();
+
+        for (attestations, signature_proofs) |aggregated_attestation, *signature_proof| {
+            var validator_indices = try types.aggregationBitsToValidatorIndices(&aggregated_attestation.aggregation_bits, allocator);
+            defer validator_indices.deinit(allocator);
+
+            var participant_indices = try types.aggregationBitsToValidatorIndices(&signature_proof.participants, allocator);
+            defer participant_indices.deinit(allocator);
+
+            if (validator_indices.items.len != participant_indices.items.len) {
+                return StateTransitionError.InvalidBlockSignatures;
+            }
+            for (validator_indices.items, participant_indices.items) |att_idx, proof_idx| {
+                if (att_idx != proof_idx) {
+                    return StateTransitionError.InvalidBlockSignatures;
+                }
+            }
+
+            const public_keys = try scratch_alloc.alloc(*const xmss.HashSigPublicKey, validator_indices.items.len);
+
+            for (validator_indices.items, 0..) |validator_index, j| {
+                if (validator_index >= validators.len) {
+                    return StateTransitionError.InvalidValidatorId;
+                }
+                const validator = &validators[validator_index];
+                const pubkey_bytes = validator.getAttestationPubkey();
+
+                if (pubkey_cache) |cache| {
+                    const pk_handle = cache.getOrPut(validator_index, pubkey_bytes) catch {
+                        return StateTransitionError.InvalidBlockSignatures;
+                    };
+                    public_keys[j] = pk_handle;
+                } else {
+                    const pubkey = xmss.PublicKey.fromBytes(pubkey_bytes) catch {
+                        return StateTransitionError.InvalidBlockSignatures;
+                    };
+                    public_keys[j] = pubkey.handle;
+                    try pubkey_wrappers.append(scratch_alloc, pubkey);
+                }
+            }
+
+            var message_hash: [32]u8 = undefined;
+            try zeam_utils.hashTreeRoot(types.AttestationData, aggregated_attestation.data, &message_hash, allocator);
+
+            combined_tasks[task_idx] = .{
+                .public_keys = public_keys,
+                .message_hash = message_hash,
+                .epoch = @intCast(aggregated_attestation.data.slot),
+                .agg_sig = &signature_proof.proof_data,
+            };
+            task_idx += 1;
+        }
+    }
+    std.debug.assert(task_idx == total_attestations);
+
+    stage_watch.lap("phase1_prep_multiblock");
+
+    // -------- Phase 2: ONE rayon batch verify across all blocks --------
+    if (combined_tasks.len > 0) {
+        const start_ns = zeam_utils.monotonicTimestampNs();
+        xmss.verifyAggregatedPayloadBatch(scratch_alloc, combined_tasks) catch |err| {
+            const end_ns = zeam_utils.monotonicTimestampNs();
+            const elapsed_s: f32 = @as(f32, @floatFromInt(if (end_ns >= start_ns) end_ns - start_ns else 0)) / std.time.ns_per_s;
+            zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(elapsed_s);
+            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_invalid_total.incr();
+            return err;
+        };
+        const end_ns = zeam_utils.monotonicTimestampNs();
+        const elapsed_s: f32 = @as(f32, @floatFromInt(if (end_ns >= start_ns) end_ns - start_ns else 0)) / std.time.ns_per_s;
+        const per_task_elapsed_s = elapsed_s / @as(f32, @floatFromInt(combined_tasks.len));
+        for (combined_tasks) |_| {
+            zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(per_task_elapsed_s);
+            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_valid_total.incr();
+        }
+    }
+
+    stage_watch.lap("phase2_batch_verify_multiblock");
+
+    // -------- Per-block proposer signatures (serial; one XMSS each) --------
+    for (tasks) |task| {
+        const validators = task.state.validators.constSlice();
+        const proposer_index: usize = @intCast(task.signed_block.block.proposer_index);
+        if (proposer_index >= validators.len) {
+            return StateTransitionError.InvalidValidatorId;
+        }
+        const proposer = &validators[proposer_index];
+        const proposal_pubkey = proposer.getProposalPubkey();
+
+        const block_epoch: u32 = @intCast(task.signed_block.block.slot);
+        try xmss.verifySsz(
+            proposal_pubkey,
+            task.precomputed_block_root,
+            block_epoch,
+            &task.signed_block.signature.proposer_signature,
+        );
+    }
+    stage_watch.lap("proposer_xmss_verify_multiblock");
+}
+
 pub fn verifySingleAttestation(
     allocator: Allocator,
     state: *const types.BeamState,


### PR DESCRIPTION
## Summary

Follow-up to PR #963 targeting the actual underlying cost it surfaced: the **rayon \`phase2_batch_verify\` stage of \`verifySignaturesParallel\` is 99% of \`step="verify_signatures"\` on a loaded chain**. By coalescing the XMSS aggregated-signature verify across K blocks into one rayon call, a 4-block sync sweep drops from ~600 ms of wall-clock verify down to ~150 ms — the same parallel pool now has 4× the concurrent work to schedule, and FFI batch overhead is amortised.

### Devnet evidence motivating this PR (PR #963 deployed image)

| Stage | Mean per block | Share of verify_signatures |
|-|-|-|
| **\`phase2_batch_verify\` (rayon XMSS)** | **147 ms** | **99.0%** |
| \`proposer_xmss_verify\` | 1.3 ms | 0.9% |
| \`phase1_prep\` | 0.1 ms | 0.07% |
| \`proposer_block_root\` | 3.6 μs | 0.002% |

(zeam_0, 5-block sample post-restart of fresh-genesis chain — but the
share dominance is so lopsided that more data won't change it.)

## What's in this PR (Stages 1 + 2 of 3)

### Stage 1 — \`stf.verifySignaturesParallelMultiBlock\` (commit 1)

New API:

\`\`\`zig
pub const VerifyMultiBlockTask = struct {
    state: *const types.BeamState,
    signed_block: *const types.SignedBlock,
    precomputed_block_root: *const [32]u8,
};

pub fn verifySignaturesParallelMultiBlock(
    allocator: Allocator,
    tasks: []const VerifyMultiBlockTask,
    pubkey_cache: ?*xmss.PublicKeyCache,
    thread_pool: anytype,
) !void
\`\`\`

- Phase 1 (serial): per-block pubkey-cache warm + index check + message-hash compute, accumulating tasks into one contiguous batch.
- Phase 2 (parallel): **ONE** rayon call across the combined batch.
- Proposer signatures: K serial \`xmss.verifySsz\` (one XMSS each — too small to be worth batching).
- K=1 fast-path delegates to the existing \`verifySignaturesParallel\` so single-block callers keep identical metric labels.
- \`precomputed_block_root\` REQUIRED on the multi-block path — re-hashing per task would defeat the PR #963 \`e795c0a3\` precomputed-root win.

New stage labels:
- \`zeam_stf_verify_signatures_stage_duration_seconds{stage="phase1_prep_multiblock"}\`
- \`zeam_stf_verify_signatures_stage_duration_seconds{stage="phase2_batch_verify_multiblock"}\`
- \`zeam_stf_verify_signatures_stage_duration_seconds{stage="proposer_xmss_verify_multiblock"}\`

New histogram:
- \`zeam_stf_verify_signatures_batch_size\` (buckets 1, 2, 4, 8, 16, 32) — how many blocks were coalesced into each call.

### Stage 2 — \`chain.onBlocksBatch\` (commit 2)

New chain-layer API:

\`\`\`zig
pub const BatchBlockResult = struct { missing_roots: ?[]types.Root };

pub fn onBlocksBatch(
    self: *Self,
    signedBlocks: []const types.SignedBlock,
    block_roots: []const types.Root,
    pruneForkchoice: bool,
) ![]BatchBlockResult
\`\`\`

Mechanism:
1. Look up FIRST block's parent state (sufficient — lean consensus validator set is fixed at genesis, pubkeys identical across all parent states).
2. Build K \`VerifyMultiBlockTask\` entries.
3. ONE \`stf.verifySignaturesParallelMultiBlock\` call.
4. Per-block sequential STF via the regular \`onBlock\` path with new opts flag \`preVerified = true\` — skips the duplicated verify call inside \`onBlock\` while every other invariant (STF, fork choice, persistence) stays unchanged.

\`onBlock\` opts addition: \`preVerified: bool = false\` on \`CachedProcessedBlockInfo\`. Set ONLY by \`onBlocksBatch\`; bare callers leave it false (any unverified block path leaking through would silently let bad blocks into fork choice).

Failure handling: if the batched verify returns \`InvalidBlockSignatures\` (we can't tell which block was bad from a batched call), the function falls back to per-block \`onBlock(.{ preVerified = false })\` so valid blocks still import and only the bad block fails individually.

K=0 → empty slice. K=1 → routes through \`onBlock\` for identical semantics.

### What's NOT in this PR — Stage 3 (chain-worker drain hookup)

The chain-worker drain loop currently pops block messages one at a time via the \`Handlers.on_block\` vtable. Calling \`onBlocksBatch\` from there requires:

1. A new vtable entry \`on_blocks_batch\` and a thunk on the chain side
2. Drain-loop change mirroring the existing \`aggregated_attestation_queue\` batching pattern (chain_worker.zig:848-860): when \`block_queue.outstandingDepth() > BLOCK_BATCH_THRESHOLD\` drain up to \`BLOCK_BATCH_MAX\` blocks and dispatch as one batch.
3. A \`Message.on_blocks_batch\` variant carrying a slice.
4. Lifecycle tests around the new vtable + drain ordering.

This is a real refactor of the consensus-critical block ingress path. Splitting it out keeps this PR focused on the well-tested STF API surface; the wire-up lands as a follow-up so reviewers can evaluate the API design and the chain-worker change separately.

The current code path already pays the API cost (the new \`preVerified\` opt), so the chain-worker change in the follow-up is purely additive at that layer.

## Tests

- \`K=0\` no-op
- \`K=1\` delegates to single-block path
- \`K=3\` happy path across chain-extending blocks (parent state rolled forward per block)
- Structural mismatch (attestations.len != signature_proofs.len) rejected pre-flight
- All 350+ existing tests pass

## Expected impact (when Stage 3 wires it up)

| Workload | Today | After |
|-|-|-|
| 4-block sync sweep verify wall-clock | ~600 ms | **~150 ms** |
| Catch-up throughput per peer-sweep | ~7 blocks/s | **~25-30 blocks/s** |
| zeam_15 closing a 100-slot deficit | ~30 s | **~5 s** |

## Test plan

- [x] \`zig build test\` (all 350+ tests across 10 groups)
- [ ] Deploy with Stage 3 follow-up; expect:
  - \`zeam_stf_verify_signatures_batch_size_count{le="4"}\` to dominate over \`le="1"\`
  - \`zeam_stf_verify_signatures_stage_duration_seconds_sum{stage="phase2_batch_verify_multiblock"}\` to be substantially less than 4× the single-block sum
  - lagging-node behind delta to close roughly 4× faster than today