### PR TITLE
chore: bump leanMultisig multisig-glue dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -181,7 +181,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -192,7 +192,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -703,7 +703,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "backend"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -1792,7 +1792,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3100,6 +3100,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,9 +3328,10 @@ dependencies = [
 [[package]]
 name = "lean_compiler"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_vm",
  "pest",
  "pest_derive",
@@ -3324,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "lean_prover"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3333,6 +3353,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "rand 0.10.1",
+ "serde",
  "sub_protocols",
  "tracing",
  "utils",
@@ -3341,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "lean_vm"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "itertools 0.14.0",
@@ -3417,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "leansig_wrapper"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "ethereum_ssz",
@@ -4085,7 +4106,7 @@ dependencies = [
 [[package]]
 name = "mt-air"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-poly",
@@ -4094,7 +4115,7 @@ dependencies = [
 [[package]]
 name = "mt-fiat-shamir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4102,12 +4123,13 @@ dependencies = [
  "mt-utils",
  "rayon",
  "serde",
+ "tracing",
 ]
 
 [[package]]
 name = "mt-field"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-utils",
@@ -4122,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "mt-koala-bear"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4138,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "mt-poly"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-field",
@@ -4146,12 +4168,13 @@ dependencies = [
  "rand 0.10.1",
  "rayon",
  "serde",
+ "system-info",
 ]
 
 [[package]]
 name = "mt-sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-air",
  "mt-fiat-shamir",
@@ -4164,7 +4187,7 @@ dependencies = [
 [[package]]
 name = "mt-symetric"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "mt-field",
  "mt-koala-bear",
@@ -4174,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "mt-utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "serde",
 ]
@@ -4182,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "mt-whir"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "itertools 0.14.0",
  "mt-fiat-shamir",
@@ -4194,6 +4217,7 @@ dependencies = [
  "mt-utils",
  "rand 0.10.1",
  "rayon",
+ "system-info",
  "tracing",
 ]
 
@@ -4359,7 +4383,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4514,6 +4538,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -5478,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5530,7 +5579,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "p3-field 0.5.1",
  "p3-maybe-rayon 0.5.1",
@@ -5570,7 +5619,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5601,7 +5650,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5703,7 +5752,7 @@ dependencies = [
 [[package]]
 name = "p3-koala-bear"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "p3-challenger 0.5.1",
  "p3-field 0.5.1",
@@ -5733,7 +5782,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5755,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 
 [[package]]
 name = "p3-mds"
@@ -5774,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "p3-dft 0.5.1",
  "p3-field 0.5.1",
@@ -5824,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -5858,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon1"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "p3-field 0.5.1",
  "p3-mds 0.5.1",
@@ -5881,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "p3-field 0.5.1",
  "p3-mds 0.5.1",
@@ -5919,7 +5968,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "itertools 0.14.0",
  "p3-field 0.5.1",
@@ -5956,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.5.1"
-source = "git+https://github.com/Plonky3/Plonky3.git#82cfad73cd734d37a0d51953094f970c531817ec"
+source = "git+https://github.com/Plonky3/Plonky3.git#5ef05b2a75aab9024ea4e77bfdcdda75da20beec"
 dependencies = [
  "serde",
  "transpose",
@@ -6692,14 +6741,17 @@ dependencies = [
 [[package]]
 name = "rec_aggregation"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
+ "include_dir",
  "lean_compiler",
  "lean_prover",
  "lean_vm",
  "leansig_wrapper",
  "lz4_flex",
+ "objc2",
+ "objc2-foundation",
  "postcard",
  "rand 0.10.1",
  "serde",
@@ -6707,6 +6759,7 @@ dependencies = [
  "sub_protocols",
  "tracing",
  "utils",
+ "zk-alloc",
 ]
 
 [[package]]
@@ -7221,7 +7274,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7655,7 +7708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7766,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "sub_protocols"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "lean_vm",
@@ -7844,6 +7897,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-info"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "rayon",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7865,7 +7927,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8417,7 +8479,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.1.0"
-source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa#5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
 dependencies = [
  "backend",
  "tracing",
@@ -9268,6 +9330,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zk-alloc"
+version = "0.1.0"
+source = "git+https://github.com/leanEthereum/leanMultisig.git?rev=f66d4a974eced803574eb0ea43d812e523c8d7ad#f66d4a974eced803574eb0ea43d812e523c8d7ad"
+dependencies = [
+ "libc",
+ "system-info",
 ]
 
 [[package]]

--- a/rust/hashsig-glue/src/lib.rs
+++ b/rust/hashsig-glue/src/lib.rs
@@ -1,7 +1,7 @@
 // Production config (default).
 //
 // Upstream renamed `Scheme...` → `SIG...` in `lifetime_2_to_the_32` only
-// (leanSig main, pulled in via leanMultisig `5eba3b1`). The `lifetime_2_to_the_8`
+// (leanSig main, pulled in via leanMultisig `f66d4a9`). The `lifetime_2_to_the_8`
 // test module below is unchanged and still exports `Scheme...`.
 #[cfg(not(feature = "test-config"))]
 mod config {

--- a/rust/multisig-glue/Cargo.toml
+++ b/rust/multisig-glue/Cargo.toml
@@ -12,14 +12,14 @@ edition = "2021"
 #               same hardware class as the devnet aggregator hosts.
 #   - 5fbd5bf: Plonky3 PR #1600 NEON dot-product regression coverage
 #   - e5c2183: leanSig dep flipped to `main` (devnet4 merged into main)
-#   - 5eba3b1: rec_aggregation BenchmarkReport (API-additive, source of
+#   - f66d4a9: rec_aggregation BenchmarkReport (API-additive, source of
 #               the per-node breakdown that lean-bench / op tooling read)
 # Devnet operators reported ~16 sig/s on 2eb4b9d (Apr 17) vs ~37 sig/s on
-# leanMultisig benchmarks against 5eba3b1 — the 939a767 inline removal is
+# leanMultisig benchmarks against f66d4a9 — the 939a767 inline removal is
 # the dominant contributor on the prod hardware.
-rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
-leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
-backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa" }
+rec_aggregation = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
+leansig_wrapper = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
+backend = { git = "https://github.com/leanEthereum/leanMultisig.git", rev = "f66d4a974eced803574eb0ea43d812e523c8d7ad" }
 rayon = "1"
 
 [lib]

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn xmss_aggregate(
                 return std::ptr::null();
             }
             let proof_bytes = slice::from_raw_parts(proof_ptrs[i], proof_lens[i]);
-            let proof = match AggregatedXMSS::deserialize(proof_bytes) {
+            let proof = match AggregatedXMSS::decompress(proof_bytes) {
                 Some(p) => p,
                 None => return std::ptr::null(),
             };
@@ -180,13 +180,16 @@ pub unsafe extern "C" fn xmss_aggregate(
     let t_marshal_done = Instant::now();
 
     // Call rec_aggregation
-    let (_pub_keys, agg_sig) = rec_xmss_aggregate(
+    let (_pub_keys, agg_sig) = match rec_xmss_aggregate(
         &children_with_keys,
         raw_xmss,
         message_hash,
         slot,
         log_inv_rate,
-    );
+    ) {
+        Ok(result) => result,
+        Err(_) => return std::ptr::null(),
+    };
 
     let t_stark_done = Instant::now();
 
@@ -235,7 +238,7 @@ pub unsafe extern "C" fn xmss_verify_aggregated(
 
     // Deserialize aggregate signature
     let bytes = slice::from_raw_parts(agg_sig_bytes, agg_sig_len);
-    let agg_sig = match AggregatedXMSS::deserialize(bytes) {
+    let agg_sig = match AggregatedXMSS::decompress(bytes) {
         Some(sig) => sig,
         None => return false,
     };
@@ -339,7 +342,7 @@ pub unsafe extern "C" fn xmss_verify_aggregated_batch(
 
     tasks.par_iter().all(|task| {
         let sig_bytes = slice::from_raw_parts(task.sig_ptr as *const u8, task.sig_len);
-        let agg_sig = match AggregatedXMSS::deserialize(sig_bytes) {
+        let agg_sig = match AggregatedXMSS::decompress(sig_bytes) {
             Some(sig) => sig,
             None => return false,
         };
@@ -374,7 +377,7 @@ pub unsafe extern "C" fn xmss_aggregate_signature_to_bytes(
     }
 
     let agg_sig_ref = &*agg_sig;
-    let serialized = agg_sig_ref.serialize();
+    let serialized = agg_sig_ref.compress();
 
     if serialized.len() > buffer_len {
         return 0;
@@ -403,7 +406,7 @@ pub unsafe extern "C" fn xmss_aggregate_signature_from_bytes(
 
     let input_slice = slice::from_raw_parts(bytes, bytes_len);
 
-    match AggregatedXMSS::deserialize(input_slice) {
+    match AggregatedXMSS::decompress(input_slice) {
         Some(agg_sig) => Box::into_raw(Box::new(agg_sig)),
         None => std::ptr::null_mut(),
     }

--- a/rust/multisig-glue/src/lib.rs
+++ b/rust/multisig-glue/src/lib.rs
@@ -188,7 +188,10 @@ pub unsafe extern "C" fn xmss_aggregate(
         log_inv_rate,
     ) {
         Ok(result) => result,
-        Err(_) => return std::ptr::null(),
+        Err(err) => {
+            eprintln!("xmss_aggregate failed: {err}");
+            return std::ptr::null();
+        }
     };
 
     let t_stark_done = Instant::now();


### PR DESCRIPTION
## Summary
- bump `rust/multisig-glue` leanMultisig git dependencies from `5eba3b141455349d7cdbf0f5d3ccfb2e640b02aa` to `f66d4a974eced803574eb0ea43d812e523c8d7ad`
- refresh `rust/Cargo.lock` for the new leanMultisig/Plonky3 transitive pins
- adapt `multisig-glue` to upstream `AggregatedXMSS::{compress,decompress}` and fallible aggregation API
- log `xmss_aggregate` upstream `AggregationError`s before returning null to the Zig caller

## Compatibility / rollout note
This is **not** a rolling-compatible aggregate wire/proof-format bump.

The outer aggregate byte encoding is still postcard + lz4, but the payload/schema and proof internals changed between `5eba3b1` and `f66d4a9`:
- old `AggregatedXMSS`: `{ proof: Proof<F>, bytecode_point, metadata }`
- new `AggregatedXMSS`: `{ info: AggregatedXMSSInfo { without_pubkeys, pubkeys }, proof: ExecutionProof }`
- upstream also includes verifier/prover transcript and circuit changes such as Fiat-Shamir duplex sponge, bus/fingerprint changes, type-2 aggregation support, stricter decode/proof validation, and Plonky3 git rev movement (`82cfad73` -> `5ef05b2a`).

So old and new nodes should be treated as separate aggregate-protocol versions. Rollout plan: coordinated devnet cutover only; do not run a mixed aggregator fleet expecting cross-version aggregate reuse. Discard/let-prune any cached `latest_*_aggregated_payloads` from the old version during the upgrade rather than deserializing/reusing them after restart.

## Transitive lockfile audit
Expected from the upstream bump:
- leanMultisig crates move to `f66d4a9`
- Plonky3 crates remain `0.5.1` but move git rev `82cfad73` -> `5ef05b2a`
- new upstream helper deps: `include_dir`, `system-info`, `zk-alloc`, and macOS-only `objc2*` crates
- Cargo resolver also rewrites a few `windows-sys` lock references; no Linux code path impact expected

These can change prover bytes, so this PR should be merged only with the coordinated devnet/prover cutover above.

## Validation
- `cargo check -p multisig-glue`
- `cargo fmt --check`
- `zig build test` with Zig `0.16.0` (`/home/node/.local/zig/zig-x86_64-linux-0.16.0/zig`)

## Follow-up required before merge
- run hive/devnet validation for the coordinated aggregate-format cutover
