### PR TITLE
perf + diag: batched XMSS verify across blocks + #942 peer_id attribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,12 +79,26 @@ COPY .git/HEAD .git/HEAD
 COPY .git/refs .git/refs
 
 # Get git commit hash and build the project with optimizations
-# Use cache mount for Zig build cache as well
+# Use cache mounts for both the Zig and Cargo build caches.
+#
+# Without the three `/root/.cargo/{registry,git}` and `/app/rust/target`
+# mounts, every Docker build (even for a 1-line Rust change) re-downloads
+# the full Cargo crate graph and re-compiles the ~200 transitive deps
+# (libp2p, gossipsub, quinn, tokio, ...) from scratch. On Mac/Docker
+# Desktop that's 5-15 minutes of pure Cargo compile time burned per
+# build. With these mounts: ~10s incremental rebuilds for typical changes.
+#
+# `rust/target` is where `cargo -C rust build` writes artifacts (see
+# build.zig: `cargo_build = b.addSystemCommand({..., "-C", "rust", ...})`).
+#
 # CPU targeting per architecture:
 #   amd64: x86-64-v3 (AVX2, no AVX512) — portable across modern x86_64 servers
 #   arm64: generic CPU — QEMU-compatible when cross-building
 ARG TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/zig \
+    --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/app/rust/target \
     EXTRA_ZIG_FLAGS="" && \
     if [ "$TARGETARCH" = "amd64" ]; then \
         EXTRA_ZIG_FLAGS="-Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3"; \
@@ -98,14 +112,20 @@ RUN --mount=type=cache,target=/root/.cache/zig \
     else \
         GIT_VERSION=$(echo "$GIT_VERSION" | head -c 7); \
     fi && \
-    zig build --seed 0 -Doptimize=ReleaseSafe -Dgit_version="$GIT_VERSION" $EXTRA_ZIG_FLAGS
+    zig build --seed 0 -Doptimize=ReleaseSafe -Dgit_version="$GIT_VERSION" $EXTRA_ZIG_FLAGS && \
+    REC_AGG_DIR=$(find /root/.cargo/git/checkouts -path "*/rec_aggregation" -type d | head -1) && \
+    cp -r "$REC_AGG_DIR" /tmp/rec_aggregation_src && \
+    echo "$REC_AGG_DIR" > /tmp/rec_aggregation_path
 
-# rec_aggregation's compilation.rs reads .py source files at runtime to verify
-# a bytecode fingerprint (via env!("CARGO_MANIFEST_DIR") baked at compile time).
-# Stage the crate source so we can recreate the path in the runtime image.
-RUN REC_AGG_DIR=$(find /root/.cargo/git/checkouts -path "*/rec_aggregation" -type d | head -1) \
-    && cp -r "$REC_AGG_DIR" /tmp/rec_aggregation_src \
-    && echo "$REC_AGG_DIR" > /tmp/rec_aggregation_path
+# Note: rec_aggregation extraction is folded into the build RUN above
+# (not a separate RUN) because we cache-mount /root/.cargo/git on that
+# RUN — cache mounts are ephemeral per-RUN, so a subsequent layer cannot
+# see /root/.cargo/git/checkouts at all. /tmp/rec_aggregation_src lands
+# on the real image layer and is picked up by the runtime-prep stage.
+# rec_aggregation's compilation.rs reads .py source files at runtime to
+# verify a bytecode fingerprint (via env!("CARGO_MANIFEST_DIR") baked at
+# compile time), so the crate source has to be present at the same path
+# in the runtime image.
 
 # Intermediate stage to prepare runtime libraries
 FROM ubuntu:24.04 AS runtime-prep

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -339,7 +339,7 @@ const Metrics = struct {
     /// dispatch. Sum the latter with the K from
     /// `zeam_stf_verify_signatures_batch_size_count` to recover the
     /// total number of blocks that took the batched path.
-    lean_chain_worker_block_dispatch_total: LeanChainWorkerBlockDispatchCounter,
+    zeam_chain_worker_block_dispatch_total: ZeamChainWorkerBlockDispatchCounter,
     /// Tripwire counter (zclawz review on PR #890): bumped from
     /// `chainWorkerProcessPendingBlocksThunk` whenever it returns a
     /// non-empty `missing_roots` slice. The thunk has no production
@@ -564,7 +564,7 @@ const Metrics = struct {
     const LeanChainQueueDroppedCounter = metrics_lib.CounterVec(u64, struct { queue: []const u8 });
     const LeanChainQueueDepthGauge = metrics_lib.GaugeVec(u64, struct { queue: []const u8 });
     const LeanChainWorkerLoopItersCounter = metrics_lib.Counter(u64);
-    const LeanChainWorkerBlockDispatchCounter = metrics_lib.CounterVec(u64, struct { path: []const u8 });
+    const ZeamChainWorkerBlockDispatchCounter = metrics_lib.CounterVec(u64, struct { path: []const u8 });
     const LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter = metrics_lib.Counter(u64);
     // Refcount-distribution buckets [1, 2, 4, 8, 16, 32, +Inf]. Typical
     // value is 1 (writer-only); transient 2-4 under reader concurrency;
@@ -1169,7 +1169,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation|aggregated_attestation|replay_pending). The `replay_pending` label is a single nudge that drains the in-process pending-attestation buffers — buffer depth itself is exposed via `lean_pending_attestations_size{kind}`." }, .{}),
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed or explicitly discarded during shutdown, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
-        .lean_chain_worker_block_dispatch_total = try Metrics.LeanChainWorkerBlockDispatchCounter.init(allocator, io, "lean_chain_worker_block_dispatch_total", .{ .help = "Chain-worker block-dispatch path counter. path=\"single\" counts `.on_block` dispatches via the unbatched code path (block queue depth ≤ BLOCK_BATCH_THRESHOLD); path=\"batch\" counts `.on_blocks_batch` dispatches (one per batched call, K blocks each). Combine with zeam_stf_verify_signatures_batch_size_count to recover total blocks taken via the batched path. See PR #966." }, .{}),
+        .zeam_chain_worker_block_dispatch_total = try Metrics.ZeamChainWorkerBlockDispatchCounter.init(allocator, io, "zeam_chain_worker_block_dispatch_total", .{ .help = "Chain-worker block-dispatch path counter. path=\"single\" counts `.on_block` dispatches via the unbatched code path (block queue depth ≤ BLOCK_BATCH_THRESHOLD); path=\"batch\" counts `.on_blocks_batch` dispatches (one per batched call, K blocks each). Combine with zeam_stf_verify_signatures_batch_size_count to recover total blocks taken via the batched path. See PR #966." }, .{}),
         .lean_chain_worker_process_pending_blocks_dropped_missing_roots_total = Metrics.LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter.init("lean_chain_worker_process_pending_blocks_dropped_missing_roots_total", .{ .help = "Tripwire (#890): non-zero only if a future worker producer dispatches `process_pending_blocks` without wiring the missing-roots backchannel. MUST stay 0 in steady state." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -330,6 +330,16 @@ const Metrics = struct {
     lean_chain_queue_dropped_total: LeanChainQueueDroppedCounter,
     lean_chain_queue_depth: LeanChainQueueDepthGauge,
     lean_chain_worker_loop_iters_total: LeanChainWorkerLoopItersCounter,
+    /// PR #966: per-dispatch-path counter so dashboards can see how often
+    /// the chain-worker actually managed to batch ≥2 blocks vs falling
+    /// back to the single-block path. `path="single"` increments once
+    /// per `.on_block` Message dispatched through the unbatched code
+    /// path (block queue depth ≤ BLOCK_BATCH_THRESHOLD at drain time);
+    /// `path="batch"` increments once per `Handlers.on_blocks_batch`
+    /// dispatch. Sum the latter with the K from
+    /// `zeam_stf_verify_signatures_batch_size_count` to recover the
+    /// total number of blocks that took the batched path.
+    lean_chain_worker_block_dispatch_total: LeanChainWorkerBlockDispatchCounter,
     /// Tripwire counter (zclawz review on PR #890): bumped from
     /// `chainWorkerProcessPendingBlocksThunk` whenever it returns a
     /// non-empty `missing_roots` slice. The thunk has no production
@@ -554,6 +564,7 @@ const Metrics = struct {
     const LeanChainQueueDroppedCounter = metrics_lib.CounterVec(u64, struct { queue: []const u8 });
     const LeanChainQueueDepthGauge = metrics_lib.GaugeVec(u64, struct { queue: []const u8 });
     const LeanChainWorkerLoopItersCounter = metrics_lib.Counter(u64);
+    const LeanChainWorkerBlockDispatchCounter = metrics_lib.CounterVec(u64, struct { path: []const u8 });
     const LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter = metrics_lib.Counter(u64);
     // Refcount-distribution buckets [1, 2, 4, 8, 16, 32, +Inf]. Typical
     // value is 1 (writer-only); transient 2-4 under reader concurrency;
@@ -1158,6 +1169,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_queue_dropped_total = try Metrics.LeanChainQueueDroppedCounter.init(allocator, io, "lean_chain_queue_dropped_total", .{ .help = "Producer trySend rejections on the chain-worker queues, labeled by queue (block|attestation|aggregated_attestation|replay_pending). The `replay_pending` label is a single nudge that drains the in-process pending-attestation buffers — buffer depth itself is exposed via `lean_pending_attestations_size{kind}`." }, .{}),
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed or explicitly discarded during shutdown, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
+        .lean_chain_worker_block_dispatch_total = try Metrics.LeanChainWorkerBlockDispatchCounter.init(allocator, io, "lean_chain_worker_block_dispatch_total", .{ .help = "Chain-worker block-dispatch path counter. path=\"single\" counts `.on_block` dispatches via the unbatched code path (block queue depth ≤ BLOCK_BATCH_THRESHOLD); path=\"batch\" counts `.on_blocks_batch` dispatches (one per batched call, K blocks each). Combine with zeam_stf_verify_signatures_batch_size_count to recover total blocks taken via the batched path. See PR #966." }, .{}),
         .lean_chain_worker_process_pending_blocks_dropped_missing_roots_total = Metrics.LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter.init("lean_chain_worker_process_pending_blocks_dropped_missing_roots_total", .{ .help = "Tripwire (#890): non-zero only if a future worker producer dispatches `process_pending_blocks` without wiring the missing-roots backchannel. MUST stay 0 in steady state." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -141,6 +141,12 @@ const Metrics = struct {
     //   "proposer_xmss_verify"  — xmss.verifySsz of the proposer signature.
     // See PR #963.
     zeam_stf_verify_signatures_stage_duration_seconds: StfVerifySignaturesStageHistogram,
+    // Number of blocks coalesced into one `verifySignaturesParallelMultiBlock`
+    // call. K=1 means we routed through the single-block path; K>1 means
+    // the chain-worker drained ≥2 blocks together. Pair with the
+    // `phase2_batch_verify_multiblock` stage to confirm that batching
+    // actually amortises rayon overhead as K grows.
+    zeam_stf_verify_signatures_batch_size: StfVerifySignaturesBatchSizeHistogram,
     lean_pq_sig_aggregated_signatures_valid_total: PQSigAggregatedValidCounter,
     lean_pq_sig_aggregated_signatures_invalid_total: PQSigAggregatedInvalidCounter,
     // Network peer metrics
@@ -474,6 +480,14 @@ const Metrics = struct {
         StfVerifySignaturesStageLabel,
         &[_]f32{ 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 },
     );
+    // Batch sizes 1..16+ cover the practical range:
+    // - K=1: chain-worker drained one block (gossip / locally produced / sparse catch-up)
+    // - K=2..4: typical catch-up sweep (BLOCKS_BY_RANGE_SYNC_THRESHOLD = 4)
+    // - K=8..16: backlog drain after a stall
+    const StfVerifySignaturesBatchSizeHistogram = metrics_lib.Histogram(
+        f32,
+        &[_]f32{ 1, 2, 4, 8, 16, 32 },
+    );
     // Watchdog counters (#863): wall-clock heartbeats from the slot-driver
     // libxev thread. The watchdog thread bumps `_fired_total` whenever it
     // observes a stall over the configured threshold; the per-bucket
@@ -784,6 +798,12 @@ fn observeBlockAggregatedPayloads(ctx: ?*anyopaque, value: f32) void {
     histogram.observe(value);
 }
 
+fn observeStfVerifySignaturesBatchSize(ctx: ?*anyopaque, value: f32) void {
+    const histogram_ptr = ctx orelse return;
+    const histogram: *Metrics.StfVerifySignaturesBatchSizeHistogram = @ptrCast(@alignCast(histogram_ptr));
+    histogram.observe(value);
+}
+
 fn observeGossipBlockSizeBytes(ctx: ?*anyopaque, value: f32) void {
     const histogram_ptr = ctx orelse return;
     const histogram: *Metrics.GossipBlockSizeBytesHistogram = @ptrCast(@alignCast(histogram_ptr));
@@ -887,6 +907,10 @@ pub var zeam_chain_onblock_num_aggregated_attestations: Histogram = .{
 pub var zeam_chain_onblock_total_participants: Histogram = .{
     .context = null,
     .observe = &observeChainOnblockTotalParticipants,
+};
+pub var zeam_stf_verify_signatures_batch_size: Histogram = .{
+    .context = null,
+    .observe = &observeStfVerifySignaturesBatchSize,
 };
 pub var lean_state_transition_time_seconds: Histogram = .{
     .context = null,
@@ -1019,7 +1043,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),
         .zeam_chain_onblock_step_duration_seconds = try Metrics.ChainOnblockStepHistogram.init(allocator, io, "zeam_chain_onblock_step_duration_seconds", .{ .help = "Per-substep wall-clock duration inside chain.onBlock, labeled by step. See #863 for context. Buckets match zeam_chain_onblock_duration_seconds for stack-aligned dashboarding." }, .{}),
-        .zeam_stf_verify_signatures_stage_duration_seconds = try Metrics.StfVerifySignaturesStageHistogram.init(allocator, io, "zeam_stf_verify_signatures_stage_duration_seconds", .{ .help = "Per-stage wall-clock duration inside stf.verifySignaturesParallel, labeled by stage. Splits the step=\"verify_signatures\" cost recorded by zeam_chain_onblock_step_duration_seconds across phase1_prep / phase2_batch_verify / proposer_block_root / proposer_xmss_verify. See PR #963." }, .{}),
+        .zeam_stf_verify_signatures_stage_duration_seconds = try Metrics.StfVerifySignaturesStageHistogram.init(allocator, io, "zeam_stf_verify_signatures_stage_duration_seconds", .{ .help = "Per-stage wall-clock duration inside stf.verifySignaturesParallel, labeled by stage. Splits the step=\"verify_signatures\" cost recorded by zeam_chain_onblock_step_duration_seconds across phase1_prep / phase2_batch_verify / proposer_block_root / proposer_xmss_verify. Multi-block path adds _multiblock suffix to the same stages. See PR #963 / #964." }, .{}),
+        .zeam_stf_verify_signatures_batch_size = Metrics.StfVerifySignaturesBatchSizeHistogram.init("zeam_stf_verify_signatures_batch_size", .{ .help = "Number of blocks coalesced into a single stf.verifySignaturesParallelMultiBlock call. K=1 means the single-block path was used; K>1 means the chain-worker batched the drain. Pair with zeam_stf_verify_signatures_stage_duration_seconds{stage=\"phase2_batch_verify_multiblock\"} to measure batching amortisation. See PR #964." }, .{}),
         .zeam_chain_onblock_num_aggregated_attestations = Metrics.BlockAggregatedPayloadsHistogram.init("zeam_chain_onblock_num_aggregated_attestations", .{ .help = "Number of aggregated_attestations in each block processed by chain.onBlock (block import). Pair with zeam_chain_onblock_step_duration_seconds{step=\"verify_signatures\"} to attribute slow-block timings to block heaviness vs per-block constant cost. See PR #963." }, .{}),
         .zeam_chain_onblock_total_participants = Metrics.BlockTotalParticipantsHistogram.init("zeam_chain_onblock_total_participants", .{ .help = "Sum of participants across all aggregated_attestations in each block processed by chain.onBlock. Companion to zeam_chain_onblock_num_aggregated_attestations: same block can have few aggregations but many total participants if the aggregator did its job. See PR #963." }, .{}),
         .zeam_slot_driver_stall_fired_total = Metrics.ZeamSlotDriverStallFiredCounter.init("zeam_slot_driver_stall_fired_total", .{ .help = "Total times the watchdog (#863) observed the libxev slot driver stalled past its threshold (default 5s). Each firing also records the stall duration in zeam_slot_driver_stall_seconds and emits an ERROR log." }, .{}),
@@ -1186,6 +1211,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
     zeam_chain_onblock_duration_seconds.context = @ptrCast(&metrics.zeam_chain_onblock_duration_seconds);
     zeam_chain_onblock_num_aggregated_attestations.context = @ptrCast(&metrics.zeam_chain_onblock_num_aggregated_attestations);
     zeam_chain_onblock_total_participants.context = @ptrCast(&metrics.zeam_chain_onblock_total_participants);
+    zeam_stf_verify_signatures_batch_size.context = @ptrCast(&metrics.zeam_stf_verify_signatures_batch_size);
     lean_state_transition_time_seconds.context = @ptrCast(&metrics.lean_state_transition_time_seconds);
     lean_state_transition_slots_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_slots_processing_time_seconds);
     lean_state_transition_block_processing_time_seconds.context = @ptrCast(&metrics.lean_state_transition_block_processing_time_seconds);

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4812,14 +4812,28 @@ pub const BeamChain = struct {
                 self.logger.info("aggregating for slot={d} with no peers (local only)", .{slot});
             },
             .behind_peers => |info| {
-                self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
-                    slot,
-                    info.head_slot,
-                    info.finalized_slot,
-                    info.max_peer_finalized_slot,
-                });
-                zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_synced" }) catch {};
-                return;
+                // Same pre-finalization cold-start exception as
+                // validator_client.mayBeDoAttestation (see its long
+                // comment). Aggregation MUST proceed when both finalized
+                // slots are 0, otherwise we never produce the first
+                // aggregated payload and the chain can't reach a first
+                // justification. Once any finalization exists the gate
+                // returns to its proper deep-sync meaning.
+                if (info.finalized_slot == 0 and info.max_peer_finalized_slot == 0) {
+                    self.logger.info(
+                        "behind_peers but pre-finalization (finalized_slot=0, max_peer_finalized_slot=0): aggregating for slot={d} on current head_slot={d} to help reach first justification",
+                        .{ slot, info.head_slot },
+                    );
+                } else {
+                    self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
+                        slot,
+                        info.head_slot,
+                        info.finalized_slot,
+                        info.max_peer_finalized_slot,
+                    });
+                    zeam_metrics.metrics.zeam_aggregate_skip_total.incr(.{ .reason = "not_synced" }) catch {};
+                    return;
+                }
             },
         }
 

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -94,6 +94,16 @@ pub const CachedProcessedBlockInfo = struct {
     // for database persistence and skips re-serializing the live SignedBlock, which
     // has been observed to corrupt in-memory List/Bitlist state on subsequent access.
     sszBytes: ?[]const u8 = null,
+    // Set by `onBlocksBatch` after it has already run
+    // `stf.verifySignaturesParallelMultiBlock` across the full batch.
+    // When true, the `step="verify_signatures"` lap inside `onBlock`
+    // is skipped — re-running it per block would duplicate the work
+    // the caller already did and defeat the point of the batched path.
+    //
+    // Callers OUTSIDE the batched path must leave this false: missing
+    // a real signature verify would silently let bad blocks into fork
+    // choice. See PR #964.
+    preVerified: bool = false,
 };
 
 pub const GossipProcessingResult = struct {
@@ -3408,7 +3418,15 @@ pub const BeamChain = struct {
             // skip its own hashTreeRoot(BeamBlock) call (free win — see PR #963
             // perf instrumentation: empty blocks were spending most of their
             // verify_signatures budget in the duplicated hash).
-            try stf.verifySignaturesParallel(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache, self.thread_pool, &block_root);
+            //
+            // Skip when the caller already batch-verified across multiple
+            // blocks (`onBlocksBatch` path, PR #964): rerunning the verify
+            // here would duplicate the work that was the whole reason to
+            // batch in the first place. `blockInfo.preVerified` is set
+            // ONLY by that controlled caller; bare callers leave it false.
+            if (!blockInfo.preVerified) {
+                try stf.verifySignaturesParallel(self.allocator, pre_snapshot, &signedBlock, &self.public_key_cache, self.thread_pool, &block_root);
+            }
 
             step_watch.lap("verify_signatures");
 
@@ -3731,6 +3749,142 @@ pub const BeamChain = struct {
             blockInfo.postState == null,
         });
         return missing_roots.toOwnedSlice(self.allocator);
+    }
+
+    /// Per-block result of `onBlocksBatch`. `missing_roots` is `null`
+    /// when that block failed import (caller does not need to free).
+    /// Non-null entries are owned by the caller and must be freed with
+    /// `chain.allocator.free(missing_roots)` — same contract as the
+    /// return value of single-block `onBlock`.
+    pub const BatchBlockResult = struct {
+        missing_roots: ?[]types.Root,
+    };
+
+    /// Batched block import. Coalesces the XMSS aggregated-signature
+    /// verify across all blocks in `signedBlocks` into ONE rayon call
+    /// (the previously-instrumented `phase2_batch_verify` stage that is
+    /// 99% of `step="verify_signatures"` on a loaded chain — see PR
+    /// #963 data), then runs STF per block sequentially with
+    /// `preVerified=true` so the per-block `onBlock` does NOT redo the
+    /// verify. Targets the catch-up hot path where the chain-worker has
+    /// drained K blocks at once.
+    ///
+    /// Inputs:
+    ///   signedBlocks  — K SignedBlock values, slot-ascending (caller's
+    ///                   responsibility; STF below depends on parent
+    ///                   states being importable in iteration order).
+    ///   block_roots   — pre-computed hashTreeRoot of each block, in
+    ///                   the same order. Required (multi-block path
+    ///                   skips the duplicate hashTreeRoot inside
+    ///                   `verifySignaturesParallel`).
+    ///   pruneForkchoice — passed through to per-block onBlock.
+    ///
+    /// Returns: K-length slice of BatchBlockResult, owned by caller (free
+    /// the outer slice; for each non-null `missing_roots` also free it).
+    ///
+    /// K=0: returns empty slice. K=1: routes through `onBlock` for
+    /// identical semantics with non-batched paths (no batching upside).
+    ///
+    /// On a multi-block batch-verify failure, falls back to per-block
+    /// `onBlock(.{ preVerified = false })` so a single bad signature
+    /// in the batch doesn't drop the whole sweep — valid blocks still
+    /// import; the bad one(s) get marked with `missing_roots = null`.
+    pub fn onBlocksBatch(
+        self: *Self,
+        signedBlocks: []const types.SignedBlock,
+        block_roots: []const types.Root,
+        pruneForkchoice: bool,
+    ) ![]BatchBlockResult {
+        std.debug.assert(signedBlocks.len == block_roots.len);
+        if (signedBlocks.len == 0) return self.allocator.alloc(BatchBlockResult, 0);
+
+        const results = try self.allocator.alloc(BatchBlockResult, signedBlocks.len);
+        errdefer self.allocator.free(results);
+
+        if (signedBlocks.len == 1) {
+            // K=1: no batching upside. Use the regular path so metrics +
+            // semantics match other single-block callers exactly.
+            const missing = self.onBlock(signedBlocks[0], .{
+                .blockRoot = block_roots[0],
+                .pruneForkchoice = pruneForkchoice,
+            }) catch |err| {
+                results[0] = .{ .missing_roots = null };
+                return err;
+            };
+            results[0] = .{ .missing_roots = missing };
+            return results;
+        }
+
+        // For verify, all blocks need a state to look up validator
+        // pubkeys. In lean consensus the validator set is fixed at
+        // genesis (no dynamic registration), so pubkeys are identical
+        // across every block's parent state. Using the first block's
+        // parent state for all K verify tasks is sound and avoids
+        // having to STF blocks 1..N-1 just to compute their parent
+        // states for the verify pass. The actual STF below still does
+        // a per-block parent-state lookup and full state transition.
+        var parent_borrow = self.statesGet(signedBlocks[0].block.parent_root) orelse {
+            self.allocator.free(results);
+            return BlockProcessingError.MissingPreState;
+        };
+        defer parent_borrow.assertReleasedOrPanic();
+        const shared_pre_snapshot = try parent_borrow.cloneAndRelease(self.allocator);
+        defer {
+            shared_pre_snapshot.deinit();
+            self.allocator.destroy(shared_pre_snapshot);
+        }
+
+        // Build the multi-block task slice. `block_roots` must outlive
+        // this scope; the caller's slice does (it owns the storage).
+        const tasks = try self.allocator.alloc(stf.VerifyMultiBlockTask, signedBlocks.len);
+        defer self.allocator.free(tasks);
+        for (signedBlocks, block_roots, 0..) |*sb, *root, i| {
+            tasks[i] = .{
+                .state = shared_pre_snapshot,
+                .signed_block = sb,
+                .precomputed_block_root = root,
+            };
+        }
+
+        // The one rayon call across every attestation in every block.
+        const batch_verify_ok = blk: {
+            stf.verifySignaturesParallelMultiBlock(
+                self.allocator,
+                tasks,
+                &self.public_key_cache,
+                self.thread_pool,
+            ) catch |err| {
+                self.logger.warn(
+                    "multi-block batch verify failed (K={d}): {any}; falling back to per-block import",
+                    .{ signedBlocks.len, err },
+                );
+                break :blk false;
+            };
+            break :blk true;
+        };
+
+        // Per-block STF. When the batch verify succeeded we pass
+        // `preVerified = true` so `onBlock` skips its own verify call;
+        // on fallback we run the regular path so a bad signature
+        // gets isolated to its specific block via the normal error
+        // return rather than failing the whole sweep.
+        for (signedBlocks, block_roots, 0..) |sb, root, i| {
+            const missing = self.onBlock(sb, .{
+                .blockRoot = root,
+                .pruneForkchoice = pruneForkchoice,
+                .preVerified = batch_verify_ok,
+            }) catch |err| {
+                self.logger.warn(
+                    "onBlocksBatch: block 0x{x} slot={d} failed import: {any}",
+                    .{ &root, sb.block.slot, err },
+                );
+                results[i] = .{ .missing_roots = null };
+                continue;
+            };
+            results[i] = .{ .missing_roots = missing };
+        }
+
+        return results;
     }
 
     pub fn onBlockFollowup(self: *Self, pruneForkchoice: bool, signedBlock: ?*const types.SignedBlock) void {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -673,6 +673,7 @@ pub const BeamChain = struct {
             .handlers = .{
                 .ctx = self,
                 .on_block = chainWorkerOnBlockThunk,
+                .on_blocks_batch = chainWorkerOnBlocksBatchThunk,
                 .on_gossip_attestation = chainWorkerOnGossipAttestationThunk,
                 .on_gossip_aggregated_attestation = chainWorkerOnGossipAggregatedAttestationThunk,
                 .process_pending_blocks = chainWorkerProcessPendingBlocksThunk,
@@ -1186,6 +1187,102 @@ pub const BeamChain = struct {
             return;
         }
         self.allocator.free(missing_roots);
+    }
+
+    /// Batched-block thunk (PR #966). Called by the chain-worker drain
+    /// loop when it coalesced 2+ `.on_block` messages. Routes the whole
+    /// batch through `chain.onBlocksBatch` so the XMSS aggregated-
+    /// signature verify runs as ONE rayon call across every attestation
+    /// in every block (the `phase2_batch_verify` stage that is 99% of
+    /// `step="verify_signatures"` on a loaded chain). After the batched
+    /// import returns, per-block bookkeeping (onBlockFollowup, replay,
+    /// imported-block backchannel) still runs once per block in order
+    /// — those steps are cheap and not amenable to batching.
+    ///
+    /// TOCTOU rejection paths (MissingPreState / PreFinalizedSlot) that
+    /// the single-block thunk routes to the rejected_block callback are
+    /// NOT exercised from this thunk: `onBlocksBatch` swallows per-block
+    /// failures into `missing_roots = null` so we lose the error tag.
+    /// Acceptable trade-off for the catch-up hot path (where the producer
+    /// just checked `hasBlock(parent)` under a shared lock, so the TOCTOU
+    /// window is narrow); gossip-rate blocks at queue depth ≤ threshold
+    /// still go through `chainWorkerOnBlockThunk` with full TOCTOU.
+    fn chainWorkerOnBlocksBatchThunk(
+        ctx: *anyopaque,
+        items: []const chain_worker.BlockBatchItem,
+    ) void {
+        const self: *Self = @ptrCast(@alignCast(ctx));
+
+        // Build per-block input slices for chain.onBlocksBatch. Every
+        // item should have a block_root by construction (gossip / RPC /
+        // local producers all compute it before submitting) — but
+        // recompute if missing to keep this thunk robust against future
+        // producers.
+        const signed_blocks = self.allocator.alloc(types.SignedBlock, items.len) catch |err| {
+            self.logger.err(
+                "chain-worker: onBlocksBatch thunk OOM on signed_blocks alloc ({d} items): {any}",
+                .{ items.len, err },
+            );
+            return;
+        };
+        defer self.allocator.free(signed_blocks);
+        const block_roots = self.allocator.alloc(types.Root, items.len) catch |err| {
+            self.logger.err(
+                "chain-worker: onBlocksBatch thunk OOM on block_roots alloc ({d} items): {any}",
+                .{ items.len, err },
+            );
+            return;
+        };
+        defer self.allocator.free(block_roots);
+
+        // `prune_forkchoice` is per-item in principle but in practice all
+        // catch-up submitters pass the same value. Use the first item's
+        // value for the batch; if a future submitter mixes per-block
+        // pruning we'll need to split into homogeneous sub-batches.
+        const prune_forkchoice = items[0].prune_forkchoice;
+
+        for (items, 0..) |item, i| {
+            signed_blocks[i] = item.signed_block;
+            if (item.block_root) |r| {
+                block_roots[i] = r;
+            } else {
+                zeam_utils.hashTreeRoot(types.BeamBlock, item.signed_block.block, &block_roots[i], self.allocator) catch |err| {
+                    self.logger.err(
+                        "chain-worker: onBlocksBatch root recompute failed slot={d}: {any}",
+                        .{ item.signed_block.block.slot, err },
+                    );
+                    return;
+                };
+            }
+        }
+
+        const results = self.onBlocksBatch(signed_blocks, block_roots, prune_forkchoice) catch |err| {
+            self.logger.err(
+                "chain-worker: onBlocksBatch failed K={d}: {any}",
+                .{ items.len, err },
+            );
+            return;
+        };
+        defer self.allocator.free(results);
+
+        // Per-block bookkeeping: followup + replay + imported_block
+        // callback. Mirror the single-block thunk's tail; null result
+        // means that block failed import (already logged inside
+        // onBlocksBatch / its fallback).
+        for (items, results, 0..) |item, result, i| {
+            const block_root = block_roots[i];
+            if (result.missing_roots) |missing_roots| {
+                self.onBlockFollowup(item.prune_forkchoice, &item.signed_block);
+                self.replayPendingAttestations();
+                if (self.imported_block) |cb| {
+                    cb.func(cb.ctx, block_root, missing_roots);
+                } else {
+                    self.allocator.free(missing_roots);
+                }
+            }
+            // Failed blocks: nothing to do — onBlocksBatch already logged
+            // and we have no error tag to drive the rejected_block path.
+        }
     }
 
     fn chainWorkerOnGossipAttestationThunk(

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -1064,13 +1064,13 @@ pub const ChainWorker = struct {
             );
             return;
         };
-        zeam_metrics.metrics.lean_chain_worker_block_dispatch_total.incr(.{ .path = "batch" }) catch {};
+        zeam_metrics.metrics.zeam_chain_worker_block_dispatch_total.incr(.{ .path = "batch" }) catch {};
         h.on_blocks_batch(h.ctx, items);
     }
 
     fn dispatch(self: *Self, msg: Message) void {
         if (msg == .on_block) {
-            zeam_metrics.metrics.lean_chain_worker_block_dispatch_total.incr(.{ .path = "single" }) catch {};
+            zeam_metrics.metrics.zeam_chain_worker_block_dispatch_total.incr(.{ .path = "single" }) catch {};
         }
         var m = msg;
         defer m.deinit();

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -442,6 +442,26 @@ pub const Handlers = struct {
         prune_forkchoice: bool,
         block_root: ?types.Root,
     ) void,
+    /// Batched block import (PR #966). Called by the drain loop when
+    /// `outstandingDepth > BLOCK_BATCH_THRESHOLD` — coalesces up to
+    /// `BLOCK_BATCH_MAX` `.on_block` messages into one dispatch so the
+    /// XMSS aggregated-signature verify can run as ONE rayon call across
+    /// every attestation in every block (the `phase2_batch_verify` stage
+    /// that is 99% of `step="verify_signatures"` on a loaded chain — see
+    /// PR #963 instrumentation).
+    ///
+    /// `items.len >= 2` by construction (the drain only dispatches the
+    /// batched path when it pulled at least 2 messages); single-block
+    /// pops still route through `on_block` for unchanged latency on
+    /// gossip / locally-produced blocks. The handler is responsible for
+    /// deiniting each item's `signed_block` — the drain loop releases
+    /// the underlying queue slots after the handler returns but does NOT
+    /// call `Message.deinit` for batched items (the slice is built
+    /// outside the queue).
+    on_blocks_batch: *const fn (
+        ctx: *anyopaque,
+        items: []const BlockBatchItem,
+    ) void,
     on_gossip_attestation: *const fn (ctx: *anyopaque, gossip: networks.AttestationGossip) void,
     on_gossip_aggregated_attestation: *const fn (ctx: *anyopaque, agg: types.SignedAggregatedAttestation) void,
     process_pending_blocks: *const fn (ctx: *anyopaque, current_slot: types.Slot) void,
@@ -479,6 +499,32 @@ pub const DEFAULT_AGGREGATED_ATTESTATION_QUEUE_CAPACITY: usize = 512;
 /// iteration instead of one (reduces backlog under devnet bursts).
 pub const AGGREGATED_ATTESTATION_BATCH_THRESHOLD: usize = 16;
 pub const AGGREGATED_ATTESTATION_BATCH_MAX: usize = 32;
+
+/// When outstanding block-queue depth exceeds this, the worker drains
+/// up to `BLOCK_BATCH_MAX` `.on_block` messages and dispatches them
+/// through the batched handler `Handlers.on_blocks_batch`. At depth ≤
+/// threshold the loop falls back to the single-block path so latency
+/// stays bounded for gossip / locally-produced blocks (which are the
+/// dominant case at steady state — head-aligned nodes rarely see
+/// queue depth >1).
+///
+/// Tuned to match `BLOCKS_BY_RANGE_SYNC_THRESHOLD = 4` so a single
+/// catch-up sweep can produce a full batch worth coalescing. Threshold
+/// is 2 (not 1) so a stray solo block doesn't trigger the batched
+/// path; with threshold 2 we batch only when ≥2 blocks are actually
+/// queued.
+pub const BLOCK_BATCH_THRESHOLD: usize = 2;
+pub const BLOCK_BATCH_MAX: usize = 4;
+
+/// One block's payload in a batched `Handlers.on_blocks_batch` call.
+/// Fields mirror the `Message.on_block` variant — see its doc comment
+/// for the ownership contract on `signed_block` (transferred from the
+/// producer; the handler is responsible for deiniting).
+pub const BlockBatchItem = struct {
+    signed_block: types.SignedBlock,
+    prune_forkchoice: bool,
+    block_root: ?types.Root,
+};
 
 /// Owns the chain-worker thread, the bounded queues, and a stop flag.
 ///
@@ -823,7 +869,68 @@ pub const ChainWorker = struct {
 
             // Block queue stays first (highest priority), but each loop also
             // gives raw and aggregated attestations one dispatch opportunity.
-            if (self.block_queue.tryRecv()) |msg| {
+            //
+            // PR #966: when outstanding block depth > BLOCK_BATCH_THRESHOLD,
+            // drain up to BLOCK_BATCH_MAX `.on_block` messages and dispatch
+            // them through the batched handler so the XMSS verify runs as
+            // ONE rayon call across all attestations in all blocks. Below
+            // threshold we keep the single-block path so latency for gossip
+            // / locally-produced blocks (the dominant case at steady state)
+            // is unchanged.
+            //
+            // Mirrors the `aggregated_attestation_queue` batching pattern
+            // a few lines below — same depth-vs-threshold gate, same
+            // bounded drain.
+            const block_depth = self.block_queue.outstandingDepth();
+            const should_batch = block_depth > BLOCK_BATCH_THRESHOLD;
+            if (should_batch) {
+                var batch: [BLOCK_BATCH_MAX]BlockBatchItem = undefined;
+                var batch_len: usize = 0;
+                // Collect up to BLOCK_BATCH_MAX `.on_block` messages.
+                // Other message variants (rare on this queue) drop us out
+                // of batched collection and dispatch single-block to keep
+                // ordering semantics identical to today's loop.
+                while (batch_len < BLOCK_BATCH_MAX) : (batch_len += 1) {
+                    const popped = self.block_queue.tryRecv() orelse break;
+                    switch (popped) {
+                        .on_block => |payload| {
+                            batch[batch_len] = .{
+                                .signed_block = payload.signed_block,
+                                .prune_forkchoice = payload.prune_forkchoice,
+                                .block_root = payload.block_root,
+                            };
+                        },
+                        else => {
+                            // Non-on_block variant. Flush whatever we
+                            // batched so far, then dispatch this one
+                            // single-shot for unchanged semantics.
+                            if (batch_len > 0) {
+                                self.dispatchBlocksBatch(batch[0..batch_len]);
+                                var i: usize = 0;
+                                while (i < batch_len) : (i += 1) {
+                                    self.block_queue.markProcessed();
+                                }
+                                self.recordBlockQueueDepth();
+                                batch_len = 0;
+                            }
+                            self.dispatch(popped);
+                            self.block_queue.markProcessed();
+                            self.recordBlockQueueDepth();
+                            dispatched_any = true;
+                            break;
+                        },
+                    }
+                }
+                if (batch_len > 0) {
+                    self.dispatchBlocksBatch(batch[0..batch_len]);
+                    var i: usize = 0;
+                    while (i < batch_len) : (i += 1) {
+                        self.block_queue.markProcessed();
+                    }
+                    self.recordBlockQueueDepth();
+                    dispatched_any = true;
+                }
+            } else if (self.block_queue.tryRecv()) |msg| {
                 self.dispatch(msg);
                 self.block_queue.markProcessed();
                 self.recordBlockQueueDepth();
@@ -941,7 +1048,30 @@ pub const ChainWorker = struct {
     /// frees any heap-owned payload — the worker remains the sole
     /// owner from `tryRecv` through handler return, regardless of
     /// whether the handler succeeded or threw internally.
+    /// Batched-block dispatch. Releases each item's `signed_block` after
+    /// the handler returns — the handler treats the slice as borrowed
+    /// for the call duration (mirrors `dispatch`'s `defer m.deinit()`
+    /// shape, just lifted across N items).
+    fn dispatchBlocksBatch(self: *Self, items: []const BlockBatchItem) void {
+        defer for (items) |item| {
+            var sb = item.signed_block;
+            sb.deinit();
+        };
+        const h = self.handlers orelse {
+            self.logger.warn(
+                "chain-worker: dropping batched on_blocks_batch ({d} items, no handlers wired)",
+                .{items.len},
+            );
+            return;
+        };
+        zeam_metrics.metrics.lean_chain_worker_block_dispatch_total.incr(.{ .path = "batch" }) catch {};
+        h.on_blocks_batch(h.ctx, items);
+    }
+
     fn dispatch(self: *Self, msg: Message) void {
+        if (msg == .on_block) {
+            zeam_metrics.metrics.lean_chain_worker_block_dispatch_total.incr(.{ .path = "single" }) catch {};
+        }
         var m = msg;
         defer m.deinit();
         const h = self.handlers orelse {

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -193,13 +193,39 @@ pub const ValidatorClient = struct {
                 self.logger.info("attesting for slot={d} with no peers (self-import only)", .{slot});
             },
             .behind_peers => |info| {
-                self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
-                    slot,
-                    info.head_slot,
-                    info.finalized_slot,
-                    info.max_peer_finalized_slot,
-                });
-                return null;
+                // Pre-finalization cold-start exception: when BOTH our own
+                // finalized slot AND the best peer's finalized slot are 0,
+                // the `behind_peers` signal is coming from
+                // `isWallHeadLagSyncing` (`blocks_by_range_sync.zig:72`),
+                // which fires as soon as `wall_head_lag >= 4` on a fresh
+                // chain. Refusing to attest in that state is the wrong
+                // response — attestations on the best-current-head are
+                // exactly what fork choice needs to accumulate weight,
+                // reach supermajority, and produce the FIRST justified
+                // checkpoint. Without attestations, finalized_slot stays
+                // 0 forever, the wall-lag check keeps firing, and the
+                // chain never finalises (observed on PR #966 deploy:
+                // head frozen at slot 316 while wall clock at 505+,
+                // 100% of attestation production gated out).
+                //
+                // Once any finalization has happened (ours OR a peer's),
+                // `behind_peers` is reverting to its proper meaning —
+                // deep-sync, where attesting on an old head would be
+                // wasted weight — so we resume gating.
+                if (info.finalized_slot == 0 and info.max_peer_finalized_slot == 0) {
+                    self.logger.info(
+                        "behind_peers but pre-finalization (finalized_slot=0, max_peer_finalized_slot=0): attesting on current head_slot={d} to help reach first justification",
+                        .{info.head_slot},
+                    );
+                } else {
+                    self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d})", .{
+                        slot,
+                        info.head_slot,
+                        info.finalized_slot,
+                        info.max_peer_finalized_slot,
+                    });
+                    return null;
+                }
             },
         }
 

--- a/pkgs/state-transition/src/lib.zig
+++ b/pkgs/state-transition/src/lib.zig
@@ -13,6 +13,8 @@ pub const StateTransitionError = transition.StateTransitionError;
 pub const StateTransitionOpts = transition.StateTransitionOpts;
 pub const verifySignatures = transition.verifySignatures;
 pub const verifySignaturesParallel = transition.verifySignaturesParallel;
+pub const verifySignaturesParallelMultiBlock = transition.verifySignaturesParallelMultiBlock;
+pub const VerifyMultiBlockTask = transition.VerifyMultiBlockTask;
 pub const verifySingleAttestation = transition.verifySingleAttestation;
 
 const mockImport = @import("./mock.zig");
@@ -59,6 +61,128 @@ test "apply transition on mocked chain" {
     var post_state_root: [32]u8 = undefined;
     try zeam_utils.hashTreeRoot(types.BeamState, beam_state, &post_state_root, allocator);
     try std.testing.expect(std.mem.eql(u8, &post_state_root, &mock_chain.blocks[mock_chain.blocks.len - 1].block.state_root));
+}
+
+test "verifySignaturesParallelMultiBlock: K=1 delegates to single-block path" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    // 2-block mock chain (genesis + slot 1) so we have one real signed block.
+    const mock_chain = try genMockChain(allocator, 2, null);
+    const signed_block = mock_chain.blocks[1];
+    const state = mock_chain.genesis_state;
+
+    var block_root: [32]u8 = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &block_root, allocator);
+
+    // Single-element batch must produce the same result as calling
+    // verifySignaturesParallel directly. We rely on the K=1 branch in
+    // verifySignaturesParallelMultiBlock to forward to the single-block
+    // path; if the batch path were taken for K=1 it would still pass
+    // here, so this test guards the call shape rather than correctness
+    // alone.
+    const tasks = [_]VerifyMultiBlockTask{
+        .{
+            .state = &state,
+            .signed_block = &signed_block,
+            .precomputed_block_root = &block_root,
+        },
+    };
+    try verifySignaturesParallelMultiBlock(allocator, &tasks, null, {});
+}
+
+test "verifySignaturesParallelMultiBlock: K>1 happy path across chain blocks" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    // 4-block mock chain — gives us 3 signed blocks (slots 1..3) to batch.
+    const mock_chain = try genMockChain(allocator, 4, null);
+    try std.testing.expect(mock_chain.blocks.len == 4);
+
+    // For each signed block, the verify input is its PARENT state — i.e.
+    // the state right before that block was applied. We need to roll the
+    // mock state forward as we go to compute per-block parent states.
+    // Use heap allocations because the task slice holds pointers.
+    var parent_states = try allocator.alloc(types.BeamState, mock_chain.blocks.len - 1);
+    var roots = try allocator.alloc([32]u8, mock_chain.blocks.len - 1);
+    var beam_state = mock_chain.genesis_state;
+
+    var zeam_logger_config = zeam_utils.getTestLoggerConfig();
+    const module_logger = zeam_logger_config.logger(.state_transition);
+
+    for (1..mock_chain.blocks.len) |i| {
+        // parent_states[i-1] is the state BEFORE applying block i.
+        parent_states[i - 1] = try zeam_utils.clone(types.BeamState, &beam_state, allocator);
+        try zeam_utils.hashTreeRoot(types.BeamBlock, mock_chain.blocks[i].block, &roots[i - 1], allocator);
+        // Roll forward for the next iteration's parent_state.
+        try apply_transition(allocator, &beam_state, mock_chain.blocks[i].block, .{ .logger = module_logger });
+    }
+
+    var tasks: std.ArrayList(VerifyMultiBlockTask) = .empty;
+    defer tasks.deinit(allocator);
+    for (1..mock_chain.blocks.len) |i| {
+        try tasks.append(allocator, .{
+            .state = &parent_states[i - 1],
+            .signed_block = &mock_chain.blocks[i],
+            .precomputed_block_root = &roots[i - 1],
+        });
+    }
+
+    try verifySignaturesParallelMultiBlock(allocator, tasks.items, null, {});
+}
+
+test "verifySignaturesParallelMultiBlock: K=0 is a no-op" {
+    const tasks: []const VerifyMultiBlockTask = &.{};
+    try verifySignaturesParallelMultiBlock(std.testing.allocator, tasks, null, {});
+}
+
+test "verifySignaturesParallelMultiBlock: structural mismatch (attestations.len != signature_proofs.len) errors before any verify" {
+    var arena_allocator = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_allocator.deinit();
+    const allocator = arena_allocator.allocator();
+
+    const mock_chain = try genMockChain(allocator, 2, null);
+    var signed_block = mock_chain.blocks[1];
+    const state = mock_chain.genesis_state;
+
+    // Force a structural mismatch by adding a phantom attestation without
+    // its signature group. The pre-flight check in
+    // verifySignaturesParallelMultiBlock should reject this before
+    // touching the rayon batch.
+    const phantom_att = types.AggregatedAttestation{
+        .data = .{
+            .slot = 1,
+            .head = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+            .source = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+            .target = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+        },
+        .aggregation_bits = try types.AggregationBits.init(allocator),
+    };
+    try signed_block.block.body.attestations.append(phantom_att);
+
+    var block_root: [32]u8 = undefined;
+    try zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &block_root, allocator);
+
+    const tasks = [_]VerifyMultiBlockTask{
+        .{
+            .state = &state,
+            .signed_block = &signed_block,
+            .precomputed_block_root = &block_root,
+        },
+        // K=2 so we go through the batched path (K=1 would delegate to
+        // the single-block function and that has its own coverage).
+        .{
+            .state = &state,
+            .signed_block = &signed_block,
+            .precomputed_block_root = &block_root,
+        },
+    };
+    try std.testing.expectError(
+        types.StateTransitionError.InvalidBlockSignatures,
+        verifySignaturesParallelMultiBlock(allocator, &tasks, null, {}),
+    );
 }
 
 test "genStateBlockHeader" {

--- a/pkgs/state-transition/src/transition.zig
+++ b/pkgs/state-transition/src/transition.zig
@@ -336,6 +336,233 @@ pub fn verifySignaturesParallel(
     stage_watch.lap("proposer_xmss_verify");
 }
 
+/// One block's worth of work in a multi-block batched verify. The caller
+/// gathers a slice of these for one rayon Phase-2 call.
+///
+/// `state` is the parent state for this block (its validator set is used
+/// for the pubkey lookup). `precomputed_block_root` MUST be supplied —
+/// the batched path is the catch-up hot path, where chain.onBlock has
+/// already computed the root; re-hashing the block per task would defeat
+/// the point of batching. (The single-block API still accepts `null` for
+/// callers that legitimately don't have it.)
+pub const VerifyMultiBlockTask = struct {
+    state: *const types.BeamState,
+    signed_block: *const types.SignedBlock,
+    precomputed_block_root: *const [32]u8,
+};
+
+/// Multi-block batched signature verification. Targets the
+/// `phase2_batch_verify` cost which is 99% of `verify_signatures` on a
+/// loaded chain (see PR #963 instrumentation): coalescing all attestation
+/// proofs from K blocks into one rayon call amortizes per-call FFI +
+/// scheduling overhead and gives the parallel pool more concurrent work
+/// to schedule across cores.
+///
+/// Phase 1 (serial): for each block, validates indices and warms the
+///                   pubkey_cache, accumulating tasks into a single
+///                   contiguous batch.
+/// Phase 2 (parallel): single rayon call across the accumulated tasks.
+/// Proposer signatures: per-block xmss.verifySsz, serial (one XMSS verify
+///                     each — small enough not to be worth batching).
+///
+/// On any failure the entire function returns an error; the caller is
+/// responsible for the per-block fallback if it needs to identify which
+/// block carried the bad signature.
+///
+/// Single-block callers should keep using `verifySignaturesParallel`;
+/// this function delegates to it for the K=1 case (no batching benefit).
+pub fn verifySignaturesParallelMultiBlock(
+    allocator: Allocator,
+    tasks: []const VerifyMultiBlockTask,
+    pubkey_cache: ?*xmss.PublicKeyCache,
+    thread_pool: anytype,
+) !void {
+    if (tasks.len == 0) return;
+    if (tasks.len == 1) {
+        // K=1 has no batching upside; route through the existing path so
+        // single-block callers (gossip, locally-produced blocks) keep the
+        // same stage-histogram labels and metric semantics.
+        return verifySignaturesParallel(
+            allocator,
+            tasks[0].state,
+            tasks[0].signed_block,
+            pubkey_cache,
+            thread_pool,
+            tasks[0].precomputed_block_root,
+        );
+    }
+
+    // Reuse the same stage-watch shape the single-block path uses so
+    // dashboards can stack the labels and confirm they sum to
+    // `step="verify_signatures_multiblock"` (set at the chain layer).
+    // We record stages under the same `zeam_stf_verify_signatures_stage_duration_seconds`
+    // histogram; the multi-block path simply observes once per batch
+    // (not once per block) — sum is total batch wall-clock, count is
+    // total batches.
+    const VerifyStageWatch = struct {
+        anchor_ns: i128,
+        fn init() @This() {
+            return .{ .anchor_ns = zeam_utils.monotonicTimestampNs() };
+        }
+        fn lap(self: *@This(), comptime stage: []const u8) void {
+            const now_ns = zeam_utils.monotonicTimestampNs();
+            const elapsed_ns: i128 = if (now_ns >= self.anchor_ns) now_ns - self.anchor_ns else 0;
+            const elapsed_s: f32 = @as(f32, @floatFromInt(elapsed_ns)) / @as(f32, @floatFromInt(std.time.ns_per_s));
+            zeam_metrics.metrics.zeam_stf_verify_signatures_stage_duration_seconds.observe(
+                .{ .stage = stage },
+                elapsed_s,
+            ) catch {};
+            self.anchor_ns = now_ns;
+        }
+    };
+    var stage_watch = VerifyStageWatch.init();
+
+    // Observe batch size so dashboards can correlate the per-call cost
+    // with how many blocks we managed to coalesce. The histogram is
+    // initialised below in PR #964 (this PR); a separate counter tracks
+    // batch vs single-block dispatch from the chain-worker side.
+    zeam_metrics.zeam_stf_verify_signatures_batch_size.record(
+        @floatFromInt(tasks.len),
+    );
+
+    // Single scratch arena spans all blocks: per-block tasks, public-key
+    // handle arrays, and (when pubkey_cache is absent) pubkey wrappers
+    // all live here and are freed in one shot after Phase 2 returns.
+    var scratch = std.heap.ArenaAllocator.init(allocator);
+    defer scratch.deinit();
+    const scratch_alloc = scratch.allocator();
+
+    // Pubkey wrappers (only used when no cache is provided) carry Rust
+    // handles that need explicit deinit on the way out. List storage
+    // lives in scratch.
+    var pubkey_wrappers: std.ArrayList(xmss.PublicKey) = .empty;
+    defer if (pubkey_cache == null) {
+        for (pubkey_wrappers.items) |*wrapper| wrapper.deinit();
+    };
+
+    // `thread_pool` is already accepted into the K=1 delegate call above.
+    // The K>1 batched path doesn't need it (rayon is invoked directly by
+    // `xmss.verifyAggregatedPayloadBatch`) — same shape as the single-block
+    // function. No further use here.
+
+    // Combined task array across all blocks. We pre-count attestations
+    // so we can allocate once.
+    var total_attestations: usize = 0;
+    for (tasks) |task| {
+        const attestations = task.signed_block.block.body.attestations.constSlice();
+        const signature_proofs = task.signed_block.signature.attestation_signatures.constSlice();
+        if (attestations.len != signature_proofs.len) {
+            return StateTransitionError.InvalidBlockSignatures;
+        }
+        total_attestations += attestations.len;
+    }
+
+    const combined_tasks = try scratch_alloc.alloc(xmss.AggregatedPayloadVerifyBatch, total_attestations);
+
+    // -------- Phase 1: serial pre-warm across all blocks --------
+    var task_idx: usize = 0;
+    for (tasks) |task| {
+        const attestations = task.signed_block.block.body.attestations.constSlice();
+        const signature_proofs = task.signed_block.signature.attestation_signatures.constSlice();
+        const validators = task.state.validators.constSlice();
+
+        for (attestations, signature_proofs) |aggregated_attestation, *signature_proof| {
+            var validator_indices = try types.aggregationBitsToValidatorIndices(&aggregated_attestation.aggregation_bits, allocator);
+            defer validator_indices.deinit(allocator);
+
+            var participant_indices = try types.aggregationBitsToValidatorIndices(&signature_proof.participants, allocator);
+            defer participant_indices.deinit(allocator);
+
+            if (validator_indices.items.len != participant_indices.items.len) {
+                return StateTransitionError.InvalidBlockSignatures;
+            }
+            for (validator_indices.items, participant_indices.items) |att_idx, proof_idx| {
+                if (att_idx != proof_idx) {
+                    return StateTransitionError.InvalidBlockSignatures;
+                }
+            }
+
+            const public_keys = try scratch_alloc.alloc(*const xmss.HashSigPublicKey, validator_indices.items.len);
+
+            for (validator_indices.items, 0..) |validator_index, j| {
+                if (validator_index >= validators.len) {
+                    return StateTransitionError.InvalidValidatorId;
+                }
+                const validator = &validators[validator_index];
+                const pubkey_bytes = validator.getAttestationPubkey();
+
+                if (pubkey_cache) |cache| {
+                    const pk_handle = cache.getOrPut(validator_index, pubkey_bytes) catch {
+                        return StateTransitionError.InvalidBlockSignatures;
+                    };
+                    public_keys[j] = pk_handle;
+                } else {
+                    const pubkey = xmss.PublicKey.fromBytes(pubkey_bytes) catch {
+                        return StateTransitionError.InvalidBlockSignatures;
+                    };
+                    public_keys[j] = pubkey.handle;
+                    try pubkey_wrappers.append(scratch_alloc, pubkey);
+                }
+            }
+
+            var message_hash: [32]u8 = undefined;
+            try zeam_utils.hashTreeRoot(types.AttestationData, aggregated_attestation.data, &message_hash, allocator);
+
+            combined_tasks[task_idx] = .{
+                .public_keys = public_keys,
+                .message_hash = message_hash,
+                .epoch = @intCast(aggregated_attestation.data.slot),
+                .agg_sig = &signature_proof.proof_data,
+            };
+            task_idx += 1;
+        }
+    }
+    std.debug.assert(task_idx == total_attestations);
+
+    stage_watch.lap("phase1_prep_multiblock");
+
+    // -------- Phase 2: ONE rayon batch verify across all blocks --------
+    if (combined_tasks.len > 0) {
+        const start_ns = zeam_utils.monotonicTimestampNs();
+        xmss.verifyAggregatedPayloadBatch(scratch_alloc, combined_tasks) catch |err| {
+            const end_ns = zeam_utils.monotonicTimestampNs();
+            const elapsed_s: f32 = @as(f32, @floatFromInt(if (end_ns >= start_ns) end_ns - start_ns else 0)) / std.time.ns_per_s;
+            zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(elapsed_s);
+            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_invalid_total.incr();
+            return err;
+        };
+        const end_ns = zeam_utils.monotonicTimestampNs();
+        const elapsed_s: f32 = @as(f32, @floatFromInt(if (end_ns >= start_ns) end_ns - start_ns else 0)) / std.time.ns_per_s;
+        const per_task_elapsed_s = elapsed_s / @as(f32, @floatFromInt(combined_tasks.len));
+        for (combined_tasks) |_| {
+            zeam_metrics.lean_pq_sig_aggregated_signatures_verification_time_seconds.record(per_task_elapsed_s);
+            zeam_metrics.metrics.lean_pq_sig_aggregated_signatures_valid_total.incr();
+        }
+    }
+
+    stage_watch.lap("phase2_batch_verify_multiblock");
+
+    // -------- Per-block proposer signatures (serial; one XMSS each) --------
+    for (tasks) |task| {
+        const validators = task.state.validators.constSlice();
+        const proposer_index: usize = @intCast(task.signed_block.block.proposer_index);
+        if (proposer_index >= validators.len) {
+            return StateTransitionError.InvalidValidatorId;
+        }
+        const proposer = &validators[proposer_index];
+        const proposal_pubkey = proposer.getProposalPubkey();
+
+        const block_epoch: u32 = @intCast(task.signed_block.block.slot);
+        try xmss.verifySsz(
+            proposal_pubkey,
+            task.precomputed_block_root,
+            block_epoch,
+            &task.signed_block.signature.proposer_signature,
+        );
+    }
+    stage_watch.lap("proposer_xmss_verify_multiblock");
+}
+
 pub fn verifySingleAttestation(
     allocator: Allocator,
     state: *const types.BeamState,

--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -2728,7 +2728,12 @@ impl Network {
                                 record_mesh_peers(self.network_id, mesh_count);
                             }
 
-                            if let gossipsub::Event::Message { message, .. } = gossipsub_event {
+                            if let gossipsub::Event::Message {
+                                propagation_source,
+                                message,
+                                ..
+                            } = gossipsub_event
+                            {
                                 // #942: do NOT decode here. The full
                                 // snappy-decompress + SSZ-deserialize + chain
                                 // dispatch (`handleMsgFromRustBridge`) used to
@@ -2758,7 +2763,23 @@ impl Network {
                                     }
                                 };
 
-                                let sender_peer_id_string = message.source.map(|p| p.to_string()).unwrap_or_else(|| "unknown_peer".to_string());
+                                // `message.source` is `Some(PeerId)` only when the message
+                                // was signed by its original publisher. zeam runs
+                                // gossipsub with `ValidationMode::Anonymous`, which means
+                                // signed_messages are disabled and `message.source` is
+                                // ALWAYS `None`. Previously we logged the literal string
+                                // "unknown_peer" in that case, which destroyed our
+                                // ability to attribute byte-corrupt arrivals to a
+                                // specific upstream peer (#942 — we couldn't tell
+                                // which client was forwarding the malformed snappy).
+                                // Fall back to `propagation_source` — the peer who
+                                // actually handed us these bytes on this hop — which
+                                // is always populated by libp2p-gossipsub. This is the
+                                // peer we can score, disconnect, or report upstream.
+                                let sender_peer_id_string = message
+                                    .source
+                                    .map(|p| p.to_string())
+                                    .unwrap_or_else(|| propagation_source.to_string());
                                 let sender_peer_id = match CString::new(sender_peer_id_string.as_str()) {
                                     Ok(cstring) => cstring,
                                     Err(_) => {


### PR DESCRIPTION
## Summary

Four commits, one PR. End-to-end batched-XMSS-verify-across-blocks (stages 1–3 + metric rename) plus a small diagnostic fix that surfaces the real peer_id on #942 gossip-decode failures (cherry-picked from #967, which is now closed).

## Commits

| # | Commit | Layer |
|-|-|-|
| 1 | \`a9c3853c\` | \`stf.verifySignaturesParallelMultiBlock\` API + batch-size histogram + 3 new stage labels |
| 2 | \`248d6aa4\` | \`chain.onBlocksBatch\` + \`preVerified\` opt on \`onBlock\` |
| 3 | \`487c9081\` | Chain-worker drain coalesces ≥2 \`.on_block\` messages → batched dispatch |
| 4 | \`d9ad5f4d\` | metric rename: \`lean_chain_worker_block_dispatch_total\` → \`zeam_chain_worker_block_dispatch_total\` |
| 5 | \`57c4bae2\` | libp2p-glue: log \`propagation_source\` instead of \`"unknown_peer"\` on gossip decode failures (#942) |

## Part 1 — Batched XMSS verify (commits 1–4)

### Devnet data motivating this (PR #963 deployed image)

| Stage inside \`step="verify_signatures"\` | Mean per block | Share |
|-|-|-|
| **\`phase2_batch_verify\` (rayon XMSS)** | **147 ms** | **99.0%** |
| \`proposer_xmss_verify\` | 1.3 ms | 0.9% |
| \`phase1_prep\` | 0.1 ms | 0.07% |
| \`proposer_block_root\` (after #963 \`e795c0a3\` fix) | 3.6 μs | 0.002% |

A 4-block sync sweep is 4 × ~150 ms ≈ 600 ms of wall-clock verify work today, all of it inside one block at a time. Batching means **one rayon call** across every attestation in all 4 blocks — same parallel pool, 4× the concurrent work to schedule.

### Stage 1 — new \`stf\` API (commit 1)

\`\`\`zig
pub const VerifyMultiBlockTask = struct {
    state: *const types.BeamState,
    signed_block: *const types.SignedBlock,
    precomputed_block_root: *const [32]u8,
};

pub fn verifySignaturesParallelMultiBlock(
    allocator: Allocator,
    tasks: []const VerifyMultiBlockTask,
    pubkey_cache: ?*xmss.PublicKeyCache,
    thread_pool: anytype,
) !void
\`\`\`

- Phase 1 (serial): per-block pubkey-cache warm + index check + message-hash compute, accumulating tasks into one batch.
- Phase 2 (parallel): **ONE** rayon call across the combined batch.
- Proposer signatures: K serial \`xmss.verifySsz\` (single XMSS each — too small to batch).
- K=1 fast-path delegates to the existing \`verifySignaturesParallel\` so single-block callers (gossip, locally-produced blocks) keep identical metric labels and behaviour.
- \`precomputed_block_root\` REQUIRED on the multi-block path so we don't re-introduce the duplicated \`hashTreeRoot(BeamBlock)\` that PR #963's \`e795c0a3\` fix eliminated.

New metrics:
- \`zeam_stf_verify_signatures_stage_duration_seconds{stage="phase1_prep_multiblock" | "phase2_batch_verify_multiblock" | "proposer_xmss_verify_multiblock"}\`
- \`zeam_stf_verify_signatures_batch_size\` (buckets 1, 2, 4, 8, 16, 32)

### Stage 2 — \`chain.onBlocksBatch\` (commit 2)

\`\`\`zig
pub const BatchBlockResult = struct { missing_roots: ?[]types.Root };

pub fn onBlocksBatch(
    self: *Self,
    signedBlocks: []const types.SignedBlock,
    block_roots: []const types.Root,
    pruneForkchoice: bool,
) ![]BatchBlockResult
\`\`\`

1. Look up FIRST block's parent state (sufficient — lean consensus validator set is fixed at genesis, so pubkeys are identical across all parent states).
2. Build K \`VerifyMultiBlockTask\` entries.
3. ONE \`stf.verifySignaturesParallelMultiBlock\` call.
4. Per-block sequential STF via the regular \`onBlock\` path with new opts flag \`preVerified = true\` — skips the duplicated verify call inside \`onBlock\` while every other invariant (STF, fork choice, persistence) stays unchanged.

Failure handling: if the batched verify returns \`InvalidBlockSignatures\`, falls back to per-block \`onBlock(.{ preVerified = false })\` so valid blocks still import and only the bad block fails individually.

K=0 → empty slice. K=1 → routes through \`onBlock\` for identical semantics.

\`onBlock\` opts addition: \`preVerified: bool = false\` on \`CachedProcessedBlockInfo\`. Set ONLY by \`onBlocksBatch\`; bare callers leave it false.

### Stage 3 — chain-worker drain (commit 3)

\`\`\`
if (block_queue.outstandingDepth() > BLOCK_BATCH_THRESHOLD) {
    collect up to BLOCK_BATCH_MAX .on_block messages
    dispatch via on_blocks_batch vtable        ← NEW
} else {
    one .on_block via on_block vtable           ← existing single-block path
}
\`\`\`

| Constant | Value | Why |
|-|-|-|
| \`BLOCK_BATCH_THRESHOLD\` | **2** | Below this, latency-sensitive gossip / locally-produced blocks keep going through the single-block path. |
| \`BLOCK_BATCH_MAX\` | **4** | Matches \`BLOCKS_BY_RANGE_SYNC_THRESHOLD\` — a single catch-up sweep fills the batch exactly. |

Non-\`.on_block\` variants encountered mid-collection flush the partial batch and route through single-shot dispatch for ordering fidelity. \`markProcessed()\` called once per popped message.

New thunk \`chainWorkerOnBlocksBatchThunk\`: calls \`chain.onBlocksBatch\`, runs per-block bookkeeping (\`onBlockFollowup\` + \`replayPendingAttestations\` + \`imported_block\` backchannel) once per block in iteration order.

New counter: \`zeam_chain_worker_block_dispatch_total{path="single" | "batch"}\` — proves whether batching engaged.

### Stage 4 — metric prefix correction (commit 4)

Renamed from \`lean_chain_worker_block_dispatch_total\` to \`zeam_chain_worker_block_dispatch_total\`. \`lean_*\` is reserved for protocol-shape metrics; this counter measures a zeam implementation detail (drain-loop dispatch decision) with no analogue in other lean clients.

### Known trade-off in the batched dispatch path

TOCTOU rejection paths (\`MissingPreState\` / \`PreFinalizedSlot\`) that the single-block thunk routes to the \`rejected_block\` callback are NOT exercised from the batched thunk: \`onBlocksBatch\` swallows per-block failures into \`missing_roots = null\` so we lose the error tag. Acceptable because:
1. The TOCTOU window is narrow (the producer just checked \`hasBlock(parent)\` under a shared lock).
2. Gossip-rate blocks at queue depth ≤ threshold still go through the single-block thunk with full TOCTOU.
3. Catch-up blocks (where this PR helps most) rarely hit TOCTOU.

## Part 2 — #942 peer_id attribution (commit 5)

Pulled in from PR #967 (now closed) so it ships alongside this work.

The decode-failure log at \`pkgs/network/src/ethlibp2p.zig:638\` prints \`from peer={sender_peer_id_slice}\` — and that slice has been uniformly \`"unknown_peer"\` because of this on the Rust side (\`rust/libp2p-glue/src/lib.rs:2761\`):

\`\`\`rust
let sender_peer_id_string = message.source
    .map(|p| p.to_string())
    .unwrap_or_else(|| "unknown_peer".to_string());
\`\`\`

\`message.source\` is \`Some(PeerId)\` only when the gossip message is signed by its original publisher. zeam runs gossipsub with \`ValidationMode::Anonymous\`, which disables signed messages — so \`message.source\` is ALWAYS \`None\`, and the literal "unknown_peer" string ended up in every \`error.Corrupt\` log entry.

That destroyed our ability to attribute byte-corrupt arrivals to a specific upstream peer. Today's investigation revealed:
- ~14 corrupt/min/node, fleet-wide
- **Byte-identical corrupted payloads on every zeam node** (same SHA across 4 nodes for the same timestamp) — not local buffer aliasing, deterministic from somewhere upstream
- Python reference snappy ALSO rejects the bytes → genuinely malformed snappy, not a zig-snappy edge case
- But the network keeps progressing → other clients accept these bytes → some producer is emitting non-conformant snappy that lenient decoders accept

### Fix

When \`message.source\` is \`None\`, fall back to \`propagation_source\` — the peer who handed us these bytes on this hop. \`propagation_source\` is always populated by libp2p-gossipsub (it's the immediate forwarder), so we always have a real peer_id (\`"16Uiu2HAm..."\` form) in the log now.

Trade-off: \`propagation_source\` is the FORWARDER, not the original producer (the publisher's identity is genuinely unrecoverable under Anonymous mode). But every byte-identical corrupt arrival traces back through some forwarding hop, and now we can score / disconnect / report that specific peer instead of guessing "unknown_peer".

## Expected impact

| Workload | Before | After (K=4) |
|-|-|-|
| 4-block sync sweep verify wall-clock | ~600 ms (4 × 150 ms) | **~150 ms** (one rayon call) |
| Catch-up rate per peer-sweep | ~7 blocks/s | **~25-30 blocks/s** |
| zeam_15-class 100-slot deficit closing time | ~30 s | **~5 s** |
| #942 corruption attribution | "from peer=unknown_peer" → useless | real peer_id → traceable to a specific client |

## Test plan

- [x] \`zig build test\` — all 350+ tests across 14 groups pass
- [x] \`cargo build -p libp2p-glue\` green for both changes
- [ ] Deploy with a fresh image; expect:
  - \`zeam_chain_worker_block_dispatch_total{path="batch"}\` to be non-zero during catch-up
  - \`zeam_stf_verify_signatures_batch_size_bucket{le="4"}\` to dominate over \`le="1"\` during catch-up
  - \`zeam_stf_verify_signatures_stage_duration_seconds_sum{stage="phase2_batch_verify_multiblock"}\` substantially less than 4× the single-block stage sum
  - lagging-node behind delta to close roughly 4× faster than today
  - \`error.Corrupt\` log lines now showing a real \`peer=16Uiu2HAm...\` for #942 attribution