### PR TITLE
deps: bump zig-libp2p to main (zquic client-side PTO)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "git+https://github.com/ch4r10t33r/zig-libp2p.git?ref=bump/zquic-rawapp-retransmit#b6c9af2ed382254978ec1010ff26132eaade4859",
-            .hash = "zig_libp2p-0.1.8-lil2hN1XEwAgYwAuxgmkFSZbbRVFKJhsMVACt0nosZ5V",
+            .url = "git+https://github.com/ch4r10t33r/zig-libp2p.git?ref=main#fe729c87bbdbcabcd6888c49edcca7ed4ce695bd",
+            .hash = "zig_libp2p-0.1.8-lil2hMVXEwBEnbtpBf5S7RfWno7bJOod12Bf7WEzMnQG",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Pulls in ch4r10t33r/zquic#143 via zig-libp2p main. Closes the tail-loss gap left after #140/#142: the client now PTO-probes on idle bytes_in_flight, eliciting an ACK that lets the loss detector retransmit the dropped tail packets.

Supersedes #978.