### PR TITLE
deps: bump zig-libp2p to main (zquic raw-app retransmit landed)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "git+https://github.com/ch4r10t33r/zig-libp2p.git?ref=bump/zquic-rawapp-retransmit#b6c9af2ed382254978ec1010ff26132eaade4859",
-            .hash = "zig_libp2p-0.1.8-lil2hN1XEwAgYwAuxgmkFSZbbRVFKJhsMVACt0nosZ5V",
+            .url = "git+https://github.com/ch4r10t33r/zig-libp2p.git?ref=main#7e38e7eaa9f0049623e39db7f31919ab23cc6ef3",
+            .hash = "zig_libp2p-0.1.8-lil2hMVXEwB4O8mXE-InMZcOofAusHbEHtuZ9Daw59ub",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Pulls in the zquic raw-application STREAM retransmit fixes via zig-libp2p main.

zquic master now includes:
- ch4r10t33r/zquic#139 sendmmsg-rc handling
- ch4r10t33r/zquic#140 server-side raw-app STREAM retransmit
- ch4r10t33r/zquic#142 client-side raw-app STREAM retransmit + ACK handling

Verified end-to-end on local devnet: status-RPC timeouts 226/min → 0; both zeam nodes advance head_slot from genesis.