### PR TITLE
ci: escape Telegram release notification backticks

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -537,20 +537,20 @@ jobs:
         MESSAGE="🚀 *Zeam $GITHUB_TAG Release SUCCESS*
 
         *Release Details:*
-        • Version: `$VERSION`
-        • Network: `$GITHUB_TAG`
+        • Version: \`$VERSION\`
+        • Network: \`$GITHUB_TAG\`
         • Repository: [${{ github.repository }}]($REPO_URL)
 
         *🐋 Docker Images Available:*
-        • Multi-arch: `$REGISTRY/$IMAGE_NAME:$DOCKER_TAG`
-        • AMD64: `$REGISTRY/$IMAGE_NAME:$DOCKER_TAG-amd64`
-        • ARM64: `$REGISTRY/$IMAGE_NAME:$DOCKER_TAG-arm64`
+        • Multi-arch: \`$REGISTRY/$IMAGE_NAME:$DOCKER_TAG\`
+        • AMD64: \`$REGISTRY/$IMAGE_NAME:$DOCKER_TAG-amd64\`
+        • ARM64: \`$REGISTRY/$IMAGE_NAME:$DOCKER_TAG-arm64\`
 
         *🔗 Quick Links:*
         • [GitHub Release]($REPO_URL/releases/tag/$GITHUB_TAG)
 
         *🌿 Deployment:*
-        • Code pushed to `$DOCKER_TAG` branch
+        • Code pushed to \`$DOCKER_TAG\` branch
         • Shadow branch: $SHADOW_STATUS
 
         _🤖 Automated release notification_"


### PR DESCRIPTION
## Summary
- Escape Markdown inline-code backticks in the Telegram release success message
- Prevent Bash from treating release values like version/tag/image as command substitutions before jq/curl runs

## Validation
- Verified the workflow file now contains escaped backticks for the Telegram `MESSAGE` fields
