### PR TITLE
node, metrics: invalid-block-roots cache to break orphan-refetch livelock (#942 follow-up)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -344,6 +344,20 @@ const Metrics = struct {
     /// `zeam_stf_verify_signatures_batch_size_count` to recover the
     /// total number of blocks that took the batched path.
     zeam_chain_worker_block_dispatch_total: ZeamChainWorkerBlockDispatchCounter,
+    /// Total roots inserted into `BeamChain.invalid_block_roots` over the
+    /// process lifetime (de-duped — a re-mark of the same root does not
+    /// increment). A sustained nonzero rate signals a peer producing
+    /// malformed blocks; pair with the cross-client logs from devnet
+    /// 2a4b7197 (ream's "Failed to deserialize AggregatedXMSS proof") to
+    /// attribute the producer.
+    zeam_chain_invalid_block_root_marked_total: ZeamChainInvalidBlockRootMarkedCounter,
+    /// Early-drops at `chain.onBlock`'s entry guard. Labeled by site:
+    /// "self" = block's own root was already cached; "parent" = cascade
+    /// from a cached parent_root (descendant-of-invalid). High and
+    /// growing hit rate indicates a peer / orphan-dependents path is
+    /// repeatedly redelivering the same known-bad root — exactly the
+    /// 12,676-chunks-per-5-min livelock observed on slot=13.
+    zeam_chain_invalid_block_root_hit_total: ZeamChainInvalidBlockRootHitCounter,
     /// Tripwire counter (zclawz review on PR #890): bumped from
     /// `chainWorkerProcessPendingBlocksThunk` whenever it returns a
     /// non-empty `missing_roots` slice. The thunk has no production
@@ -569,6 +583,14 @@ const Metrics = struct {
     const LeanChainQueueDepthGauge = metrics_lib.GaugeVec(u64, struct { queue: []const u8 });
     const LeanChainWorkerLoopItersCounter = metrics_lib.Counter(u64);
     const ZeamChainWorkerBlockDispatchCounter = metrics_lib.CounterVec(u64, struct { path: []const u8 });
+    // Invalid-block-roots cache counters (slot=13 #942 follow-up). `marked`
+    // increments once per fresh insert; `hit{site}` increments on every
+    // early-drop in `chain.onBlock` so the ratio shows how much wasted
+    // verify the cache saved. Two `site` values: "self" (block's own root
+    // was previously marked) and "parent" (cascade: parent_root was marked,
+    // so child is invalid by descent).
+    const ZeamChainInvalidBlockRootMarkedCounter = metrics_lib.Counter(u64);
+    const ZeamChainInvalidBlockRootHitCounter = metrics_lib.CounterVec(u64, struct { site: []const u8 });
     const LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter = metrics_lib.Counter(u64);
     // Refcount-distribution buckets [1, 2, 4, 8, 16, 32, +Inf]. Typical
     // value is 1 (writer-only); transient 2-4 under reader concurrency;
@@ -1191,6 +1213,8 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_chain_queue_depth = try Metrics.LeanChainQueueDepthGauge.init(allocator, io, "lean_chain_queue_depth", .{ .help = "Outstanding chain-worker messages accepted by producers but not yet fully processed or explicitly discarded during shutdown, labeled by queue (block|attestation|aggregated_attestation)." }, .{}),
         .lean_chain_worker_loop_iters_total = Metrics.LeanChainWorkerLoopItersCounter.init("lean_chain_worker_loop_iters_total", .{ .help = "Cumulative chain-worker loop iterations. External watchdogs use the delta between scrapes to detect worker stalls." }, .{}),
         .zeam_chain_worker_block_dispatch_total = try Metrics.ZeamChainWorkerBlockDispatchCounter.init(allocator, io, "zeam_chain_worker_block_dispatch_total", .{ .help = "Chain-worker block-dispatch path counter. path=\"single\" counts `.on_block` dispatches via the unbatched code path (block queue depth ≤ BLOCK_BATCH_THRESHOLD); path=\"batch\" counts `.on_blocks_batch` dispatches (one per batched call, K blocks each). Combine with zeam_stf_verify_signatures_batch_size_count to recover total blocks taken via the batched path. See PR #966." }, .{}),
+        .zeam_chain_invalid_block_root_marked_total = Metrics.ZeamChainInvalidBlockRootMarkedCounter.init("zeam_chain_invalid_block_root_marked_total", .{ .help = "Block roots inserted into the chain's invalid-block-roots cache after a deterministic-failure verify verdict (signature deserialize/verify fail, structural mismatch, proposer-sig fail). De-duped per root. Slot=13 #942 follow-up." }, .{}),
+        .zeam_chain_invalid_block_root_hit_total = try Metrics.ZeamChainInvalidBlockRootHitCounter.init(allocator, io, "zeam_chain_invalid_block_root_hit_total", .{ .help = "Early-drops at chain.onBlock's invalid-block-roots guard. site=\"self\" when the block's own root was already cached; site=\"parent\" when the cascade fires on a known-invalid parent_root. High rate signals an orphan-dependents refetch storm against a known-bad root." }, .{}),
         .lean_chain_worker_process_pending_blocks_dropped_missing_roots_total = Metrics.LeanChainWorkerProcessPendingBlocksDroppedMissingRootsCounter.init("lean_chain_worker_process_pending_blocks_dropped_missing_roots_total", .{ .help = "Tripwire (#890): non-zero only if a future worker producer dispatches `process_pending_blocks` without wiring the missing-roots backchannel. MUST stay 0 in steady state." }, .{}),
         .lean_chain_state_refcount_distribution = Metrics.LeanChainStateRefcountDistributionHistogram.init("lean_chain_state_refcount_distribution", .{ .help = "Distribution of refcount values across map-resident BeamState entries at scrape time. Typical value 1 (writer-only); transient 2-4 under reader concurrency; values >16 indicate leaked acquires." }, .{}),
         // Slice (d)/(e) of #803 — see field doc for label semantics.

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -31,6 +31,16 @@ const rc_beam_state = @import("./rc_beam_state.zig");
 const RcBeamState = rc_beam_state.RcBeamState;
 const chain_worker = @import("./chain_worker.zig");
 const blocks_by_range_sync = @import("./blocks_by_range_sync.zig");
+const invalid_block_cache = @import("./invalid_block_cache.zig");
+const InvalidBlockSet = invalid_block_cache.InvalidBlockSet;
+
+/// Bound on the in-memory invalid-block-roots cache (see
+/// `BeamChain.invalid_block_roots`). 10 000 32-byte roots ≈ 320 KB plus
+/// hashmap overhead — comfortably small. Sized large enough to cover a
+/// sustained burst of malformed blocks (e.g. the slot=13 ethlambda
+/// AggregatedXMSS deserialize failure observed on devnet 2a4b7197) without
+/// FIFO-evicting still-arriving repeats.
+const INVALID_BLOCK_CACHE_MAX_ENTRIES: usize = 10_000;
 
 const networkFactory = @import("./network.zig");
 const PeerInfo = networkFactory.PeerInfo;
@@ -296,6 +306,21 @@ pub const BeamChain = struct {
     public_key_cache: xmss.PublicKeyCache,
     // Cache for root to slot mapping to optimize block processing performance.
     root_to_slot_cache: types.RootToSlotCache,
+
+    /// Bounded set of block roots that failed verification with a
+    /// deterministic-failure error (signature deserialize/verify fail,
+    /// structural mismatch, proposer-sig fail). Reads from
+    /// `chainWorkerOnBlockThunk`'s catch arm (write) and `onBlock`'s entry
+    /// guard (read), plus the orphan-tracking path in `node.zig`.
+    ///
+    /// See `invalid_block_cache.zig` for the spec-safety rationale and the
+    /// exhaustive list of which errors are deterministic enough to insert.
+    /// Without this, a peer that keeps gossiping a malformed block (or a
+    /// later block whose parent_root chains back to one) wedges the
+    /// orphan-dependents loop into a refetch-and-fail livelock — the slot=13
+    /// `AggregatedXMSS` deserialize failure observed on devnet image
+    /// 2a4b7197 chewed ~6 MB/s of catch-up bandwidth per node.
+    invalid_block_roots: InvalidBlockSet,
     /// Optional worker pool for parallelizing CPU-bound steps (currently:
     /// attestation signature verification and `compactAttestations`). Owned
     /// by the caller (e.g. the CLI's main), not by the chain.
@@ -635,6 +660,7 @@ pub const BeamChain = struct {
             // CAS protocol and validator-set-growth caveats.
             .public_key_cache = try xmss.PublicKeyCache.init(allocator, @intCast(opts.config.genesis.numValidators())),
             .root_to_slot_cache = types.RootToSlotCache.init(allocator),
+            .invalid_block_roots = InvalidBlockSet.init(allocator, INVALID_BLOCK_CACHE_MAX_ENTRIES),
             .thread_pool = opts.thread_pool,
             // pending_blocks is the future-slot queue (issue #788). It's an
             // unmanaged ArrayList, so default-init to `.empty`; the lock
@@ -1189,6 +1215,58 @@ pub const BeamChain = struct {
                 // matches the pre-#890 chain-worker behaviour;
                 // production wires the callback in `BeamNode.init`.
             }
+
+            // Deterministic-failure classifier (slot=13 #942 follow-up).
+            // For any error category that is purely a function of the
+            // block bytes — signature deserialize/verify fail, structural
+            // mismatch, proposer-sig fail — insert the root into
+            // `invalid_block_roots` so the orphan-dependents refetch loop
+            // and any future gossip redelivery short-circuit at
+            // `onBlock`'s entry guard without re-running STF / XMSS
+            // verify.
+            //
+            // State-dependent errors (InvalidPostState, MissingPreState,
+            // PreFinalizedSlot, UnknownParentBlock, FutureSlot) are
+            // intentionally EXCLUDED — a re-org through a different
+            // ancestor could legitimately re-enable such blocks, and the
+            // pre-existing `rejected_block` callback (above) already
+            // handles the TOCTOU-shaped MissingPreState / PreFinalizedSlot
+            // cases. KnownInvalidBlock is also excluded so we don't
+            // double-count the cache hit.
+            const is_deterministic_invalid = switch (err) {
+                xmss.AggregationError.InvalidAggregateSignature,
+                types.StateTransitionError.InvalidBlockSignatures,
+                types.StateTransitionError.InvalidValidatorId,
+                BlockProcessingError.InvalidSignatureGroups,
+                BlockProcessingError.DuplicateAttestationData,
+                BlockProcessingError.TooManyAttestationData,
+                xmss.HashSigError.InvalidSignature,
+                xmss.HashSigError.VerificationFailed,
+                xmss.HashSigError.DeserializationFailed,
+                xmss.HashSigError.InvalidMessageLength,
+                => true,
+                else => false,
+            };
+            if (is_deterministic_invalid) {
+                const r_root: types.Root = block_root orelse blk: {
+                    var rr: types.Root = undefined;
+                    zeam_utils.hashTreeRoot(types.BeamBlock, signed_block.block, &rr, self.allocator) catch |hash_err| {
+                        self.logger.err(
+                            "chain-worker: invalid-block-mark skipped, root recompute failed slot={d} err={any}: {any}",
+                            .{ signed_block.block.slot, err, hash_err },
+                        );
+                        break :blk std.mem.zeroes(types.Root);
+                    };
+                    break :blk rr;
+                };
+                if (!std.mem.eql(u8, &r_root, &std.mem.zeroes(types.Root))) {
+                    self.markInvalidRoot(r_root);
+                    self.logger.warn(
+                        "chain-worker: marking root=0x{x} slot={d} as permanently invalid (err={any})",
+                        .{ &r_root, signed_block.block.slot, err },
+                    );
+                }
+            }
             self.logger.err("chain-worker: onBlock failed slot={d}: {any}", .{
                 signed_block.block.slot,
                 err,
@@ -1731,6 +1809,11 @@ pub const BeamChain = struct {
 
         // Clean up root to slot cache
         self.root_to_slot_cache.deinit();
+
+        // Drop the invalid-block-roots cache. The mutex inside is unused
+        // after chain_worker.stop() above (sole writer) and no remaining
+        // libxev path reads after deinit, so a plain deinit is safe.
+        self.invalid_block_roots.deinit();
         // Clean up any blocks that were queued waiting for the forkchoice clock
         // (each entry wraps the SignedBlock + its precomputed root).
         for (self.pending_blocks.items) |*entry| {
@@ -1758,6 +1841,26 @@ pub const BeamChain = struct {
     /// Returns the current aggregator role flag.
     pub fn isAggregator(self: *const Self) bool {
         return self.is_aggregator_enabled.load(.acquire);
+    }
+
+    /// True if `root` is the hash of a block that previously failed
+    /// verification with a deterministic-failure error. Safe to call from
+    /// any thread (libxev gossip path, chain-worker, RPC handlers). See
+    /// `invalid_block_roots` field doc + `invalid_block_cache.zig` for the
+    /// spec-safety argument.
+    pub fn isInvalidRoot(self: *Self, root: types.Root) bool {
+        return self.invalid_block_roots.contains(root);
+    }
+
+    /// Mark `root` as permanently invalid. Callers MUST restrict this to
+    /// deterministic-failure errors — see the enumeration in
+    /// `invalid_block_cache.zig`. State-dependent errors (InvalidPostState,
+    /// MissingPreState) MUST NOT call this: a future re-org through a
+    /// different ancestor could legitimately re-enable the block.
+    pub fn markInvalidRoot(self: *Self, root: types.Root) void {
+        const inserted = self.invalid_block_roots.mark(root);
+        // Plain Counter (no labels) — incr() doesn't fail, no `try`/`catch`.
+        if (inserted) zeam_metrics.metrics.zeam_chain_invalid_block_root_marked_total.incr();
     }
 
     /// Atomically flips the aggregator role and returns the previous value.
@@ -3529,6 +3632,35 @@ pub const BeamChain = struct {
                     );
                 }
             }
+        }
+
+        // Invalid-block-roots short-circuit. Cheap O(1) HashMap lookup
+        // against the bounded cache populated by `chainWorkerOnBlockThunk`
+        // when verify returned a deterministic-failure verdict. Two
+        // separate checks:
+        //
+        //   (a) this block's own root → already proven invalid; redelivery
+        //       (gossip echo, blocks_by_root refetch from a peer still
+        //       serving it) should not pay the STF/XMSS cost a second time.
+        //   (b) the parent's root → descendant-of-invalid is itself
+        //       invalid per spec (a chain rooted at an invalid block
+        //       cannot be canonical). Mark the child too so future
+        //       deliveries short-circuit on (a).
+        //
+        // Both raise `KnownInvalidBlock` so `chainWorkerOnBlockThunk`'s
+        // existing classifier sees a distinct error tag and does NOT
+        // re-mark — avoiding a metric double-count.
+        if (self.invalid_block_roots.contains(block_root)) {
+            zeam_metrics.metrics.zeam_chain_invalid_block_root_hit_total.incr(.{ .site = "self" }) catch {};
+            return BlockProcessingError.KnownInvalidBlock;
+        }
+        if (self.invalid_block_roots.contains(block.parent_root)) {
+            // Cascade. Don't goto `markInvalidRoot` (extra metric
+            // increment); inline the insert so the cascade hit is
+            // bucketed under `site="parent"` instead.
+            _ = self.invalid_block_roots.mark(block_root);
+            zeam_metrics.metrics.zeam_chain_invalid_block_root_hit_total.incr(.{ .site = "parent" }) catch {};
+            return BlockProcessingError.KnownInvalidBlock;
         }
 
         const post_state_owned = blockInfo.postState == null;
@@ -5563,6 +5695,13 @@ pub const BlockProcessingError = error{
     InvalidSignatureGroups,
     DuplicateAttestationData,
     TooManyAttestationData,
+    /// Block's hash-tree-root, or its `parent_root`, is already in the
+    /// `invalid_block_roots` cache from a prior deterministic-failure
+    /// verdict. Surfaced from `onBlock`'s entry guard so callers can
+    /// distinguish "we already proved this invalid" from a fresh verify
+    /// failure (which would itself populate the cache). Cheap-drop: STF /
+    /// XMSS verify never run on this code path.
+    KnownInvalidBlock,
 };
 const BlockProductionError = error{ NotImplemented, MissingPreState };
 const AttestationValidationError = error{

--- a/pkgs/node/src/invalid_block_cache.zig
+++ b/pkgs/node/src/invalid_block_cache.zig
@@ -1,0 +1,149 @@
+//! Bounded set of permanently-invalid block roots.
+//!
+//! See `BeamChain.invalid_block_roots` for the call-site contract and the
+//! commit log for the slot=13 devnet trace this defends against.
+//!
+//! Block validity is a deterministic predicate over the block's bytes
+//! (`hash_tree_root(block)` → unique content). Once a verifier returns a
+//! deterministic-failure verdict (signature deserialize/verify fail,
+//! structural mismatch, proposer-sig fail) for root R, refetching R will
+//! always reproduce the same verdict — caching the verdict avoids
+//! re-running the full verify on every gossip / blocks_by_root delivery.
+//!
+//! Spec-safe because:
+//!   * the spec defines block validity as `f(block_bytes)`; this cache is a
+//!     memoization of f
+//!   * fork-choice (LMD-GHOST) only chooses between *valid* heads; an
+//!     invalid block can never be on a future canonical chain, so blacklisting
+//!     does not interfere with re-orgs
+//!
+//! Caller must ONLY insert for deterministic failures:
+//!   * AggregationError.InvalidAggregateSignature
+//!   * StateTransitionError.InvalidBlockSignatures
+//!   * StateTransitionError.InvalidValidatorId
+//!   * BlockProcessingError.InvalidSignatureGroups
+//!   * BlockProcessingError.DuplicateAttestationData
+//!   * BlockProcessingError.TooManyAttestationData
+//!   * HashSigError.InvalidSignature / VerificationFailed (proposer sig)
+//!
+//! Do NOT insert for state-dependent or transient errors:
+//!   * InvalidPostState (our pre-state may be wrong; a re-org through a
+//!     different ancestor could legitimately re-enable the block)
+//!   * MissingPreState / MissingState (transient — state may arrive later)
+//!   * UnknownParentBlock / FutureSlot (transient — block ordering)
+
+const std = @import("std");
+const types = @import("@zeam/types");
+const zeam_utils = @import("@zeam/utils");
+
+pub const InvalidBlockSet = struct {
+    /// O(1) membership test.
+    roots: std.AutoHashMap(types.Root, void),
+    /// FIFO eviction order. When `roots.count() == max_entries` we drop the
+    /// front of this queue before inserting the new root, so memory is
+    /// bounded over the node's lifetime.
+    insertion_order: std.ArrayListUnmanaged(types.Root),
+    /// Single-writer (chain-worker) + multi-reader (libxev gossip/orphan
+    /// paths). Held only inside the cache methods; never co-held with any
+    /// other chain lock.
+    mutex: zeam_utils.SyncMutex = .{},
+    max_entries: usize,
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, max_entries: usize) Self {
+        return .{
+            .roots = std.AutoHashMap(types.Root, void).init(allocator),
+            .insertion_order = .empty,
+            .max_entries = max_entries,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.roots.deinit();
+        self.insertion_order.deinit(self.allocator);
+    }
+
+    /// Returns true if `root` was newly inserted, false if it was already
+    /// present (in which case `insertion_order` is left untouched — we
+    /// don't refresh recency on duplicate marks). On OOM the root is
+    /// silently dropped: the worst case is a missed dedup, not a
+    /// correctness bug.
+    pub fn mark(self: *Self, root: types.Root) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        const gop = self.roots.getOrPut(root) catch return false;
+        if (gop.found_existing) return false;
+
+        // First time we've seen this root. Enforce the cap before
+        // appending so the queue + map sizes stay in lockstep.
+        if (self.roots.count() > self.max_entries and self.insertion_order.items.len > 0) {
+            const evicted = self.insertion_order.orderedRemove(0);
+            // Don't remove `root` itself even if FIFO points at it — the
+            // caller is mid-insert. Skip eviction in that pathological
+            // case (max_entries=0); cache stays empty.
+            if (!std.mem.eql(u8, &evicted, &root)) {
+                _ = self.roots.remove(evicted);
+            } else {
+                _ = self.roots.remove(root);
+                return false;
+            }
+        }
+        self.insertion_order.append(self.allocator, root) catch {
+            // Roll back the map insert so we don't desync.
+            _ = self.roots.remove(root);
+            return false;
+        };
+        return true;
+    }
+
+    pub fn contains(self: *Self, root: types.Root) bool {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.roots.contains(root);
+    }
+
+    pub fn count(self: *Self) usize {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        return self.roots.count();
+    }
+};
+
+test "InvalidBlockSet — basic mark + contains" {
+    var set = InvalidBlockSet.init(std.testing.allocator, 4);
+    defer set.deinit();
+
+    const r1: types.Root = [_]u8{1} ** 32;
+    const r2: types.Root = [_]u8{2} ** 32;
+
+    try std.testing.expect(!set.contains(r1));
+    try std.testing.expect(set.mark(r1));
+    try std.testing.expect(set.contains(r1));
+    // Duplicate mark is a no-op.
+    try std.testing.expect(!set.mark(r1));
+    try std.testing.expectEqual(@as(usize, 1), set.count());
+
+    try std.testing.expect(set.mark(r2));
+    try std.testing.expectEqual(@as(usize, 2), set.count());
+}
+
+test "InvalidBlockSet — FIFO eviction at cap" {
+    var set = InvalidBlockSet.init(std.testing.allocator, 2);
+    defer set.deinit();
+
+    const r1: types.Root = [_]u8{1} ** 32;
+    const r2: types.Root = [_]u8{2} ** 32;
+    const r3: types.Root = [_]u8{3} ** 32;
+
+    _ = set.mark(r1);
+    _ = set.mark(r2);
+    _ = set.mark(r3); // evicts r1
+    try std.testing.expect(!set.contains(r1));
+    try std.testing.expect(set.contains(r2));
+    try std.testing.expect(set.contains(r3));
+    try std.testing.expectEqual(@as(usize, 2), set.count());
+}

--- a/pkgs/node/src/lib.zig
+++ b/pkgs/node/src/lib.zig
@@ -42,5 +42,6 @@ test "get tests" {
     _ = @import("./chain_worker.zig");
     _ = @import("./rc_beam_state.zig");
     _ = @import("./slot_driver_watchdog.zig");
+    _ = @import("./invalid_block_cache.zig");
     @import("std").testing.refAllDecls(@This());
 }

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -990,6 +990,23 @@ pub const BeamNode = struct {
     /// Safe to call from any thread that reaches the gossip/reqresp
     /// orphan-block paths; the map has its own dedicated lock.
     fn trackOrphanDependent(self: *Self, parent_root: types.Root, child_block_root: types.Root) void {
+        // Slot=13 #942 follow-up: skip the orphan-dependents entry entirely
+        // when `parent_root` has previously failed verify with a
+        // deterministic-failure verdict. The cached parent will never be
+        // importable; tracking the child would just queue a fetch that
+        // chain.onBlock would short-circuit on `KnownInvalidBlock` anyway
+        // (the parent-cascade arm). Cascade-mark the child here so any
+        // future delivery of the SAME child also short-circuits at the
+        // `site="self"` arm. Avoids the 12,676-chunks-per-5-min livelock
+        // observed against ethlambda_0's slot=13 reserve.
+        if (self.chain.isInvalidRoot(parent_root)) {
+            self.chain.markInvalidRoot(child_block_root);
+            self.logger.debug(
+                "skip tracking orphan dependent 0x{x}: parent 0x{x} is known-invalid; cascade-marked child",
+                .{ &child_block_root, &parent_root },
+            );
+            return;
+        }
         self.orphan_dependents_lock.lock();
         defer self.orphan_dependents_lock.unlock();
         const gop = self.orphan_dependents.getOrPut(parent_root) catch |err| {


### PR DESCRIPTION
## Summary

Adds a bounded FIFO-evicting set of permanently-invalid block roots on `BeamChain`. On verify failure with a deterministic-failure error (signature deserialize/verify fail, structural mismatch, proposer-sig fail), the root is inserted; subsequent deliveries short-circuit at `chain.onBlock`'s entry guard before STF/XMSS runs, both for the block's own root and for any block whose `parent_root` was previously marked (descendant-of-invalid is invalid per spec).

## Why

Devnet image `2a4b7197` (post-#966) wedged 12 of 16 zeam nodes at slot=420 with `justified=finalized=0`. Root cause: ethlambda's block at slot=13 carries a malformed `AggregatedXMSS` proof.

- zeam rejects with `error.InvalidAggregateSignature`
- ream rejects with `Attestation aggregated signature verification failed: Failed to deserialize AggregatedXMSS proof`

Same root across all peers (`parent_root=0x906d64c9…`); 50+ rejection events per node. The current orphan-dependents path then re-requests descendants forever — zeam_1 fired 12,676 `blocks_by_range` chunks in 5 min against ethlambda_0, all returning the same slot=428 child that descends from the bad slot=13 ancestor, all failing to extend `our_head` past 420.

## Spec safety

Block validity is a deterministic function of block bytes (`hash_tree_root(block)` → unique content). Caching the verdict is memoization. Fork-choice (LMD-GHOST) only picks between *valid* chains; an invalid block can never appear on any future canonical chain, so the cache cannot interfere with re-orgs.

Classifier inclusion is restricted to invariant-deterministic failures:

| Error | Cached? | Why |
|---|---|---|
| `AggregationError.InvalidAggregateSignature` | ✅ | Bytes → bool |
| `StateTransitionError.InvalidBlockSignatures` | ✅ | Bytes + validator-set-at-state → bool |
| `StateTransitionError.InvalidValidatorId` | ✅ | Bytes + validator-set-at-state → bool |
| `BlockProcessingError.InvalidSignatureGroups` | ✅ | Structural over bytes |
| `BlockProcessingError.DuplicateAttestationData` | ✅ | Structural over bytes |
| `BlockProcessingError.TooManyAttestationData` | ✅ | Structural over bytes |
| `HashSigError.{InvalidSignature, VerificationFailed, DeserializationFailed, InvalidMessageLength}` | ✅ | Proposer sig bytes |
| `InvalidPostState` | ❌ | State-dependent — pre-state may be wrong; re-org could re-enable |
| `MissingPreState` / `MissingState` | ❌ | Transient |
| `PreFinalizedSlot` | ❌ | Existing `rejected_block` callback handles it |
| `UnknownParentBlock` / `FutureSlot` | ❌ | Transient ordering, not a verdict |
| `KnownInvalidBlock` (new) | ❌ | Already cached — don't double-count |

## What changed

| File | Change |
|---|---|
| `pkgs/node/src/invalid_block_cache.zig` (new, 145 LOC) | `InvalidBlockSet` bounded FIFO set + 2 unit tests |
| `pkgs/node/src/chain.zig` (+139) | Field, init/deinit, `isInvalidRoot`/`markInvalidRoot`, `onBlock` entry guard (self + parent cascade), classifier in `chainWorkerOnBlockThunk` catch arm, new `BlockProcessingError.KnownInvalidBlock` |
| `pkgs/node/src/node.zig` (+17) | `trackOrphanDependent` skips when parent is known-invalid; cascade-marks the child |
| `pkgs/metrics/src/lib.zig` (+24) | `zeam_chain_invalid_block_root_marked_total` + `…_hit_total{site}` |
| `pkgs/node/src/lib.zig` (+1) | Wire module into the test runner |

Cache bound: 10 000 roots (~320 KB) with FIFO eviction.

## Expected devnet impact

Once deployed, the 12 wedged zeam nodes should:
- Mark the slot=13 root after their first verify fail (one log line each)
- Stop the 12,676-chunk-per-5-min `blocks_by_range` storm against the bad fork
- Drain stale orphan-dependents for the slot=13 root (no more `Re-requesting 1 orphan dependent(s)` for its descendants)
- Recover bandwidth/CPU and converge on the canonical-without-slot=13 fork that zeam_6/7/15 already follow

This does NOT fix the upstream ethlambda producer bug — that's a separate cross-client follow-up. This PR stops zeam from chasing the bad fork indefinitely.

## Test plan

- [x] `zig build` — green
- [x] `zig build test` — 202 existing + 2 new tests pass (`InvalidBlockSet — basic mark + contains`, `InvalidBlockSet — FIFO eviction at cap`)
- [ ] Deploy to devnet; verify `zeam_chain_invalid_block_root_marked_total ≥ 1` per node after a couple of restarts and `…_hit_total{site}` shows the expected high hit rate on the bad parent
- [ ] Verify wedged nodes' heads advance past 420 once the cache is populated
- [ ] Verify `justified_slot > 0` (downstream of the wedged-node count going below the 1/3 supermajority floor)