### PR TITLE
ci: release from PR head commit

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,12 +26,60 @@ jobs:
       docker_tag: ${{ steps.get_tags_labels.outputs.docker_tag }}
       github_tag: ${{ steps.get_tags_labels.outputs.github_tag }}
       has_devnet_tag: ${{ steps.get_tags_labels.outputs.has_devnet_tag }}
+      release_sha: ${{ steps.resolve_release.outputs.release_sha }}
+      release_short_sha: ${{ steps.resolve_release.outputs.release_short_sha }}
+      publish_latest: ${{ steps.resolve_release.outputs.publish_latest }}
 
     steps:
-    - name: Checkout code
+    - name: Checkout release PR head
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Resolve release commit
+      id: resolve_release
+      run: |
+        git fetch origin main --prune --tags --force
+
+        PR_HEAD_SHA=$(git rev-parse HEAD)
+        PR_HEAD_TREE=$(git rev-parse HEAD^{tree})
+        MAIN_TREE=$(git rev-parse origin/main^{tree})
+        RELEASE_SHA="$PR_HEAD_SHA"
+
+        # Empty release commits are only a PR vehicle. If the release PR head is
+        # an empty single-parent commit, publish the parent commit instead so
+        # git tags, Docker metadata, and devnet branches point at the code that
+        # is actually being released.
+        if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -eq 2 ]; then
+          PARENT_SHA=$(git rev-parse HEAD^)
+          PARENT_TREE=$(git rev-parse HEAD^^{tree})
+          if [ "$PR_HEAD_TREE" = "$PARENT_TREE" ]; then
+            RELEASE_SHA="$PARENT_SHA"
+            echo "ℹ️ Release PR head is an empty commit; publishing parent ${RELEASE_SHA:0:8}"
+          fi
+        fi
+
+        RELEASE_SHORT_SHA=$(git rev-parse --short "$RELEASE_SHA")
+        RELEASE_TREE=$(git rev-parse "$RELEASE_SHA^{tree}")
+
+        echo "release_sha=$RELEASE_SHA" >> $GITHUB_OUTPUT
+        echo "release_short_sha=$RELEASE_SHORT_SHA" >> $GITHUB_OUTPUT
+
+        if [ "$RELEASE_TREE" = "$MAIN_TREE" ]; then
+          echo "publish_latest=true" >> $GITHUB_OUTPUT
+          echo "✅ Release tree matches current main; latest Docker tag will be published"
+        else
+          echo "publish_latest=false" >> $GITHUB_OUTPUT
+          echo "ℹ️ Release tree differs from current main; skipping latest Docker tag for pinned release"
+        fi
+
+        if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+          echo "❌ Release commit must be reachable from main history"
+          exit 1
+        fi
+
+        echo "✅ Release commit: $RELEASE_SHORT_SHA"
 
     - name: Extract tags from PR labels
       id: get_tags_labels
@@ -106,14 +154,14 @@ jobs:
 
         # Create version tag if needed
         if [ "$CREATE_VERSION_TAG" = "true" ]; then
-          git tag -a "${{ steps.get_tags_labels.outputs.git_tag }}" -m "Release version ${{ steps.get_tags_labels.outputs.version }}"
+          git tag -a "${{ steps.get_tags_labels.outputs.git_tag }}" "${{ steps.resolve_release.outputs.release_sha }}" -m "Release version ${{ steps.get_tags_labels.outputs.version }}"
           git push origin "${{ steps.get_tags_labels.outputs.git_tag }}"
           echo "✅ Created version tag ${{ steps.get_tags_labels.outputs.git_tag }}"
         fi
 
         # Create devnet git tag (DevnetX)
         if [ "$CREATE_DEVNET_TAG" = "true" ]; then
-          git tag -a "$DEVNET_GIT_TAG" -m "Devnet release for $DEVNET_GIT_TAG"
+          git tag -a "$DEVNET_GIT_TAG" "${{ steps.resolve_release.outputs.release_sha }}" -m "Devnet release for $DEVNET_GIT_TAG"
           git push origin "$DEVNET_GIT_TAG"
           echo "✅ Created devnet git tag $DEVNET_GIT_TAG"
         fi
@@ -132,10 +180,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-    - name: Checkout code
+    - name: Checkout release commit
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ needs.create-tags.outputs.release_sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -153,7 +202,7 @@ jobs:
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
-          type=raw,value=latest-${{ matrix.arch }}
+          type=raw,value=latest-${{ matrix.arch }},enable=${{ needs.create-tags.outputs.publish_latest == 'true' }}
           type=raw,value=${{ needs.create-tags.outputs.version }}-${{ matrix.arch }},enable=${{ needs.create-tags.outputs.version != 'null' }}
           type=raw,value=${{ needs.create-tags.outputs.docker_tag }}-${{ matrix.arch }},enable=${{ needs.create-tags.outputs.has_devnet_tag == 'true' }}
 
@@ -200,8 +249,8 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          GIT_COMMIT=${{ github.sha }}
-          GIT_BRANCH=${{ github.ref_name }}
+          GIT_COMMIT=${{ needs.create-tags.outputs.release_sha }}
+          GIT_BRANCH=${{ needs.create-tags.outputs.docker_tag || github.event.pull_request.head.ref }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         provenance: false
@@ -222,6 +271,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Create and push multi-arch manifest for latest
+      if: ${{ needs.create-tags.outputs.publish_latest == 'true' }}
       run: |
         docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-amd64 \
@@ -310,10 +360,11 @@ jobs:
       needs.create-tags.outputs.has_devnet_tag == 'true'
 
     steps:
-    - name: Checkout code
+    - name: Checkout release commit
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ needs.create-tags.outputs.release_sha }}
 
     - name: Delete existing devnet release if exists
       run: |
@@ -335,15 +386,39 @@ jobs:
       run: |
         DEVNET_TAG="${{ needs.create-tags.outputs.github_tag }}"
         VERSION="${{ needs.create-tags.outputs.version }}"
-        PREVIOUS_TAG=$(git tag -l \
-          | grep -iE "^[Dd]evnet[0-9]+$" \
-          | awk '{ print tolower($0), $0 }' \
-          | sort -V -r -k1,1 \
-          | awk '{ print $2 }' \
-          | grep -iv "^$DEVNET_TAG$" \
-          | head -1)
+        VERSION_TAG="v$VERSION"
+        PREVIOUS_TAG=""
 
-        if [ -n "$PREVIOUS_TAG" ] && [ "$PREVIOUS_TAG" != "$DEVNET_TAG" ]; then
+        # For devnet releases, compare against the previous devnet tag for the
+        # same network sequence: DevnetN -> DevnetN-1. This keeps Devnet5
+        # changelogs anchored to Devnet4, even if version numbering is not a
+        # perfect proxy for network transitions. For non-devnet releases, fall
+        # back to the nearest lower vX.Y.Z version tag.
+        if [ -n "$DEVNET_TAG" ]; then
+          DEVNET_NUMBER="${DEVNET_TAG#Devnet}"
+          if [ "$DEVNET_NUMBER" -gt 0 ] 2>/dev/null; then
+            PREVIOUS_DEVNET_NUMBER=$((DEVNET_NUMBER - 1))
+            PREVIOUS_DEVNET_TAG="Devnet$PREVIOUS_DEVNET_NUMBER"
+            if git rev-parse "$PREVIOUS_DEVNET_TAG" >/dev/null 2>&1; then
+              PREVIOUS_TAG="$PREVIOUS_DEVNET_TAG"
+            elif git rev-parse "devnet$PREVIOUS_DEVNET_NUMBER" >/dev/null 2>&1; then
+              PREVIOUS_TAG="devnet$PREVIOUS_DEVNET_NUMBER"
+            fi
+          fi
+        fi
+
+        if [ -z "$PREVIOUS_TAG" ]; then
+          while IFS= read -r TAG; do
+            TAG_VERSION="${TAG#v}"
+            HIGHEST=$(printf '%s\n%s\n' "$TAG_VERSION" "$VERSION" | sort -V | tail -1)
+            if [ "$TAG_VERSION" != "$VERSION" ] && [ "$HIGHEST" = "$VERSION" ]; then
+              PREVIOUS_TAG="$TAG"
+              break
+            fi
+          done < <(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V -r)
+        fi
+
+        if [ -n "$PREVIOUS_TAG" ] && [ "$PREVIOUS_TAG" != "$VERSION_TAG" ] && [ "$PREVIOUS_TAG" != "$DEVNET_TAG" ]; then
           echo "✅ Found previous tag: $PREVIOUS_TAG"
           echo "📝 Generating changelog from $PREVIOUS_TAG to current release..."
           
@@ -377,7 +452,7 @@ jobs:
           echo "ℹ️ No previous release found or this is the first release"
           CHANGELOG="## 📋 Changes
 
-          This is the first devnet release."
+          This is the first versioned release before $VERSION_TAG."
         fi
 
         # Save changelog to output (escape newlines for GitHub Actions)
@@ -397,6 +472,7 @@ jobs:
           ## Release Information
           - **Version**: ${{ needs.create-tags.outputs.version }}
           - **Network**: ${{ needs.create-tags.outputs.github_tag }}
+          - **Release commit**: `${{ needs.create-tags.outputs.release_short_sha }}`
           - **Docker Images**: `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.create-tags.outputs.docker_tag }}`
 
           ## 📋 Changes
@@ -414,7 +490,7 @@ jobs:
 
           ## 🏷️ All Available Tags
           ```bash
-          # Latest release
+          # Latest release (only updated when release PR head matches current main)
           docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
           # Version-specific
@@ -436,21 +512,15 @@ jobs:
         DEVNET_BRANCH="$DOCKER_TAG"  # branch = devnetX
 
         echo "✅ GitHub tag: $GITHUB_TAG, Docker tag/branch: $DOCKER_TAG"
-        # Fetch all remotes first - ensures origin/main and all branches are available
-        git fetch origin
+        RELEASE_SHA="${{ needs.create-tags.outputs.release_sha }}"
 
-        if git ls-remote --heads origin | grep -q "refs/heads/$DEVNET_BRANCH$"; then
-          echo "✅ $DEVNET_BRANCH branch exists, updating it"
+        # Fetch all remotes first - ensures release commit and branches are available
+        git fetch origin --prune --tags --force
 
-          git checkout "$DEVNET_BRANCH"
-          git merge origin/main --no-edit
-        else
-          echo "✅ $DEVNET_BRANCH branch doesn't exist, creating it from main"
-          git checkout -b "$DEVNET_BRANCH" origin/main
-        fi
-
-        git push origin "$DEVNET_BRANCH"
-        echo "✅ Successfully pushed code to $DEVNET_BRANCH branch"
+        echo "✅ Updating $DEVNET_BRANCH branch to release commit ${RELEASE_SHA:0:8}"
+        git checkout -B "$DEVNET_BRANCH" "$RELEASE_SHA"
+        git push origin "$DEVNET_BRANCH" --force-with-lease
+        echo "✅ Successfully pushed release commit to $DEVNET_BRANCH branch"
 
     - name: Send Telegram success notification
       if: ${{ success() }}

--- a/.github/workflows/shadow-rebase.yml
+++ b/.github/workflows/shadow-rebase.yml
@@ -61,9 +61,10 @@ jobs:
 
     - name: Send Telegram failure notification
       if: failure()
+      env:
+        COMMIT_MSG_FULL: ${{ github.event.head_commit.message || 'manual trigger' }}
       run: |
         MAIN_SHA="${{ github.sha }}"
-        COMMIT_MSG_FULL="${{ github.event.head_commit.message || 'manual trigger' }}"
         COMMIT_MSG="${COMMIT_MSG_FULL%%$'\n'*}"
         REPO_URL="${{ github.server_url }}/${{ github.repository }}"
         RUN_URL="$REPO_URL/actions/runs/${{ github.run_id }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,132 +1,263 @@
 # Zeam Release Process
 
-This document outlines the complete process for creating releases using the automated GitHub Actions workflow.
+This document describes the PR-based, label-based release process used by the automated GitHub Actions release workflow.
 
 ## Overview
 
-The Zeam release process uses a GitHub Actions workflow that automatically creates git tags, builds Docker images, and publishes releases when a Pull Request from the `release` branch to `main` branch is merged with specific labels.
+A release is created by merging a Pull Request from the `release` branch into `main` with release labels.
+
+The workflow always reads release metadata from PR labels:
+
+- `release` — required; enables the release workflow
+- `x.y.z` — required version label, for example `0.4.36`
+- `devnetN` — optional network label, for example `devnet4` or `devnet5`
+
+The workflow resolves the release commit from the release PR head, not blindly from the top of `main`. If the PR head is an empty release commit, the workflow publishes its parent. This allows two release modes:
+
+1. **Current-main release** — create `release` from `origin/main`.
+2. **Pinned release** — create `release` from a specific earlier commit, then add an empty release commit.
+
+This keeps the process PR-reviewed and label-based while allowing releases from exact commits.
 
 ## Prerequisites
 
-- Repository access with write permissions to create branches and merge PRs
-- Understanding of semantic versioning (e.g., `1.0.0`, `1.2.3`)
-- Basic knowledge of Git and GitHub
+- Repository access with permission to create/push the `release` branch and open PRs
+- Permission to add release labels and merge the release PR
+- A unique semantic version label, for example `0.4.36`
 
-## Step-by-Step Release Process
+## Important Behavior
 
-### 1. Update Release Branch or create Release branch from Main
+### Release commit
 
-If `release` doesn't exist yet, create it from `main`. Otherwise, update it with the latest `main` branch:
+The workflow starts from the release PR head commit:
 
-#### Option A: Release Branch Already Exists
-
-```bash
-# Ensure you're on main and up to date
-git checkout main
-git pull origin main
-
-# Checkout the existing release branch
-git checkout release
-git pull origin release
-
-# Merge latest main into release
-git merge main --no-edit
+```text
+github.event.pull_request.head.sha
 ```
 
-#### Option B: Create Release Branch for the First Time
+If the PR head is an empty single-parent release commit, the workflow publishes the parent commit instead. Git tags, Docker metadata, and the devnet branch point to the commit whose code is actually being released.
 
-```bash
-# Ensure you're on main and up to date
-git checkout main
-git pull origin main
+### `latest` Docker tag
 
-# Create and checkout new release branch from main
-git checkout -b release
+`blockblaz/zeam:latest` is only updated when the resolved release tree matches current `main`.
 
-# Push the new release branch to remote
-git push -u origin release
+- Current-main release: updates `latest`
+- Pinned older release: does **not** update `latest`
+
+This prevents an older pinned devnet release from accidentally overwriting `latest`.
+
+### Devnet branch
+
+When a devnet label is present, the corresponding lowercase branch is updated to the release commit:
+
+```text
+devnet4, devnet5, ...
 ```
 
-### 2. Create Empty Commit (Required for PR)
+The branch is intentionally lowercase, while the GitHub Release tag is capitalized:
 
-Since the release branch is identical to main, create an empty commit to enable PR creation:
-
-```bash
-# Create an empty commit with release message
-git commit --allow-empty -m "Release commit for devnet x"
-
-# Push the release branch
-git push origin release
+```text
+Docker/branch: devnet4
+GitHub tag:   Devnet4
 ```
 
-### 3. Create Pull Request
+## Release Mode 1: Current-Main Release
 
-Create a Pull Request from release branch to main branch with the following labels:
+Use this when the release should include the latest code on `main`.
 
-- Required Labels:
-  - `release` – Mandatory label to trigger the release workflow
-  - Version label (MANDATORY): `x.y.z` (e.g., `1.0.0`)
-- Optional Labels:
-  - Network tag (optional): `devnet0`, `devnet1`, `devnet2`, etc.
+### Steps
 
-### 4. Review and Merge Pull Request
+```bash
+git fetch origin --prune --tags
+git checkout -B release origin/main
+git commit --allow-empty -m "Release commit for devnet5 v0.5.0"
+git push -f origin release
+```
 
-- Have the PR reviewed and approved by team members
-- Merge the Pull Request to main
-- The GitHub Actions workflow will automatically trigger
+Open a PR:
+
+```text
+release -> main
+```
+
+Add labels:
+
+```text
+release
+0.5.0
+devnet5
+```
+
+After review, merge the PR. The workflow will publish the parent of the empty release commit and, because its tree matches current `main`, update `latest`.
+
+## Release Mode 2: Pinned Release from a Specific Commit
+
+Use this when the release should be cut from an exact older commit, not from top of `main`.
+
+Common uses:
+
+- final release for an old devnet
+- release before a large breaking PR
+- known-good historical build
+- hotfix-style release from an earlier point in history
+
+### Steps
+
+Find the target commit:
+
+```bash
+git fetch origin --prune --tags
+git log --oneline origin/main
+```
+
+Create the release branch from that commit:
+
+```bash
+git checkout -B release <target-commit>
+git commit --allow-empty -m "Release commit for devnet4 v0.4.36 from <target-commit>"
+git push -f origin release
+```
+
+Open a PR:
+
+```text
+release -> main
+```
+
+Add labels:
+
+```text
+release
+0.4.36
+devnet4
+```
+
+After review, merge the PR. The workflow will publish the parent of the empty release commit. Because the release tree does not match current `main`, the workflow will skip the `latest` Docker tag.
+
+### Example: Final devnet4 Before devnet5
+
+If `0009ea9` is the commit immediately before devnet5 landed:
+
+```bash
+git fetch origin --prune --tags
+git checkout -B release 0009ea9
+git commit --allow-empty -m "Release commit for devnet4 v0.4.36 from 0009ea9"
+git push -f origin release
+```
+
+PR labels:
+
+```text
+release
+0.4.36
+devnet4
+```
+
+Expected outputs:
+
+```text
+v0.4.36
+Devnet4
+blockblaz/zeam:0.4.36
+blockblaz/zeam:devnet4
+```
+
+`blockblaz/zeam:latest` is not updated for this pinned release.
 
 ## What the Workflow Creates
 
-When the PR is merged with a version label and an optional devnet label, the workflow produces the following:
+When the PR is merged with a version label and optional devnet label, the workflow produces:
 
-- Git Tags (created on the main branch)
-  - Version tag: `v{VERSION}` (e.g., `v1.2.3`)
-  - GitHub devnet tag: `{GITHUB_TAG}` (capitalized, e.g., `Devnet2`)
-    - Used for the git tag and the GitHub Release
-- Docker Images (Multi-architecture: AMD64 & ARM64)
-  - Latest: `blockblaz/zeam:latest`
-  - Version: `blockblaz/zeam:{VERSION}` (e.g., `blockblaz/zeam:1.2.3`)
-  - Devnet (docker tag): `blockblaz/zeam:{DOCKER_TAG}` (lowercase, e.g., `blockblaz/zeam:devnet2`)
-  - Architecture-specific:
-    - `blockblaz/zeam:{TAG}-amd64`
-    - `blockblaz/zeam:{TAG}-arm64`
-  - Manifests:
-    - `latest` = `latest-amd64` + `latest-arm64`
-    - `{VERSION}` = `{VERSION}-amd64` + `{VERSION}-arm64`
-    - `{DOCKER_TAG}` = `{DOCKER_TAG}-amd64` + `{DOCKER_TAG}-arm64`
-- Branch
-  - Created/updated: `{DOCKER_TAG}` (lowercase, e.g., `devnet2`)
-  - Note: Branch name intentionally differs from the GitHub devnet tag (`Devnet2`)
-- GitHub Release
-  - Created only when a devnet tag is present
-  - Title: `Zeam {GITHUB_TAG} Release` (e.g., `Zeam Devnet2 Release`)
-  - Tag name: `{GITHUB_TAG}` (e.g., `Devnet2`)
-  - Body includes:
-    - Version: `{VERSION}`
-    - Docker pull commands using `{DOCKER_TAG}`
-    - Link to the release: `/releases/tag/{GITHUB_TAG}`
-  - Marked as prerelease for devnet tags
+### Git tags
 
-### Labels to Outputs Mapping
+- Version tag: `v{VERSION}`, for example `v0.4.36`
+- Devnet tag: `{GITHUB_TAG}`, for example `Devnet4`
+  - The devnet tag is recreated if it already exists.
+  - The version tag must not already exist.
 
-- Version label → `VERSION` → creates `v{VERSION}` git tag and versioned Docker images
-- Devnet label (e.g., `devnet2`) → two outputs:
-  - `github_tag` = `Devnet2` (capitalized)
-    - Used for git tag and GitHub Release
-  - `docker_tag` = `devnet2` (lowercase)
-    - Used for Docker image tags, manifests, and branch name
+### Docker images
 
-### Example
-
-For labels:
-- Version: `0.2.6`
-- Devnet: `devnet2`
-
-Outputs:
-- Git tags: `v0.2.6`, `Devnet2`
-- Docker images:
+- Versioned image:
+  - `blockblaz/zeam:{VERSION}`
+  - `blockblaz/zeam:{VERSION}-amd64`
+  - `blockblaz/zeam:{VERSION}-arm64`
+- Devnet image, when a devnet label is present:
+  - `blockblaz/zeam:{DOCKER_TAG}`
+  - `blockblaz/zeam:{DOCKER_TAG}-amd64`
+  - `blockblaz/zeam:{DOCKER_TAG}-arm64`
+- Latest image, only for current-main releases:
   - `blockblaz/zeam:latest`
-  - `blockblaz/zeam:0.2.6`, `blockblaz/zeam:0.2.6-amd64`, `blockblaz/zeam:0.2.6-arm64`
-  - `blockblaz/zeam:devnet2`, `blockblaz/zeam:devnet2-amd64`, `blockblaz/zeam:devnet2-arm64`
-- Branch: `devnet2`
-- GitHub Release: tag `Devnet2`, title `Zeam Devnet2 Release`, prerelease
+  - `blockblaz/zeam:latest-amd64`
+  - `blockblaz/zeam:latest-arm64`
+
+### GitHub Release
+
+Created only when a devnet label is present.
+
+- Tag: `DevnetN`, for example `Devnet4`
+- Title: `Zeam DevnetN Release`
+- Marked as prerelease
+- Includes version, release commit, changelog, and Docker pull commands
+- Changelog source:
+  - If a `devnetN` label is present, changelog is generated from `DevnetN-1` when that tag exists.
+  - If no devnet label is present, or the previous devnet tag does not exist, changelog falls back to the nearest lower `vX.Y.Z` version tag.
+
+### Devnet branch
+
+Created or updated to the release commit:
+
+```text
+{DOCKER_TAG}
+```
+
+For example:
+
+```text
+devnet4
+```
+
+## Label Mapping
+
+- Version label `0.4.36` → `VERSION=0.4.36` → tag `v0.4.36`
+- Devnet label `devnet4` → Docker tag/branch `devnet4`
+- Devnet label `devnet4` → GitHub Release tag `Devnet4`
+
+## Guardrails
+
+The workflow enforces these checks:
+
+- PR must be merged into `main`.
+- PR head branch must be `release`.
+- PR must have the `release` label.
+- PR must have exactly a valid semantic version-style label, such as `0.4.36`.
+- Version tag `v{VERSION}` must not already exist.
+- Release PR parent must be reachable from `main` history.
+- `latest` is only published when the resolved release tree matches current `main`.
+
+## Troubleshooting
+
+### PR says it is behind main
+
+This is expected for pinned releases.
+
+Example:
+
+```text
+A -- B -- C -- D  main
+      \
+       R          release
+```
+
+If `release` was created from `B` and `R` is an empty release commit, GitHub may show the PR as behind `main`. That is fine. The empty release commit normally merges without conflicts because it changes no files.
+
+### Will a pinned release PR create conflicts?
+
+Usually no, as long as the release branch only contains the empty release commit. Since the commit changes no files, there is normally nothing to conflict with.
+
+### Why did `latest` not update?
+
+The workflow only updates `latest` when the resolved release tree matches current `main`. Pinned releases intentionally skip `latest`.
+
+### Why does the PR contain an empty release commit?
+
+The empty commit exists only to make a reviewable PR from `release` to `main`. The workflow detects empty single-parent release commits and publishes the parent commit, so the recorded release SHA is the target commit being released.


### PR DESCRIPTION
Fixes #980.

## Summary
- Keep the release flow PR-based and label-based (`release`, version label, optional `devnetN`).
- Build/tag releases from the release PR head commit instead of always using top of `main`.
- Allow pinned releases by creating `release` from an older commit plus an empty release commit.
- Only publish `blockblaz/zeam:latest` when the release PR head tree matches current `main`.
- Update devnet branches to the actual release commit instead of merging `origin/main`.
- Include release commit/latest status in release output and Telegram notifications.
- Fix shadow-rebase Telegram failure notification quoting so commit-message backticks do not execute as shell commands.
- Rewrite `RELEASE.md` with current-main and pinned-release steps, examples, and guardrails.

## Validation
- `git diff --check`
- Local resolver simulation: pinned pre-devnet5 commit => `publish_latest=false`; current main => `publish_latest=true`; pinned parent reachable from `origin/main`.
- Workflow string checks for PR-head checkout, release SHA propagation, guarded latest tag, and devnet branch force-with-lease update.
