### PR TITLE
libp2p-glue: log propagation_source on gossip decode failures so #942 corruption can be attributed to a specific peer

### DIFF
--- a/rust/libp2p-glue/src/lib.rs
+++ b/rust/libp2p-glue/src/lib.rs
@@ -2728,7 +2728,12 @@ impl Network {
                                 record_mesh_peers(self.network_id, mesh_count);
                             }
 
-                            if let gossipsub::Event::Message { message, .. } = gossipsub_event {
+                            if let gossipsub::Event::Message {
+                                propagation_source,
+                                message,
+                                ..
+                            } = gossipsub_event
+                            {
                                 // #942: do NOT decode here. The full
                                 // snappy-decompress + SSZ-deserialize + chain
                                 // dispatch (`handleMsgFromRustBridge`) used to
@@ -2758,7 +2763,23 @@ impl Network {
                                     }
                                 };
 
-                                let sender_peer_id_string = message.source.map(|p| p.to_string()).unwrap_or_else(|| "unknown_peer".to_string());
+                                // `message.source` is `Some(PeerId)` only when the message
+                                // was signed by its original publisher. zeam runs
+                                // gossipsub with `ValidationMode::Anonymous`, which means
+                                // signed_messages are disabled and `message.source` is
+                                // ALWAYS `None`. Previously we logged the literal string
+                                // "unknown_peer" in that case, which destroyed our
+                                // ability to attribute byte-corrupt arrivals to a
+                                // specific upstream peer (#942 — we couldn't tell
+                                // which client was forwarding the malformed snappy).
+                                // Fall back to `propagation_source` — the peer who
+                                // actually handed us these bytes on this hop — which
+                                // is always populated by libp2p-gossipsub. This is the
+                                // peer we can score, disconnect, or report upstream.
+                                let sender_peer_id_string = message
+                                    .source
+                                    .map(|p| p.to_string())
+                                    .unwrap_or_else(|| propagation_source.to_string());
                                 let sender_peer_id = match CString::new(sender_peer_id_string.as_str()) {
                                     Ok(cstring) => cstring,
                                     Err(_) => {


### PR DESCRIPTION
## Summary

The decode-failure log at \`pkgs/network/src/ethlibp2p.zig:638\` prints \`from peer={sender_peer_id_slice}\` — and that slice has been uniformly \`"unknown_peer"\` because of this on the Rust side (\`rust/libp2p-glue/src/lib.rs:2761\`):

\`\`\`rust
let sender_peer_id_string = message.source
    .map(|p| p.to_string())
    .unwrap_or_else(|| "unknown_peer".to_string());
\`\`\`

\`message.source\` is \`Some(PeerId)\` only when the gossip message is signed by its original publisher. zeam runs gossipsub with \`ValidationMode::Anonymous\`, which disables signed messages — so **\`message.source\` is ALWAYS \`None\`**, and the literal "unknown_peer" string ended up in every \`error.Corrupt\` log entry.

That destroyed our ability to attribute byte-corrupt arrivals to a specific upstream peer. Today's investigation revealed:
- ~14 corrupt/min/node, fleet-wide
- **Byte-identical corrupted payloads on every zeam node** (same SHA across 4 nodes for the same timestamp) — not local buffer aliasing, deterministic from somewhere upstream
- Python reference snappy ALSO rejects the bytes → genuinely malformed snappy, not a zig-snappy edge case
- But the network keeps progressing → other clients accept these bytes → some producer is emitting non-conformant snappy that lenient decoders accept

To localize the producer (or at least the immediate forwarder of the bad bytes) we need a real peer_id in the log.

## Fix

When \`message.source\` is \`None\`, fall back to \`propagation_source\` — the peer who handed us these bytes on this hop. \`propagation_source\` is always populated by libp2p-gossipsub (it's the immediate forwarder), so we always have a real peer_id (\`"16Uiu2HAm..."\` form) in the log now.

\`\`\`rust
if let gossipsub::Event::Message {
    propagation_source,   // ← now captured (was discarded by ..)
    message,
    ..
} = gossipsub_event
{
    ...
    let sender_peer_id_string = message
        .source
        .map(|p| p.to_string())
        .unwrap_or_else(|| propagation_source.to_string());  // ← was "unknown_peer"
}
\`\`\`

## Trade-off

\`propagation_source\` is the FORWARDER, not the original producer (the publisher's identity is genuinely unrecoverable under Anonymous mode). For #942 attribution we want the producer, not the forwarder — but every byte-identical corrupt arrival traces back through some forwarding hop, and now we can score / disconnect / report that specific peer instead of guessing "unknown_peer". After a deploy we can correlate the peer_id with the host inventory to see which client emits the failing snappy.

## Test plan

- [x] \`cargo build -p libp2p-glue\` green (only 1 file changed, 23 insertions / 2 deletions)
- [ ] Deploy and pull a fresh dump; the \`error.Corrupt\` log should now read \`from peer=16Uiu2HAm...\` instead of \`from peer=unknown_peer\`
- [ ] Use the surfaced peer_id to identify the client family producing the failing bytes

## Related

Issue #942. Sequel to the prior memory-attribution work that showed byte-bleed across copies in the gean-era devnet — the current ream-era devnet shows a different shape (byte-identical across nodes) that this log fix is required to attribute.