### PR TITLE
node, cli, database, metrics: thread process Io through instead of global_single_threaded

### DIFF
--- a/pkgs/api/src/event_broadcaster.zig
+++ b/pkgs/api/src/event_broadcaster.zig
@@ -10,7 +10,7 @@ const Checkpoint = types.Checkpoint;
 const Mutex = zeam_utils.SyncMutex;
 
 fn defaultIo() std.Io {
-    return std.Io.Threaded.global_single_threaded.io();
+    return zeam_utils.process_io.get();
 }
 
 /// Maximum size of the SSE send buffer in event_broadcaster.zig. Serialized events

--- a/pkgs/api/src/lib.zig
+++ b/pkgs/api/src/lib.zig
@@ -8,8 +8,8 @@ pub const MetricsError = error{
 };
 
 /// Initializes the metrics system. Must be called once at startup.
-pub fn init(allocator: std.mem.Allocator) !void {
-    try zeam_metrics.init(allocator);
+pub fn init(io: std.Io, allocator: std.mem.Allocator) !void {
+    try zeam_metrics.init(io, allocator);
 }
 
 /// Writes metrics to a writer (for Prometheus endpoint).

--- a/pkgs/cli/src/api_server.zig
+++ b/pkgs/cli/src/api_server.zig
@@ -44,7 +44,7 @@ const StartupStatus = enum(u8) {
 /// chain is optional - if null, chain-dependent endpoints will return 503
 /// (API server starts before chain initialization, so chain may not be available yet)
 /// Note: Metrics are served by the separate metrics_server on a different port
-pub fn startAPIServer(allocator: std.mem.Allocator, port: u16, logger_config: *LoggerConfig, chain: ?*BeamChain) !*ApiServer {
+pub fn startAPIServer(io: std.Io, allocator: std.mem.Allocator, port: u16, logger_config: *LoggerConfig, chain: ?*BeamChain) !*ApiServer {
     // Initialize the global event broadcaster for SSE events
     // This is idempotent - safe to call even if already initialized elsewhere (e.g., node.zig)
     try event_broadcaster.initGlobalBroadcaster(allocator);
@@ -60,6 +60,7 @@ pub fn startAPIServer(allocator: std.mem.Allocator, port: u16, logger_config: *L
         return err;
     };
     ctx.* = .{
+        .io = io,
         .allocator = allocator,
         .port = port,
         .logger = logger,
@@ -245,6 +246,7 @@ fn routeConnection(io: std.Io, connection: net.Stream, allocator: std.mem.Alloca
 
 /// API server context
 pub const ApiServer = struct {
+    io: std.Io,
     allocator: std.mem.Allocator,
     port: u16,
     logger: ModuleLogger,
@@ -284,7 +286,7 @@ pub const ApiServer = struct {
     }
 
     fn run(self: *Self) void {
-        const io = std.Io.Threaded.global_single_threaded.io();
+        const io = self.io;
         const address = net.IpAddress.parseIp4("0.0.0.0", self.port) catch |err| {
             self.logger.err("failed to parse server address 0.0.0.0:{d}: {}", .{ self.port, err });
             self.startup_status.store(.failed, .release);
@@ -621,7 +623,7 @@ pub const ApiServer = struct {
 
     /// Handle SSE events endpoint
     fn handleSSEEvents(self: *Self, stream: net.Stream) !void {
-        const io = std.Io.Threaded.global_single_threaded.io();
+        const io = self.io;
         var registered = false;
         errdefer if (!registered) stream.close(io);
         // Set SSE headers manually by writing HTTP response

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -412,7 +412,7 @@ fn mainInner(init: std.process.Init) !void {
             std.log.info("Successfully proved and verified all transitions", .{});
         },
         .beam => |beamcmd| {
-            api.init(allocator) catch |err| {
+            api.init(init.io, allocator) catch |err| {
                 ErrorHandler.logErrorWithOperation(err, "initialize API");
                 return err;
             };

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -301,6 +301,11 @@ pub fn main(init: std.process.Init) void {
 }
 
 fn mainInner(init: std.process.Init) !void {
+    // Install the process-wide blocking Io before any logging or thread spawning,
+    // so zeam's leaf blocking primitives use the real process Io rather than
+    // std's debug-only global single-threaded instance.
+    utils_lib.process_io.install(init.io);
+
     var gpa = std.heap.DebugAllocator(.{}).init;
     const allocator = gpa.allocator();
     defer {

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -436,13 +436,13 @@ fn mainInner(init: std.process.Init) !void {
             }
 
             // Start metrics server (doesn't need chain reference)
-            metrics_server_handle = metrics_server.startMetricsServer(allocator, beamcmd.@"metrics-port", &api_logger_config) catch |err| {
+            metrics_server_handle = metrics_server.startMetricsServer(init.io, allocator, beamcmd.@"metrics-port", &api_logger_config) catch |err| {
                 ErrorHandler.logErrorWithDetails(err, "start metrics server", .{ .port = beamcmd.@"metrics-port" });
                 return err;
             };
 
             // Start API server early. Pass null for chain - in .beam command mode, chains are created later
-            api_server_handle = api_server.startAPIServer(allocator, beamcmd.@"api-port", &api_logger_config, null) catch |err| {
+            api_server_handle = api_server.startAPIServer(init.io, allocator, beamcmd.@"api-port", &api_logger_config, null) catch |err| {
                 ErrorHandler.logErrorWithDetails(err, "start API server", .{ .port = beamcmd.@"api-port" });
                 return err;
             };
@@ -683,11 +683,11 @@ fn mainInner(init: std.process.Init) !void {
             defer allocator.free(data_dir_3);
 
             const db_backend = beamcmd.@"db-backend";
-            var db_1 = try database.Db.openBackend(allocator, logger1_config.logger(.database), data_dir_1, db_backend);
+            var db_1 = try database.Db.openBackend(init.io, allocator, logger1_config.logger(.database), data_dir_1, db_backend);
             defer db_1.deinit();
-            var db_2 = try database.Db.openBackend(allocator, logger2_config.logger(.database), data_dir_2, db_backend);
+            var db_2 = try database.Db.openBackend(init.io, allocator, logger2_config.logger(.database), data_dir_2, db_backend);
             defer db_2.deinit();
-            var db_3 = try database.Db.openBackend(allocator, logger3_config.logger(.database), data_dir_3, db_backend);
+            var db_3 = try database.Db.openBackend(init.io, allocator, logger3_config.logger(.database), data_dir_3, db_backend);
             defer db_3.deinit();
 
             // Use the same shared registry for all beam nodes
@@ -920,7 +920,7 @@ fn mainInner(init: std.process.Init) !void {
             };
 
             var lean_node: node.Node = undefined;
-            lean_node.init(allocator, &start_options) catch |err| {
+            lean_node.init(init.io, allocator, &start_options) catch |err| {
                 ErrorHandler.logErrorWithOperation(err, "initialize lean node");
                 return err;
             };

--- a/pkgs/cli/src/metrics_server.zig
+++ b/pkgs/cli/src/metrics_server.zig
@@ -12,6 +12,7 @@ const STARTUP_POLL_NS: u64 = 1 * std.time.ns_per_ms;
 /// This is a lightweight server separate from the main API server.
 /// It has no rate limiting, SSE support, or chain dependency.
 pub fn startMetricsServer(
+    io: std.Io,
     allocator: std.mem.Allocator,
     port: u16,
     logger_config: *LoggerConfig,
@@ -20,6 +21,7 @@ pub fn startMetricsServer(
 
     const ctx = try allocator.create(MetricsServer);
     ctx.* = .{
+        .io = io,
         .allocator = allocator,
         .port = port,
         .logger = logger,
@@ -58,6 +60,7 @@ const StartupStatus = enum(u8) {
 
 /// Metrics server context
 pub const MetricsServer = struct {
+    io: std.Io,
     allocator: std.mem.Allocator,
     port: u16,
     logger: ModuleLogger,
@@ -76,7 +79,7 @@ pub const MetricsServer = struct {
     }
 
     fn run(self: *Self) void {
-        const io = std.Io.Threaded.global_single_threaded.io();
+        const io = self.io;
         const address = net.IpAddress.parseIp4("0.0.0.0", self.port) catch |err| {
             self.logger.err("failed to parse server address 0.0.0.0:{d}: {}", .{ self.port, err });
             self.startup_status.store(.failed, .release);

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -168,6 +168,7 @@ pub const NodeOptions = struct {
 /// A Node that encapsulates the networking, blockchain, and validator functionalities.
 /// It manages the event loop, network interface, clock, and beam node.
 pub const Node = struct {
+    io: std.Io,
     loop: xev.Loop,
     network: networks.EthLibp2p,
     beam_node: BeamNode,
@@ -261,6 +262,7 @@ pub const Node = struct {
     /// db directory has never been created). Set it to false when wiping a db
     /// that is known to exist (genesis time mismatch case).
     fn wipeAndReopenDb(
+        io: std.Io,
         db: *database.Db,
         allocator: std.mem.Allocator,
         database_path: []const u8,
@@ -270,7 +272,6 @@ pub const Node = struct {
         ignore_not_found: bool,
     ) !void {
         db.deinit();
-        const io = std.Io.Threaded.global_single_threaded.io();
         // Both backends store their working set under the same base
         // directory; deleting it yields a clean slate for either engine.
         const backend_dir = switch (backend) {
@@ -285,14 +286,16 @@ pub const Node = struct {
                 return wipe_err;
             }
         };
-        db.* = try database.Db.openBackend(allocator, logger_config.logger(.database), database_path, backend);
+        db.* = try database.Db.openBackend(io, allocator, logger_config.logger(.database), database_path, backend);
     }
 
     pub fn init(
         self: *Self,
+        io: std.Io,
         allocator: std.mem.Allocator,
         options: *const NodeOptions,
     ) !void {
+        self.io = io;
         self.allocator = allocator;
         self.options = options;
         self.api_server_handle = null;
@@ -301,7 +304,7 @@ pub const Node = struct {
         // If path is specified load from it, otherwise use default settings
         const chain_spec_owned = self.options.chain_spec != null;
         const chain_spec = if (self.options.chain_spec) |path|
-            std.Io.Dir.cwd().readFileAlloc(std.Io.Threaded.global_single_threaded.io(), path, allocator, .limited(1024 * 1024)) catch |err| {
+            std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1024 * 1024)) catch |err| {
                 self.logger.err("failed to load chain spec at '{s}': {any}", .{ path, err });
                 return err;
             }
@@ -387,6 +390,7 @@ pub const Node = struct {
         errdefer self.clock.deinit(allocator);
 
         var db = try database.Db.openBackend(
+            io,
             allocator,
             options.logger_config.logger(.database),
             options.database_path,
@@ -407,7 +411,7 @@ pub const Node = struct {
                     local_finalized_state.config.genesis_time,
                     chain_config.genesis.genesis_time,
                 });
-                try wipeAndReopenDb(&db, allocator, options.database_path, options.logger_config, self.logger, options.db_backend, false);
+                try wipeAndReopenDb(io, &db, allocator, options.database_path, options.logger_config, self.logger, options.db_backend, false);
                 self.logger.info("stale database wiped, starting fresh & generating genesis", .{});
 
                 local_finalized_state.deinit();
@@ -418,7 +422,7 @@ pub const Node = struct {
         } else |_| {
             self.logger.info("no finalized state found in db, wiping database for a clean slate", .{});
             // ignore_not_found=true: db dir may not exist yet on a fresh install
-            try wipeAndReopenDb(&db, allocator, options.database_path, options.logger_config, self.logger, options.db_backend, true);
+            try wipeAndReopenDb(io, &db, allocator, options.database_path, options.logger_config, self.logger, options.db_backend, true);
             self.logger.info("starting fresh & generating genesis", .{});
             try self.anchor_state.genGenesisState(allocator, chain_config.genesis);
         }
@@ -571,7 +575,7 @@ pub const Node = struct {
 
         self.thread_pool = try ThreadPool.init(.{
             .allocator = allocator,
-            .io = std.Io.Threaded.global_single_threaded.io(),
+            .io = io,
             .thread_count = @intCast(worker_count),
         });
         errdefer self.thread_pool.deinit();
@@ -625,6 +629,7 @@ pub const Node = struct {
 
             // Start metrics server (doesn't need chain reference)
             self.metrics_server_handle = try metrics_server.startMetricsServer(
+                io,
                 allocator,
                 options.metrics_port,
                 options.logger_config,
@@ -648,6 +653,7 @@ pub const Node = struct {
 
             // Start API server (pass chain pointer for chain-dependent endpoints)
             self.api_server_handle = try api_server.startAPIServer(
+                io,
                 allocator,
                 options.api_port,
                 options.logger_config,

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -432,7 +432,7 @@ pub const Node = struct {
             self.logger.info("checkpoint sync enabled, downloading state from: {s}", .{checkpoint_url});
 
             // Try checkpoint sync, fall back to database/genesis on failure
-            if (downloadCheckpointState(allocator, checkpoint_url, self.logger)) |downloaded_state_const| {
+            if (downloadCheckpointState(io, allocator, checkpoint_url, self.logger)) |downloaded_state_const| {
                 var downloaded_state = downloaded_state_const;
                 // Verify state against genesis config
                 if (verifyCheckpointState(allocator, &downloaded_state, &chain_config.genesis, self.logger)) {
@@ -464,7 +464,7 @@ pub const Node = struct {
                                 self.logger.warn("checkpoint block fetch: hashTreeRoot(BeamBlockHeader) failed: {} — skipping", .{err});
                                 break :anchor_block_fetch;
                             };
-                            downloadAndStoreCheckpointBlock(allocator, checkpoint_url, anchor_block_root, anchor_state_root, &db, self.logger);
+                            downloadAndStoreCheckpointBlock(io, allocator, checkpoint_url, anchor_block_root, anchor_state_root, &db, self.logger);
                         }
                     } else {
                         self.logger.warn("skipping checkpoint sync downloaded stale/same state at slot={d}, falling back to database", .{downloaded_state.slot});
@@ -492,7 +492,7 @@ pub const Node = struct {
         // initialization (like lean_validators_count) are captured on real
         // metrics instead of being discarded by noop metrics.
         if (options.metrics_enable) {
-            try api.init(allocator);
+            try api.init(io, allocator);
             zeam_metrics.metrics.lean_node_start_time_seconds.set(@intCast(zeam_utils.unixTimestampSeconds()));
         }
 
@@ -1118,13 +1118,13 @@ pub fn buildStartOptions(
 /// Downloads finalized checkpoint state from the given URL and deserializes it
 /// Returns the deserialized state. The caller is responsible for calling deinit on it.
 fn downloadCheckpointState(
+    io: std.Io,
     allocator: std.mem.Allocator,
     url: []const u8,
     logger: zeam_utils.ModuleLogger,
 ) !types.BeamState {
     logger.info("downloading checkpoint state from: {s}", .{url});
 
-    const io = std.Io.Threaded.global_single_threaded.io();
     var client = std.http.Client{
         .allocator = allocator,
         .io = io,
@@ -1260,6 +1260,7 @@ const FINALIZED_BLOCK_PATH = "/lean/v0/blocks/finalized";
 /// anything — a missing anchor block is non-fatal: blocks_by_root will return
 /// empty for this root until the real block arrives via reqresp or gossip.
 fn downloadAndStoreCheckpointBlock(
+    io: std.Io,
     allocator: std.mem.Allocator,
     state_url: []const u8,
     expected_root: types.Root,
@@ -1289,7 +1290,6 @@ fn downloadAndStoreCheckpointBlock(
 
     logger.info("checkpoint block fetch: downloading anchor block from: {s}", .{block_url});
 
-    const io = std.Io.Threaded.global_single_threaded.io();
     var client = std.http.Client{ .allocator = allocator, .io = io };
     defer client.deinit();
 

--- a/pkgs/database/src/database.zig
+++ b/pkgs/database/src/database.zig
@@ -56,11 +56,11 @@ pub const Backend = enum {
 /// loud warning. Best-effort: any filesystem error here is suppressed
 /// — it is a diagnostic, not a correctness barrier.
 fn warnIfOtherBackendPopulated(
+    io: std.Io,
     logger: zeam_utils.ModuleLogger,
     path: []const u8,
     selected: Backend,
 ) void {
-    const io = std.Io.Threaded.global_single_threaded.io();
     const other: Backend = switch (selected) {
         .rocksdb => .lmdb,
         .lmdb => .rocksdb,
@@ -107,22 +107,24 @@ pub const Db = union(Backend) {
     /// Open with the default backend (rocksdb). Kept for call sites
     /// that don't care which engine is used (tests, legacy paths).
     pub fn open(
+        io: std.Io,
         allocator: Allocator,
         logger: zeam_utils.ModuleLogger,
         path: []const u8,
     ) !Db {
-        return openBackend(allocator, logger, path, .rocksdb);
+        return openBackend(io, allocator, logger, path, .rocksdb);
     }
 
     /// Open with an explicitly chosen backend. Used by the CLI so
     /// operators can select the engine via `--db-backend`.
     pub fn openBackend(
+        io: std.Io,
         allocator: Allocator,
         logger: zeam_utils.ModuleLogger,
         path: []const u8,
         backend: Backend,
     ) !Db {
-        warnIfOtherBackendPopulated(logger, path, backend);
+        warnIfOtherBackendPopulated(io, logger, path, backend);
         return switch (backend) {
             .rocksdb => Db{ .rocksdb = try RocksDbBackend.open(allocator, logger, path) },
             .lmdb => Db{ .lmdb = try LmdbBackend.open(allocator, logger, path) },
@@ -504,7 +506,7 @@ fn testSaveAndLoadBlock(backend: Backend) !void {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try Db.openBackend(allocator, zeam_logger_config.logger(.database_test), data_dir, backend);
+    var db = try Db.openBackend(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir, backend);
     defer db.deinit();
 
     const block_root = test_helpers.createDummyRoot(0xAB);
@@ -546,7 +548,7 @@ fn testBatchWriteAndCommit(backend: Backend) !void {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try Db.openBackend(allocator, zeam_logger_config.logger(.database_test), data_dir, backend);
+    var db = try Db.openBackend(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir, backend);
     defer db.deinit();
 
     const block_root = test_helpers.createDummyRoot(0xAA);
@@ -599,7 +601,7 @@ fn testLoadLatestFinalizedStateHappyPath(backend: Backend) !void {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try Db.openBackend(allocator, zeam_logger_config.logger(.database_test), data_dir, backend);
+    var db = try Db.openBackend(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir, backend);
     defer db.deinit();
 
     // Empty db -> no finalized slot metadata

--- a/pkgs/database/src/lmdb.zig
+++ b/pkgs/database/src/lmdb.zig
@@ -45,7 +45,7 @@ pub fn Lmdb(comptime column_namespaces: []const ColumnNamespace) type {
 
         pub fn open(allocator: Allocator, logger: zeam_utils.ModuleLogger, path: []const u8) OpenError!Self {
             logger.info("initializing LMDB", .{});
-            const io = std.Io.Threaded.global_single_threaded.io();
+            const io = zeam_utils.process_io.get();
 
             comptime {
                 if (column_namespaces.len == 0 or !std.mem.eql(u8, column_namespaces[0].namespace, "default")) {

--- a/pkgs/database/src/rocksdb.zig
+++ b/pkgs/database/src/rocksdb.zig
@@ -1025,7 +1025,7 @@ test "save and load block" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     // Create test data using helper functions
@@ -1086,7 +1086,7 @@ test "save and load state" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     // Create test data using helper functions
@@ -1131,7 +1131,7 @@ test "batch write and commit" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     // Create test data using helper functions
@@ -1213,7 +1213,7 @@ test "loadLatestFinalizedState" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     // Empty DB -> no finalized slot metadata

--- a/pkgs/database/src/rocksdb.zig
+++ b/pkgs/database/src/rocksdb.zig
@@ -30,7 +30,7 @@ pub fn RocksDB(comptime column_namespaces: []const ColumnNamespace) type {
             const owned_path = try std.fmt.allocPrintSentinel(allocator, "{s}/rocksdb", .{path}, 0);
             errdefer allocator.free(owned_path);
 
-            const io = std.Io.Threaded.global_single_threaded.io();
+            const io = zeam_utils.process_io.get();
             try std.Io.Dir.cwd().createDirPath(io, owned_path);
 
             // Ideally this should be configurable via cli args

--- a/pkgs/key-manager/src/lib.zig
+++ b/pkgs/key-manager/src/lib.zig
@@ -268,7 +268,7 @@ pub const MAX_SK_SIZE = 1024 * 1024 * 20;
 pub const MAX_PK_SIZE = 256;
 
 fn defaultIo() std.Io {
-    return std.Io.Threaded.global_single_threaded.io();
+    return zeam_utils.process_io.get();
 }
 
 fn readFileAllocAtPath(allocator: Allocator, path: []const u8, max_size: usize) ![]u8 {

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -1079,7 +1079,7 @@ pub var lean_pending_blocks_drain_iters: Histogram = .{
 };
 
 /// Initializes the metrics system. Must be called once at startup.
-pub fn init(allocator: std.mem.Allocator) !void {
+pub fn init(io: std.Io, allocator: std.mem.Allocator) !void {
     if (g_initialized) return;
 
     // For ZKVM targets, use no-op metrics
@@ -1088,8 +1088,6 @@ pub fn init(allocator: std.mem.Allocator) !void {
         g_initialized = true;
         return;
     }
-
-    const io = std.Io.Threaded.global_single_threaded.io();
 
     metrics = .{
         .zeam_chain_onblock_duration_seconds = Metrics.ChainHistogram.init("zeam_chain_onblock_duration_seconds", .{ .help = "Time taken to process a block in the chain's onBlock function." }, .{}),

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -462,7 +462,7 @@ fn shouldPersistMalformedDump() bool {
 /// segfaulted when logging it.  The fix: log from inside this function and return
 /// a plain bool; callers no longer touch the filename string at all (#725).
 fn writeFailedBytes(message_bytes: []const u8, message_type: []const u8, allocator: Allocator, timestamp: ?i64, logger: zeam_utils.ModuleLogger) bool {
-    const io = std.Io.Threaded.global_single_threaded.io();
+    const io = zeam_utils.process_io.get();
     // Create dumps directory if it doesn't exist
     std.Io.Dir.cwd().createDirPath(io, "deserialization_dumps") catch |e| {
         logger.err("Failed to create deserialization dumps directory: {any}", .{e});

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -5817,7 +5817,7 @@ test "process and add mock blocks into a node's chain" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);
@@ -5911,7 +5911,7 @@ test "printSlot output demonstration" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     // Create empty node registry for test
@@ -5995,7 +5995,7 @@ test "buildTreeVisualization integration test" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const test_registry = try allocator.create(NodeNameRegistry);
@@ -6089,7 +6089,7 @@ test "attestation validation - comprehensive" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);
@@ -6386,7 +6386,7 @@ test "attestation validation - gossip future-slot bound" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);
@@ -6519,7 +6519,7 @@ const FutureSlotTestFixture = struct {
 
         fx.tmp_dir = std.testing.tmpDir(.{});
         const data_dir = try std.fmt.allocPrint(fx.allocator, ".zig-cache/tmp/{s}", .{fx.tmp_dir.sub_path});
-        fx.db = try database.Db.open(fx.allocator, fx.zeam_logger_config.logger(.database_test), data_dir);
+        fx.db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), fx.allocator, fx.zeam_logger_config.logger(.database_test), data_dir);
 
         fx.connected_peers = try fx.allocator.create(ConnectedPeers);
         fx.connected_peers.* = ConnectedPeers.init(fx.allocator);
@@ -6987,7 +6987,7 @@ test "attestation processing - valid block attestation" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);
@@ -7099,7 +7099,7 @@ test "produceBlock - greedy selection by latest slot is suboptimal when attestat
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);
@@ -7243,7 +7243,7 @@ fn setupJustifiedSourceTestChain(allocator: std.mem.Allocator, n_blocks: usize) 
     const tmp_dir = std.testing.tmpDir(.{});
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
-    const db = try database.Db.open(allocator, zeam_logger_config.logger(.database_test), data_dir);
+    const db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, zeam_logger_config.logger(.database_test), data_dir);
 
     const connected_peers = try allocator.create(ConnectedPeers);
     connected_peers.* = ConnectedPeers.init(allocator);
@@ -7952,7 +7952,7 @@ test "BorrowedState: cloneAndRelease vs concurrent statesFetchRemoveExclusivePtr
     defer tmp_dir.cleanup();
     const data_dir = try std.fmt.allocPrint(arena, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
-    var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try std.testing.allocator.create(ConnectedPeers);
@@ -8148,7 +8148,7 @@ test "chain.statesCommitKeepExisting: getOrPut OOM releases caller rc (no leak)"
     var path_buf: [128]u8 = undefined;
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
-    var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try std.testing.allocator.create(ConnectedPeers);
@@ -8315,7 +8315,7 @@ test "chain.onBlock: two-thread concurrent import of same block — no UAF, cohe
         var path_buf: [128]u8 = undefined;
         const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
-        var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+        var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
         defer db.deinit();
 
         const connected_peers = try std.testing.allocator.create(ConnectedPeers);
@@ -8474,7 +8474,7 @@ test "chain: concurrent re-import pressure — kept_existing path race + attesta
         defer tmp_dir.cleanup();
         var path_buf: [128]u8 = undefined;
         const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
-        var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+        var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
         defer db.deinit();
 
         const connected_peers = try std.testing.allocator.create(ConnectedPeers);
@@ -8708,7 +8708,7 @@ test "chain: finalization race — onBlockFollowup + statesGet from API-shaped r
     defer tmp_dir.cleanup();
     var path_buf: [128]u8 = undefined;
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
-    var db = try database.Db.open(std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), std.testing.allocator, zeam_logger_config.logger(.database_test), data_dir);
     defer db.deinit();
 
     const connected_peers = try std.testing.allocator.create(ConnectedPeers);
@@ -8930,6 +8930,7 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
     var db = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir,
@@ -9052,6 +9053,7 @@ test "chain-worker: end-to-end submitBlock advances state via the worker thread"
     var path_buf_2: [128]u8 = undefined;
     const data_dir_2 = try std.fmt.bufPrint(&path_buf_2, ".zig-cache/tmp/{s}", .{tmp_dir_2.sub_path});
     var db2 = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir_2,
@@ -9212,6 +9214,7 @@ test "chain-worker (#890): imported_block_fn fires once per successful submitBlo
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
     var db = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir,
@@ -9327,6 +9330,7 @@ test "chain-worker (#890): rejected_block_fn fires on MissingPreState (TOCTOU ra
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
     var db = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir,
@@ -9436,6 +9440,7 @@ test "chain-worker (#890): rejected_block_fn fires on PreFinalizedSlot" {
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
 
     var db = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir,
@@ -9546,6 +9551,7 @@ test "chain.statesGet under chain_worker enabled returns Backing.none + acquired
     var path_buf: [128]u8 = undefined;
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     var db = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir,
@@ -9648,6 +9654,7 @@ test "chain.statesGet under chain_worker enabled does not block exclusive writer
     var path_buf: [128]u8 = undefined;
     const data_dir = try std.fmt.bufPrint(&path_buf, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     var db = try database.Db.open(
+        std.Io.Threaded.global_single_threaded.io(),
         std.testing.allocator,
         zeam_logger_config.logger(.database_test),
         data_dir,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -6903,7 +6903,7 @@ test "enqueuePendingBlock #788: dedup uses cached root, not re-hash" {
 test "#788 metrics: queue + drop counters appear in /metrics output" {
     if (zeam_metrics.isZKVM()) return;
 
-    try zeam_metrics.init(std.heap.page_allocator);
+    try zeam_metrics.init(std.Io.Threaded.global_single_threaded.io(), std.heap.page_allocator);
 
     // Set / bump every label so the scrape body contains a sample
     // line for each. The `catch {}` mirrors production usage —

--- a/pkgs/node/src/chain_worker.zig
+++ b/pkgs/node/src/chain_worker.zig
@@ -1695,7 +1695,7 @@ test "ChainWorker: metrics — sendBlock/sendAttestation/runLoop bump lean_chain
     // mirroring the LockTimer test pattern. Uses page_allocator for
     // the metrics init so the (process-global) hashmap survives test
     // teardown — see locking.zig comment on the same trap.
-    try zeam_metrics.init(std.heap.page_allocator);
+    try zeam_metrics.init(std.Io.Threaded.global_single_threaded.io(), std.heap.page_allocator);
 
     var logger_config = zeam_utils.getTestLoggerConfig();
     var w = try ChainWorker.init(testing.allocator, .{

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -1256,7 +1256,7 @@ test "LockTimer: acquired+released emit zeam_lock_{wait,hold}_seconds in /metric
     // that this test's allocator footprint is not tracked by the
     // testing harness; that footprint is bounded by the histogram
     // bucket we add (single (lock, site) pair) so it is acceptable.
-    try zeam_metrics.init(std.heap.page_allocator);
+    try zeam_metrics.init(std.Io.Threaded.global_single_threaded.io(), std.heap.page_allocator);
 
     var t = LockTimer.start("locktimer_test_lock", "locktimer_test_site");
     t.acquired();
@@ -1673,7 +1673,7 @@ test "lean_chain_state_refcount_distribution: writer + N readers shape (slice c-
     // Test uses page_allocator for the same reason
     // `LockTimer: ... metrics output` does — the histogram bucket
     // backing storage outlives this test.
-    try zeam_metrics.init(std.heap.page_allocator);
+    try zeam_metrics.init(std.Io.Threaded.global_single_threaded.io(), std.heap.page_allocator);
 
     const N: usize = 4;
     var rcs: [N]*rc_beam_state.RcBeamState = undefined;

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -1018,7 +1018,7 @@ pub fn ConnectedPeersImpl(comptime PeerInfo: type) type {
             }
             if (candidates.items.len == 0) return null;
 
-            const io = std.Io.Threaded.global_single_threaded.io();
+            const io = zeam_utils.process_io.get();
             var random_source = std.Random.IoSource{ .io = io };
             const random = random_source.interface();
             const pick = random.uintLessThan(usize, candidates.items.len);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -3748,7 +3748,7 @@ test "Node peer tracking on connect/disconnect" {
     const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
     defer allocator.free(data_dir);
 
-    var db = try database.Db.open(allocator, ctx.loggerConfig().logger(.database), data_dir);
+    var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, ctx.loggerConfig().logger(.database), data_dir);
     defer db.deinit();
 
     const spec_name = try allocator.dupe(u8, "zeamdev");

--- a/pkgs/node/src/stress.zig
+++ b/pkgs/node/src/stress.zig
@@ -572,7 +572,7 @@ fn runStress(allocator: Allocator, cfg: StressConfig) !StressSummary {
     try std.Io.Dir.cwd().createDirPath(io, data_dir);
     defer std.Io.Dir.cwd().deleteTree(io, data_dir) catch {};
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database), data_dir);
+    var db = try database.Db.open(io, allocator, zeam_logger_config.logger(.database), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);
@@ -1075,7 +1075,7 @@ fn runStressSaturation(allocator: Allocator, cfg: SaturationConfig) !SaturationS
     try std.Io.Dir.cwd().createDirPath(io, data_dir);
     defer std.Io.Dir.cwd().deleteTree(io, data_dir) catch {};
 
-    var db = try database.Db.open(allocator, zeam_logger_config.logger(.database), data_dir);
+    var db = try database.Db.open(io, allocator, zeam_logger_config.logger(.database), data_dir);
     defer db.deinit();
 
     const connected_peers = try allocator.create(ConnectedPeers);

--- a/pkgs/node/src/testing.zig
+++ b/pkgs/node/src/testing.zig
@@ -105,7 +105,7 @@ pub const NodeTestContext = struct {
         const data_dir = try std.fmt.allocPrint(allocator, ".zig-cache/tmp/{s}", .{tmp_dir.sub_path});
         errdefer allocator.free(data_dir);
 
-        var db = try database.Db.open(allocator, logger_config.logger(.database), data_dir);
+        var db = try database.Db.open(std.Io.Threaded.global_single_threaded.io(), allocator, logger_config.logger(.database), data_dir);
         errdefer db.deinit();
 
         const spec_name = try allocator.dupe(u8, opts.spec_name);

--- a/pkgs/utils/src/fs.zig
+++ b/pkgs/utils/src/fs.zig
@@ -1,10 +1,11 @@
 const std = @import("std");
+const process_io = @import("./process_io.zig");
 
 /// Checks if a directory exists at the given path.
 /// The path can be absolute or relative to the current working directory.
 /// Returns an error if the directory does not exist or cannot be opened.
 pub fn checkDIRExists(path: []const u8) !void {
-    const io = std.Io.Threaded.global_single_threaded.io();
+    const io = process_io.get();
     if (std.fs.path.isAbsolute(path)) {
         const dir = try std.Io.Dir.openDirAbsolute(io, path, .{});
         dir.close(io);
@@ -19,7 +20,7 @@ pub fn checkDIRExists(path: []const u8) !void {
 /// The caller is responsible for freeing the returned byte slice.
 /// `max_bytes` limits the maximum number of bytes to read to prevent excessive memory usage.
 pub fn readFileToEndAlloc(allocator: std.mem.Allocator, file_path: []const u8, max_bytes: usize) ![]u8 {
-    const io = std.Io.Threaded.global_single_threaded.io();
+    const io = process_io.get();
     return std.Io.Dir.cwd().readFileAlloc(io, file_path, allocator, .limited(max_bytes));
 }
 

--- a/pkgs/utils/src/lib.zig
+++ b/pkgs/utils/src/lib.zig
@@ -59,6 +59,8 @@ const fmt_factory = @import("./fmt.zig");
 // Avoid to use `usingnamespace` to make upgrade easier in the future.
 pub const LazyJson = fmt_factory.LazyJson;
 
+pub const process_io = @import("./process_io.zig");
+
 test {
     @import("std").testing.refAllDecls(@This());
 }

--- a/pkgs/utils/src/log.zig
+++ b/pkgs/utils/src/log.zig
@@ -2,9 +2,10 @@ const std = @import("std");
 const builtin = @import("builtin");
 const datetime = @import("datetime");
 const time_utils = @import("./time.zig");
+const process_io = @import("./process_io.zig");
 
 fn defaultIo() std.Io {
-    return std.Io.Threaded.global_single_threaded.io();
+    return process_io.get();
 }
 
 const Colors = struct {

--- a/pkgs/utils/src/process_io.zig
+++ b/pkgs/utils/src/process_io.zig
@@ -1,0 +1,23 @@
+//! Process-wide blocking Io for zeam's internal blocking primitives (SyncMutex,
+//! logger, sleep, and other leaf code that cannot practically take an Io
+//! parameter). Installed once at startup from main's process Io
+//! (std.process.Init.io). This deliberately replaces std's debug-only
+//! std.Io.Threaded.global_single_threaded for production code.
+const std = @import("std");
+
+/// The real process Io, installed once by main before any worker threads spawn.
+var installed: ?std.Io = null;
+/// Deliberate local fallback for tests / pre-install bootstrap. Not std's
+/// debug-only global instance — a zeam-owned single-threaded Threaded.
+var fallback_instance: std.Io.Threaded = .init_single_threaded;
+
+/// Call exactly once at process startup with main's `init.io`.
+pub fn install(io: std.Io) void {
+    installed = io;
+}
+
+/// The process blocking Io. After `install` (production) this is the real
+/// process Io; before it (tests / early bootstrap) a local fallback.
+pub fn get() std.Io {
+    return installed orelse fallback_instance.io();
+}

--- a/pkgs/utils/src/sync.zig
+++ b/pkgs/utils/src/sync.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
+const process_io = @import("./process_io.zig");
 
 fn defaultIo() std.Io {
-    return std.Io.Threaded.global_single_threaded.io();
+    return process_io.get();
 }
 
 pub const Mutex = struct {

--- a/pkgs/utils/src/time.zig
+++ b/pkgs/utils/src/time.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const process_io = @import("./process_io.zig");
 
 pub fn unixTimestampSeconds() i64 {
     if (builtin.target.os.tag == .freestanding) return 0;
@@ -21,7 +22,7 @@ pub fn unixTimestampMillis() i64 {
 pub fn sleepNs(ns: u64) void {
     if (builtin.target.os.tag == .freestanding) return;
 
-    const io = std.Io.Threaded.global_single_threaded.io();
+    const io = process_io.get();
     std.Io.sleep(io, .{ .nanoseconds = ns }, .awake) catch {};
 }
 


### PR DESCRIPTION
## What

Remove **every production reference** to `std.Io.Threaded.global_single_threaded` and route all of it through the process `Io`.

`global_single_threaded` is documented debug-only — *"In general… library code should accept an `Io` parameter rather than accessing this declaration. Most code should avoid referencing this declaration entirely… This instance does not support concurrency or cancelation."* It should not appear in production code regardless of whether the behavior happens to be equivalent.

## Approach (two layers)

**1. App/entrypoint components take an explicit `io: std.Io`** (threaded from `main`'s `init.io`, which already backs the `ThreadPool`):
- `ApiServer` / `MetricsServer` (io field, used in `run()` / `handleSSEEvents()`).
- `database.Db.open` / `openBackend` (+ `warnIfOtherBackendPopulated`).
- `BeamNode` / `Node.init` (io field; `wipeAndReopenDb`; the lean node's own `ThreadPool.init`).
- Checkpoint-sync HTTP (`downloadCheckpointState` / `downloadAndStoreCheckpointBlock`) — real outbound network.
- `metrics.init` / `api.init`.

**2. Leaf blocking primitives** that can't practically take an `io` param use a single deliberate process `Io` — `pkgs/utils/src/process_io.zig`, installed once from `init.io` as the first statement of `mainInner` (before any worker thread spawns; written-once-before-reads):
- `utils` `SyncMutex`/`RwLock`, logger, `sleepNs`, fs helpers.
- `key-manager`, `api/event_broadcaster`, `network/ethlibp2p` (debug dump), `database` rocksdb/lmdb backend `open`, `node/locking` connected-peers RNG.

The installed value is the **real process `Io`** (a worker-capable `Threaded`), not a single-threaded instance. A zeam-owned local fallback covers tests / pre-install bootstrap.

## Result

`grep -rn global_single_threaded pkgs/` shows **no production references** — only `test` blocks, `setupTestPrimitives`, and `tools`/`spectest`/`stress` retain it (their intended debug/test use).

## Behavior

Identical. Every converted site does plain **blocking I/O**; the API/metrics servers remain serial accept-loops; the installed process `Io` performs the same kernel operations (the `Threaded` futex/blocking path is instance-independent). No concurrency/cancellation semantics were added.

## Test plan

- `zig build` green on `main`.
- No functional change (blocking I/O semantics preserved).
