### PR TITLE
node: produce blocks during pre-finalization wall-lag stall

### DIFF
--- a/pkgs/node/src/blocks_by_range_sync.zig
+++ b/pkgs/node/src/blocks_by_range_sync.zig
@@ -67,18 +67,6 @@ pub fn shouldRefreshPeerStatus(
     return .{ .refresh = refresh, .wall_head_lag_slots = wall_head_lag_slots };
 }
 
-/// True when pre-finalization sync should report `peers_materially_ahead` based on
-/// wall-clock head lag alone (early devnets with `finalized_slot = 0`).
-pub fn isWallHeadLagSyncing(
-    our_finalized_slot: types.Slot,
-    max_peer_finalized_slot: types.Slot,
-    wall_head_lag_slots: u64,
-    threshold_slots: u64,
-) bool {
-    if (our_finalized_slot != 0 or max_peer_finalized_slot != 0) return false;
-    return wall_head_lag_slots >= threshold_slots;
-}
-
 /// Rotate a peer batch for rate-limited status refresh.
 pub fn peerBatchWindow(total_peers: usize, cursor: usize, batch_size: usize) struct {
     start: usize,
@@ -476,13 +464,6 @@ test "syncEndDecision fork abort" {
         .has_alternate_peer = true,
     };
     try std.testing.expectEqual(SyncEndAction.abort_fallback, syncEndDecision(input));
-}
-
-test "isWallHeadLagSyncing only applies before finalization" {
-    try std.testing.expect(isWallHeadLagSyncing(0, 0, 4, 4));
-    try std.testing.expect(!isWallHeadLagSyncing(0, 0, 3, 4));
-    try std.testing.expect(!isWallHeadLagSyncing(1, 0, 10, 4));
-    try std.testing.expect(!isWallHeadLagSyncing(0, 1, 10, 4));
 }
 
 test "peerBatchWindow rotates through peers" {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -30,7 +30,6 @@ const LockTimer = locking.LockTimer;
 const rc_beam_state = @import("./rc_beam_state.zig");
 const RcBeamState = rc_beam_state.RcBeamState;
 const chain_worker = @import("./chain_worker.zig");
-const blocks_by_range_sync = @import("./blocks_by_range_sync.zig");
 const invalid_block_cache = @import("./invalid_block_cache.zig");
 const InvalidBlockSet = invalid_block_cache.InvalidBlockSet;
 
@@ -4944,30 +4943,16 @@ pub const BeamChain = struct {
                 self.logger.info("aggregating for slot={d} with no peers (local only)", .{slot});
             },
             .peers_materially_ahead => |info| {
-                // Same pre-finalization cold-start exception as
-                // validator_client.mayBeDoAttestation (see its long
-                // comment). Aggregation MUST proceed when both finalized
-                // slots are 0, otherwise we never produce the first
-                // aggregated payload and the chain can't reach a first
-                // justification. Once any finalization exists the gate
-                // returns to its proper deep-sync meaning.
-                if (info.finalized_slot == 0 and info.max_peer_finalized_slot == 0) {
-                    self.logger.info(
-                        "peers_materially_ahead but pre-finalization (finalized_slot=0, max_peer_finalized_slot=0): aggregating for slot={d} on current head_slot={d} to help reach first justification",
-                        .{ slot, info.head_slot },
-                    );
-                } else {
-                    self.logBehindPeersDebug("skipping aggregation production", info);
-                    self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
-                        slot,
-                        info.head_slot,
-                        info.finalized_slot,
-                        info.max_peer_finalized_slot,
-                        info.peer_count,
-                    });
-                    zeam_metrics.metrics.lean_aggregator_skipped_total.incr(.{ .reason = "not_synced" }) catch {};
-                    return;
-                }
+                self.logBehindPeersDebug("skipping aggregation production", info);
+                self.logger.warn("skipping aggregation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
+                    slot,
+                    info.head_slot,
+                    info.finalized_slot,
+                    info.max_peer_finalized_slot,
+                    info.peer_count,
+                });
+                zeam_metrics.metrics.lean_aggregator_skipped_total.incr(.{ .reason = "not_synced" }) catch {};
+                return;
             },
         }
 
@@ -5687,19 +5672,26 @@ pub const BeamChain = struct {
         }
 
         // `peers_materially_ahead` maps to leanSpec **SYNCING** ("deep sync"). It must
-        // ONLY fire on a finalization gap; a 1-slot head delta is normal
-        // gossip latency, not deep sync, and `peers_materially_ahead` consumers
-        // (`validator_client.maybeDoProposal` / `mayBeDoAttestation`) skip
-        // proposer/attestation duties — gating those on transient head
-        // lag would silently disable validators near the head.
+        // ONLY fire on a real peer finalization gap. A pre-finalization
+        // wall-clock head lag (every node at finalized_slot=0 on a fresh
+        // devnet) is NOT deep sync — no peer is actually ahead, the
+        // chain just hasn't started yet, and reporting
+        // `peers_materially_ahead` would deadlock proposer / attester /
+        // aggregator paths (they all skip their duties on that signal,
+        // so no block is ever produced and finalization never advances).
+        //
+        // Wall-lag status-driven catch-up is still handled outside this
+        // state: `blocks_by_range_sync.shouldRefreshPeerStatus`'s
+        // `.synced` arm refreshes peer statuses whenever wall-lag
+        // exceeds the threshold, so peer head discovery still happens
+        // without flipping the high-level sync state.
         //
         // Status-driven catch-up for the head-only-gap case is handled
-        // outside this state: the `.synced` arm of `handleReqRespResponse`
-        // calls `shouldCatchUpFromPeerStatus` directly so a peer that
-        // reports a higher head triggers catch-up without changing the
-        // node's high-level sync state.
+        // similarly: the `.synced` arm of `handleReqRespResponse` calls
+        // `shouldCatchUpFromPeerStatus` directly so a peer that reports
+        // a higher head triggers catch-up without a state transition.
 
-        // Check 1/2: our head or finalization is behind peer finalization.
+        // Our head or finalization is behind peer finalization.
         // Include the exact peers whose finalized slots make this node report
         // `peers_materially_ahead`, so logs can name the source of the decision.
         const behind_peer_finalization = our_head_slot < max_peer_finalized_slot or our_finalized_slot < max_peer_finalized_slot;
@@ -5717,18 +5709,6 @@ pub const BeamChain = struct {
                 }
             }
             return info;
-        }
-
-        // Check 3: pre-finalization devnets — wall-clock head lag means we are
-        // not at chain tip even though finalization gaps are zero (#926).
-        const wall_lag = self.wall_head_lag_slots.load(.monotonic);
-        if (blocks_by_range_sync.isWallHeadLagSyncing(
-            our_finalized_slot,
-            max_peer_finalized_slot,
-            wall_lag,
-            constants.SYNC_STATUS_WALL_HEAD_LAG_THRESHOLD_SLOTS,
-        )) {
-            return self.behindPeersStatus(our_head_slot, our_finalized_slot, max_peer_finalized_slot);
         }
 
         return .synced;

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -125,16 +125,39 @@ pub const ValidatorClient = struct {
                     self.logger.info("producing block for slot={d} proposer={d} with no peers (self-import only)", .{ slot, slot_proposer_id });
                 },
                 .peers_materially_ahead => |info| {
-                    self.chain.logBehindPeersDebug("skipping block production", info);
-                    self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
-                        slot,
-                        slot_proposer_id,
-                        info.head_slot,
-                        info.finalized_slot,
-                        info.max_peer_finalized_slot,
-                        info.peer_count,
-                    });
-                    return null;
+                    // Same pre-finalization cold-start exception as
+                    // `mayBeDoAttestation` and chain.zig's aggregation
+                    // path (see those long comments). When both our
+                    // finalized slot AND the best peer's finalized slot
+                    // are 0, `peers_materially_ahead` is coming from
+                    // `isWallHeadLagSyncing` and just means "the chain
+                    // hasn't started yet". Skipping proposal in that
+                    // state on every node is a network-wide deadlock:
+                    // no block ever gets produced, attesters have
+                    // nothing to attest to, finalization stays at 0,
+                    // the wall-lag check keeps firing forever
+                    // (observed on the 2026-06-04 all-zeam devnet:
+                    // every node frozen at head_slot=0 with
+                    // behind_peer_count=0). Once any finalization
+                    // exists, `peers_materially_ahead` resumes its
+                    // proper deep-sync meaning and we gate again.
+                    if (info.finalized_slot == 0 and info.max_peer_finalized_slot == 0) {
+                        self.logger.info(
+                            "peers_materially_ahead but pre-finalization (finalized_slot=0, max_peer_finalized_slot=0): producing block for slot={d} proposer={d} on current head_slot={d} to help reach first justification",
+                            .{ slot, slot_proposer_id, info.head_slot },
+                        );
+                    } else {
+                        self.chain.logBehindPeersDebug("skipping block production", info);
+                        self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
+                            slot,
+                            slot_proposer_id,
+                            info.head_slot,
+                            info.finalized_slot,
+                            info.max_peer_finalized_slot,
+                            info.peer_count,
+                        });
+                        return null;
+                    }
                 },
             }
 

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -125,39 +125,16 @@ pub const ValidatorClient = struct {
                     self.logger.info("producing block for slot={d} proposer={d} with no peers (self-import only)", .{ slot, slot_proposer_id });
                 },
                 .peers_materially_ahead => |info| {
-                    // Same pre-finalization cold-start exception as
-                    // `mayBeDoAttestation` and chain.zig's aggregation
-                    // path (see those long comments). When both our
-                    // finalized slot AND the best peer's finalized slot
-                    // are 0, `peers_materially_ahead` is coming from
-                    // `isWallHeadLagSyncing` and just means "the chain
-                    // hasn't started yet". Skipping proposal in that
-                    // state on every node is a network-wide deadlock:
-                    // no block ever gets produced, attesters have
-                    // nothing to attest to, finalization stays at 0,
-                    // the wall-lag check keeps firing forever
-                    // (observed on the 2026-06-04 all-zeam devnet:
-                    // every node frozen at head_slot=0 with
-                    // behind_peer_count=0). Once any finalization
-                    // exists, `peers_materially_ahead` resumes its
-                    // proper deep-sync meaning and we gate again.
-                    if (info.finalized_slot == 0 and info.max_peer_finalized_slot == 0) {
-                        self.logger.info(
-                            "peers_materially_ahead but pre-finalization (finalized_slot=0, max_peer_finalized_slot=0): producing block for slot={d} proposer={d} on current head_slot={d} to help reach first justification",
-                            .{ slot, slot_proposer_id, info.head_slot },
-                        );
-                    } else {
-                        self.chain.logBehindPeersDebug("skipping block production", info);
-                        self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
-                            slot,
-                            slot_proposer_id,
-                            info.head_slot,
-                            info.finalized_slot,
-                            info.max_peer_finalized_slot,
-                            info.peer_count,
-                        });
-                        return null;
-                    }
+                    self.chain.logBehindPeersDebug("skipping block production", info);
+                    self.logger.warn("skipping block production for slot={d} proposer={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
+                        slot,
+                        slot_proposer_id,
+                        info.head_slot,
+                        info.finalized_slot,
+                        info.max_peer_finalized_slot,
+                        info.peer_count,
+                    });
+                    return null;
                 },
             }
 
@@ -218,41 +195,15 @@ pub const ValidatorClient = struct {
                 self.logger.info("attesting for slot={d} with no peers (self-import only)", .{slot});
             },
             .peers_materially_ahead => |info| {
-                // Pre-finalization cold-start exception: when BOTH our own
-                // finalized slot AND the best peer's finalized slot are 0,
-                // the `peers_materially_ahead` signal is coming from
-                // `isWallHeadLagSyncing` (`blocks_by_range_sync.zig:72`),
-                // which fires as soon as `wall_head_lag >= 4` on a fresh
-                // chain. Refusing to attest in that state is the wrong
-                // response — attestations on the best-current-head are
-                // exactly what fork choice needs to accumulate weight,
-                // reach supermajority, and produce the FIRST justified
-                // checkpoint. Without attestations, finalized_slot stays
-                // 0 forever, the wall-lag check keeps firing, and the
-                // chain never finalises (observed on PR #966 deploy:
-                // head frozen at slot 316 while wall clock at 505+,
-                // 100% of attestation production gated out).
-                //
-                // Once any finalization has happened (ours OR a peer's),
-                // `peers_materially_ahead` is reverting to its proper meaning —
-                // deep-sync, where attesting on an old head would be
-                // wasted weight — so we resume gating.
-                if (info.finalized_slot == 0 and info.max_peer_finalized_slot == 0) {
-                    self.logger.info(
-                        "peers_materially_ahead but pre-finalization (finalized_slot=0, max_peer_finalized_slot=0): attesting on current head_slot={d} to help reach first justification",
-                        .{info.head_slot},
-                    );
-                } else {
-                    self.chain.logBehindPeersDebug("skipping attestation production", info);
-                    self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
-                        slot,
-                        info.head_slot,
-                        info.finalized_slot,
-                        info.max_peer_finalized_slot,
-                        info.peer_count,
-                    });
-                    return null;
-                }
+                self.chain.logBehindPeersDebug("skipping attestation production", info);
+                self.logger.warn("skipping attestation production for slot={d}: behind peers (head_slot={d}, finalized_slot={d}, max_peer_finalized_slot={d}, behind_peer_count={d})", .{
+                    slot,
+                    info.head_slot,
+                    info.finalized_slot,
+                    info.max_peer_finalized_slot,
+                    info.peer_count,
+                });
+                return null;
             },
         }
 


### PR DESCRIPTION
## Summary

`maybeDoProposal` in `pkgs/node/src/validator_client.zig` was the only producer path missing the pre-finalization cold-start exception that `mayBeDoAttestation` ([validator_client.zig:217](https://github.com/blockblaz/zeam/blob/main/pkgs/node/src/validator_client.zig#L217)) and the aggregation path ([chain.zig:4946](https://github.com/blockblaz/zeam/blob/main/pkgs/node/src/chain.zig#L4946)) already carry. On a fresh network every node deadlocks at `head_slot = 0`.

## Why

On any devnet that starts from scratch:

- every node has `finalized_slot = 0`, every peer reports `max_peer_finalized_slot = 0`
- `isWallHeadLagSyncing` ([blocks_by_range_sync.zig:72](https://github.com/blockblaz/zeam/blob/main/pkgs/node/src/blocks_by_range_sync.zig#L72)) trips `peers_materially_ahead` purely from wall-clock lag, with `behind_peer_count = 0`
- proposer returns ` null` → no block ever produced
- attesters fire (they already have the exception) but have nothing to attest to
- finalization stays at 0, the wall-lag check keeps firing forever

Observed on the 2026-06-04 all-zeam devnet: every node frozen at `head_slot = 0` with wall slot 88+ and recurring `stuck mesh cluster detected: best peer reports head=0`:

\`\`\`
[s=64 i=0] skipping block production for slot=64 proposer=0:
  behind peers (head_slot=0, finalized_slot=0,
                max_peer_finalized_slot=0, behind_peer_count=0)
\`\`\`

`behind_peer_count = 0` — no peer is actually ahead — but the wall-lag gate still triggers because the chain hasn't started.

## Fix

Apply the same `info.finalized_slot == 0 and info.max_peer_finalized_slot == 0` exception to the block-production path. The proposer produces on the current head until any finalization exists (ours or a peer's); after that the gate returns to its proper deep-sync meaning. Matches the existing pattern verbatim from the two other producer paths.

## Test plan

- [x] `zig fmt --check .` passes
- [ ] Redeploy a devnet with `--generateGenesis`; first proposer publishes at slot 1, attestations build up, finalization advances past 0
- [ ] Confirm `skipping block production ... behind peers` no longer fires when `behind_peer_count = 0`
- [ ] Once finalization exists, confirm the deep-sync gate still kicks in on a node intentionally booted late