### PR TITLE
fix(node): propose-path layering + publish latency + coverage report

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -456,7 +456,7 @@ pub const BeamChain = struct {
 
     /// The block proof is a recursive-STARK Type-2 merge that takes seconds at the
     /// prod scheme — far longer than an 800ms interval. Running it on the libxev slot loop would
-    /// freeze gossip/tick handling, so `submitProposeOnInterval` offloads the whole propose
+    /// freeze gossip/tick handling, so `submitPropose` offloads the whole propose
     /// (produceBlock + buildBlockProof + publishBlock) to a `thread_pool` worker, mirroring the
     /// aggregate worker. At most one propose runs at a time; a second trigger is dropped (the next
     /// slot re-proposes). `proposeImpl` decrements on exit.
@@ -3636,6 +3636,88 @@ pub const BeamChain = struct {
             return BlockProcessingError.KnownInvalidBlock;
         }
 
+        // ── Locally-produced / already-imported fast path ──────────────────
+        // produceBlock has already run the state transition for this block,
+        // cached the post state (`statesPutExclusive`) and inserted the block
+        // into fork choice; the publish hop previously re-cloned the parent,
+        // re-verified AND re-ran the whole transition here, only for
+        // `statesCommitKeepExisting` below to discard the recomputed state.
+        // None of that was designed: before the per-resource locking
+        // migration, publishBlock handed the cached post state to onBlock and
+        // this entire recompute (verify included) was skipped for locally
+        // produced blocks. This path restores those semantics: a proof this
+        // node just built is not re-verified against itself — preventing a
+        // corrupt proof from being built is the build path's job — and the
+        // transition result is not recomputed only to be discarded.
+        //
+        // The two probes make the path self-validating: it activates only when
+        // BOTH the fork-choice block and the cached post state already exist
+        // (which also covers duplicate re-imports, whose first import already
+        // verified them). Any miss falls through to the full path below.
+        fastpath: {
+            if (self.forkChoice.getBlock(block_root) == null) break :fastpath;
+            {
+                var probe = self.statesGet(block_root) orelse break :fastpath;
+                probe.deinit();
+            }
+
+            // Same cache-sync step as the full path (idempotent re-put for
+            // duplicate imports).
+            {
+                var t_rts = LockTimer.start("root_to_slot", "onBlock.cachePut");
+                locking.assertNoTier5SiblingHeld("onBlock.cachePut");
+                self.root_to_slot_lock.lock();
+                locking.enterTier5();
+                t_rts.acquired();
+                defer {
+                    self.root_to_slot_lock.unlock();
+                    locking.leaveTier5();
+                    t_rts.released();
+                }
+                try self.root_to_slot_cache.put(block_root, block.slot);
+            }
+
+            // SSZ bytes for persistence — same live-serialize caveat as the
+            // full path: never pass the live SignedBlock to ssz.serialize.
+            var fp_fallback_ssz: std.ArrayList(u8) = .empty;
+            defer fp_fallback_ssz.deinit(self.allocator);
+            var fp_clone: types.SignedBlock = undefined;
+            var fp_clone_initialized = false;
+            defer if (fp_clone_initialized) fp_clone.deinit();
+            const fp_ssz_for_db: []const u8 = if (blockInfo.sszBytes) |precomputed| precomputed else blk: {
+                fp_clone = try zeam_utils.clone(types.SignedBlock, &signedBlock, self.allocator);
+                fp_clone_initialized = true;
+                try ssz.serialize(types.SignedBlock, fp_clone, &fp_fallback_ssz, self.allocator);
+                step_watch.lap("ssz_serialize_fallback");
+                break :blk fp_fallback_ssz.items;
+            };
+
+            // Persist using the cached post state (re-borrowed after the
+            // verify; if it was pruned in between, fall back to the full
+            // path which recomputes it).
+            var post_borrow = self.statesGet(block_root) orelse break :fastpath;
+            defer post_borrow.assertReleasedOrPanic();
+            const processing_time = onblock_timer.observe();
+            {
+                defer post_borrow.deinit();
+                self.updateBlockDb(fp_ssz_for_db, block_root, post_borrow.state.*, block.slot) catch |err| {
+                    self.logger.err("failed to update block database for block root=0x{x}: {any}", .{
+                        &block_root,
+                        err,
+                    });
+                };
+            }
+            try self.forkChoice.confirmBlock(block_root);
+            step_watch.lap("db_persist");
+
+            self.logger.info("processed block with root=0x{x} slot={d} processing time={d} (cached post state, verify+transition skipped)", .{
+                &block_root,
+                block.slot,
+                processing_time,
+            });
+            return try self.allocator.alloc(types.Root, 0);
+        }
+
         const post_state_owned = blockInfo.postState == null;
         const post_state = if (blockInfo.postState) |post_state_ptr| post_state_ptr else computedstate: {
             // 1. Snapshot parent state under `states_lock.shared`, then
@@ -4996,19 +5078,16 @@ pub const BeamChain = struct {
         chain.aggregate_last_completed_slot.store(@intCast(slot), .release);
     }
 
-    /// Trigger off-loop block production for `time_intervals` if this node is the
-    /// proposer for the slot. Called from the libxev interval tick at interval-in-slot 0; returns
-    /// within microseconds. The whole propose (produceBlock + Type-2 merge + publishBlock) runs on
-    /// a `thread_pool` worker so the multi-second prod-scheme merge never freezes the slot loop.
-    /// At most one propose is in flight; a second trigger is dropped (the next slot re-proposes).
-    pub fn submitProposeOnInterval(self: *Self, node: *@import("./node.zig").BeamNode, time_intervals: usize) void {
-        if (time_intervals % constants.INTERVALS_PER_SLOT != 0) return;
-        const slot = @divFloor(time_intervals, constants.INTERVALS_PER_SLOT);
-
-        // Only the node running this slot's proposer does anything.
-        const validator = if (node.validator) |*v| v else return;
-        const proposer_id = validator.getSlotProposer(slot) orelse return;
-
+    /// Trigger off-loop block production for an already-resolved proposer duty.
+    /// The "am I proposer this slot?" decision is the validator client's
+    /// (`ValidatorClient.onInterval` resolves `proposer_id` via `getSlotProposer`
+    /// and calls this at interval-in-slot 0); this function owns only the
+    /// chain-state gating (sync status) and the off-loop dispatch, and returns
+    /// within microseconds. The whole propose (produceBlock + Type-2 merge +
+    /// publishBlock) runs on a `thread_pool` worker so the multi-second
+    /// prod-scheme merge never freezes the slot loop. At most one propose is in
+    /// flight; a second trigger is dropped (the next slot re-proposes).
+    pub fn submitPropose(self: *Self, node: *@import("./node.zig").BeamNode, slot: usize, proposer_id: usize) void {
         // Sync gating (the checks the old on-loop maybeDoProposal performed).
         switch (self.getSyncStatus()) {
             .synced => {},

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -3636,90 +3636,27 @@ pub const BeamChain = struct {
             return BlockProcessingError.KnownInvalidBlock;
         }
 
-        // ── Locally-produced / already-imported fast path ──────────────────
-        // produceBlock has already run the state transition for this block,
-        // cached the post state (`statesPutExclusive`) and inserted the block
-        // into fork choice; the publish hop previously re-cloned the parent,
-        // re-verified AND re-ran the whole transition here, only for
-        // `statesCommitKeepExisting` below to discard the recomputed state.
-        // None of that was designed: before the per-resource locking
-        // migration, publishBlock handed the cached post state to onBlock and
-        // this entire recompute (verify included) was skipped for locally
-        // produced blocks. This path restores those semantics: a proof this
-        // node just built is not re-verified against itself — preventing a
-        // corrupt proof from being built is the build path's job — and the
-        // transition result is not recomputed only to be discarded.
-        //
-        // The two probes make the path self-validating: it activates only when
-        // BOTH the fork-choice block and the cached post state already exist
-        // (which also covers duplicate re-imports, whose first import already
-        // verified them). Any miss falls through to the full path below.
-        fastpath: {
-            if (self.forkChoice.getBlock(block_root) == null) break :fastpath;
-            {
-                var probe = self.statesGet(block_root) orelse break :fastpath;
-                probe.deinit();
-            }
-
-            // Same cache-sync step as the full path (idempotent re-put for
-            // duplicate imports).
-            {
-                var t_rts = LockTimer.start("root_to_slot", "onBlock.cachePut");
-                locking.assertNoTier5SiblingHeld("onBlock.cachePut");
-                self.root_to_slot_lock.lock();
-                locking.enterTier5();
-                t_rts.acquired();
-                defer {
-                    self.root_to_slot_lock.unlock();
-                    locking.leaveTier5();
-                    t_rts.released();
-                }
-                try self.root_to_slot_cache.put(block_root, block.slot);
-            }
-
-            // SSZ bytes for persistence — same live-serialize caveat as the
-            // full path: never pass the live SignedBlock to ssz.serialize.
-            var fp_fallback_ssz: std.ArrayList(u8) = .empty;
-            defer fp_fallback_ssz.deinit(self.allocator);
-            var fp_clone: types.SignedBlock = undefined;
-            var fp_clone_initialized = false;
-            defer if (fp_clone_initialized) fp_clone.deinit();
-            const fp_ssz_for_db: []const u8 = if (blockInfo.sszBytes) |precomputed| precomputed else blk: {
-                fp_clone = try zeam_utils.clone(types.SignedBlock, &signedBlock, self.allocator);
-                fp_clone_initialized = true;
-                try ssz.serialize(types.SignedBlock, fp_clone, &fp_fallback_ssz, self.allocator);
-                step_watch.lap("ssz_serialize_fallback");
-                break :blk fp_fallback_ssz.items;
-            };
-
-            // Persist using the cached post state (re-borrowed after the
-            // verify; if it was pruned in between, fall back to the full
-            // path which recomputes it).
-            var post_borrow = self.statesGet(block_root) orelse break :fastpath;
-            defer post_borrow.assertReleasedOrPanic();
-            const processing_time = onblock_timer.observe();
-            {
-                defer post_borrow.deinit();
-                self.updateBlockDb(fp_ssz_for_db, block_root, post_borrow.state.*, block.slot) catch |err| {
-                    self.logger.err("failed to update block database for block root=0x{x}: {any}", .{
-                        &block_root,
-                        err,
-                    });
-                };
-            }
-            try self.forkChoice.confirmBlock(block_root);
-            step_watch.lap("db_persist");
-
-            self.logger.info("processed block with root=0x{x} slot={d} processing time={d} (cached post state, verify+transition skipped)", .{
-                &block_root,
-                block.slot,
-                processing_time,
-            });
-            return try self.allocator.alloc(types.Root, 0);
-        }
-
         const post_state_owned = blockInfo.postState == null;
         const post_state = if (blockInfo.postState) |post_state_ptr| post_state_ptr else computedstate: {
+            // Locally produced blocks (and duplicate re-imports): produceBlock already
+            // ran the transition and cached the post state, so reuse it instead of
+            // re-cloning the parent and re-running verify + the transition — work
+            // whose result `statesCommitKeepExisting` below discards anyway because
+            // the map entry already exists. The caller cannot hand us the cached
+            // state via `blockInfo.postState`: `statesGet` returns a `BorrowedState`
+            // whose read side must not be held across the exclusive commit below
+            // (the deadlock that removed the original shortcut), and the
+            // caller-supplied path deep-clones the value a second time. Resolving
+            // the cache here keeps one owned clone and a single flow.
+            reuse: {
+                if (self.forkChoice.getBlock(block_root) == null) break :reuse;
+                var cached_borrow = self.statesGet(block_root) orelse break :reuse;
+                defer cached_borrow.assertReleasedOrPanic();
+                const snapshot = try cached_borrow.cloneAndRelease(self.allocator);
+                step_watch.lap("cached_post_state_reuse");
+                break :computedstate snapshot;
+            }
+
             // 1. Snapshot parent state under `states_lock.shared`, then
             //    release. Verify + STF run on the owned snapshot so we
             //    don't hold the read lock across the long FFI window.

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -949,11 +949,16 @@ pub const ForkChoice = struct {
                 const cc_u32 = self.config.spec.attestation_committee_count;
                 if (vc > 0 and cc_u32 > 0) {
                     const cc: usize = @intCast(cc_u32);
-                    // Determine slot from the first entry key.
+                    // Stamp the snapshot with the NEWEST data slot present.
+                    // Map iteration order is arbitrary and mixed data slots are
+                    // normal (aggregates mature over several slots), so taking
+                    // the first key would stamp a random slot.
                     var payload_slot: types.Slot = 0;
                     {
                         var it_s = self.latest_new_aggregated_payloads.iterator();
-                        if (it_s.next()) |first| payload_slot = first.key_ptr.slot;
+                        while (it_s.next()) |e| {
+                            if (e.key_ptr.slot > payload_slot) payload_slot = e.key_ptr.slot;
+                        }
                     }
                     const new_seen = try self.allocator.alloc(bool, vc);
                     var coverage_saved = false;
@@ -1892,9 +1897,13 @@ pub const ForkChoice = struct {
     ///
     /// Sections:
     ///   prev_new  – coverage saved just before the last acceptNewAttestationsUnlocked merge
-    ///               (represents the previous slot's new payloads that were accepted)
-    ///   late      – current latest_new_aggregated_payloads for `slot`
+    ///               (represents the previous round's new payloads that were accepted)
+    ///   late      – current latest_new_aggregated_payloads near `slot`
     ///               (payloads that arrived after the last merge — late arrivals)
+    ///
+    /// All sections match data slots in the window (slot - WINDOW, slot] rather
+    /// than exactly `slot`: aggregation matures payloads 2-3 slots after the
+    /// attestation slot, so an exact-slot report is permanently empty.
     ///   block     – payloads observed in the most-recently processed block
     ///   combined  – union of all three
     ///   diff      – validator-coverage delta between block and prev_new
@@ -1939,7 +1948,8 @@ pub const ForkChoice = struct {
 
         // Fill prev_new from the coverage saved before the last merge (if slot matches).
         if (self.saved_pre_merge_new_coverage) |*cov| {
-            if (cov.slot == slot) {
+            // Window match, mirroring collectCoverageFromPayloads.
+            if (cov.slot <= slot and cov.slot +| COVERAGE_REPORT_WINDOW_SLOTS > slot) {
                 const vlen = @min(cov.seen.len, validator_count);
                 @memcpy(prev_new_seen[0..vlen], cov.seen[0..vlen]);
                 const slen = @min(cov.has_subnet.len, committee_count);
@@ -4527,6 +4537,13 @@ fn pruneTrivialFromAggregateSnapshot(
     );
 }
 
+/// Coverage-report slot window. Aggregated payloads for attestation data made
+/// at slot S mature through the pipeline (gossip aggregate -> latest_new ->
+/// rotation -> latest_known / block inclusion) over the following ~2-3 slots,
+/// so a "last round" report keyed to a single exact data slot never matches
+/// anything; it must look back a few data slots.
+const COVERAGE_REPORT_WINDOW_SLOTS: types.Slot = 4;
+
 fn collectCoverageFromPayloads(
     map: *AggregatedPayloadsMap,
     slot: types.Slot,
@@ -4538,9 +4555,10 @@ fn collectCoverageFromPayloads(
 ) void {
     var it = map.iterator();
     while (it.next()) |entry| {
-        if (entry.key_ptr.slot != slot) continue;
+        // Window match (slot - WINDOW, slot]: see COVERAGE_REPORT_WINDOW_SLOTS.
+        if (entry.key_ptr.slot > slot or entry.key_ptr.slot +| COVERAGE_REPORT_WINDOW_SLOTS <= slot) continue;
         for (entry.value_ptr.items) |*stored| {
-            if (stored.slot != slot) continue;
+            if (stored.slot > slot or stored.slot +| COVERAGE_REPORT_WINDOW_SLOTS <= slot) continue;
             for (0..stored.proof.participants.len()) |validator_index| {
                 if (validator_index >= seen.len) continue;
                 if (!(stored.proof.participants.get(validator_index) catch false)) continue;
@@ -6100,4 +6118,77 @@ test "rebase: to fork branch node (G) removes previous canonical chain" {
     try std.testing.expect(ctx.fork_choice.attestations.get(2).?.latestKnown.?.index == 1);
     // I: 8 -> 2
     try std.testing.expect(ctx.fork_choice.attestations.get(3).?.latestKnown.?.index == 2);
+}
+
+test "collectCoverageFromPayloads matches data slots within the report window" {
+    const allocator = std.testing.allocator;
+    const data_slot: types.Slot = 100;
+
+    var map = AggregatedPayloadsMap.init(allocator);
+    defer {
+        var it = map.iterator();
+        while (it.next()) |entry| {
+            for (entry.value_ptr.items) |*stored| stored.proof.deinit();
+            entry.value_ptr.deinit(allocator);
+        }
+        map.deinit();
+    }
+
+    // One stored payload for attestation data made at `data_slot`, with
+    // validators 1 and 3 as participants.
+    var proof = try types.SingleMessageAggregate.init(allocator);
+    errdefer proof.deinit();
+    try types.aggregationBitsSet(&proof.participants, 1, true);
+    try types.aggregationBitsSet(&proof.participants, 3, true);
+
+    const att_data = types.AttestationData{
+        .slot = data_slot,
+        .head = .{ .root = [_]u8{0} ** 32, .slot = data_slot },
+        .target = .{ .root = [_]u8{0} ** 32, .slot = data_slot },
+        .source = .{ .root = [_]u8{0} ** 32, .slot = 0 },
+    };
+    const gop = try map.getOrPut(att_data);
+    gop.value_ptr.* = .empty;
+    try gop.value_ptr.append(allocator, .{ .slot = data_slot, .proof = proof });
+
+    const validator_count = 8;
+    const committee_count: types.SubnetId = 1;
+    var seen: [validator_count]bool = undefined;
+    var combined_seen: [validator_count]bool = undefined;
+    var has_subnet: [1]bool = undefined;
+    var combined_has: [1]bool = undefined;
+
+    const reset = struct {
+        fn run(s: []bool, cs: []bool, h: []bool, ch: []bool) void {
+            @memset(s, false);
+            @memset(cs, false);
+            @memset(h, false);
+            @memset(ch, false);
+        }
+    }.run;
+
+    // Report asked 2 slots after the data slot (the realistic aggregation
+    // pipeline lag): must match through the window.
+    reset(&seen, &combined_seen, &has_subnet, &combined_has);
+    collectCoverageFromPayloads(&map, data_slot + 2, committee_count, &seen, &combined_seen, &has_subnet, &combined_has);
+    try std.testing.expect(seen[1]);
+    try std.testing.expect(seen[3]);
+    try std.testing.expect(!seen[0]);
+    try std.testing.expect(has_subnet[0]);
+
+    // Exact-slot report still matches (window upper bound is inclusive).
+    reset(&seen, &combined_seen, &has_subnet, &combined_has);
+    collectCoverageFromPayloads(&map, data_slot, committee_count, &seen, &combined_seen, &has_subnet, &combined_has);
+    try std.testing.expect(seen[1]);
+
+    // Past the window: no match.
+    reset(&seen, &combined_seen, &has_subnet, &combined_has);
+    collectCoverageFromPayloads(&map, data_slot + COVERAGE_REPORT_WINDOW_SLOTS, committee_count, &seen, &combined_seen, &has_subnet, &combined_has);
+    try std.testing.expect(!seen[1]);
+    try std.testing.expect(!has_subnet[0]);
+
+    // Future data (report slot BEFORE the data slot): no match.
+    reset(&seen, &combined_seen, &has_subnet, &combined_has);
+    collectCoverageFromPayloads(&map, data_slot - 1, committee_count, &seen, &combined_seen, &has_subnet, &combined_has);
+    try std.testing.expect(!seen[1]);
 }

--- a/pkgs/node/src/validator_client.zig
+++ b/pkgs/node/src/validator_client.zig
@@ -86,13 +86,16 @@ pub const ValidatorClient = struct {
 
         // if a new slot interval may be do a proposal
         switch (interval) {
-            // Block production is a proposer duty — the "am I proposer this slot?" decision lives
-            // here (submitProposeOnInterval consults getSlotProposer). It runs off the slot loop on a
-            // thread_pool worker, since the prod-scheme Type-2 merge is multi-second and would freeze
-            // gossip/tick handling if run inline. The worker produces, merges, and publishes itself,
-            // so this interval emits no synchronous output.
+            // Block production is a proposer duty — the "am I proposer this slot?" decision is
+            // resolved HERE in the validator client; the chain receives the already-resolved
+            // duty and owns only chain-state gating (sync status) plus the off-loop dispatch.
+            // The heavy work runs on a thread_pool worker, since the prod-scheme Type-2 merge
+            // is multi-second and would freeze gossip/tick handling if run inline. The worker
+            // produces, merges, and publishes itself, so this interval emits no synchronous
+            // output.
             0 => {
-                self.chain.submitProposeOnInterval(node, time_intervals);
+                const proposer_id = self.getSlotProposer(slot) orelse return null;
+                self.chain.submitPropose(node, slot, proposer_id);
                 return null;
             },
             1 => return self.mayBeDoAttestation(slot),
@@ -114,7 +117,7 @@ pub const ValidatorClient = struct {
         }
     }
 
-    // Block production moved off the slot loop to submitProposeOnInterval / proposeImpl (a
+    // Block production moved off the slot loop to submitPropose / proposeImpl (a
     // thread_pool worker). The old on-loop maybeDoProposal — which built the multi-second Type-2
     // merge inline and would freeze gossip/tick handling — was removed in favour of that single
     // off-loop path. main's improvements to the old maybeDoProposal (the


### PR DESCRIPTION
Addresses three propose-path issues raised in review of the current architecture (delayed publishing, redundant STF for locally produced blocks, and the always-empty coverage report).

## 1. Proposer duty decision back in the validator client

`ValidatorClient.onInterval` now resolves `getSlotProposer` itself and calls the renamed `chain.submitPropose(node, slot, proposer_id)`; the chain keeps only chain-state gating (sync status) and the off-loop dispatch. The off-loop move itself (0f778f94) stays — the multi-second Type-2 merge must not run on the slot loop — but the duty decision no longer lives in the chain.

## 2. No redundant verify+STF on the local-block publish hop

**Archaeology:** until the per-resource locking migration (5fac5fd2, #805), `publishBlock` passed the produce-time cached post state to `onBlock`, which skipped recompute entirely for locally produced blocks. #805 removed that shortcut (a raw map pointer could no longer be carried across `states_lock.exclusive`), and as an undesigned side effect every locally produced block since has paid: parent state clone ×2 + **full proof re-verify of the proof this node just built** + **full state transition re-run** — all on the publish critical path (the network gossip send happens only after), with the recomputed state then **discarded** by `statesCommitKeepExisting` because produceBlock had already cached it.

`onBlock` now has a self-validating fast path: when BOTH the fork-choice entry and the cached post state for the block already exist (locally produced blocks on the publish hop; also duplicate re-imports, whose first import already verified them), it persists + confirms using the cached state and skips the recompute. Any probe miss falls through to the unchanged full path. This restores the pre-#805 publish semantics with borrow-discipline that satisfies the locking model (probe-and-release; no borrow held across exclusive sections). Preventing a corrupt proof from being *built* is the build path's responsibility and is being root-caused separately (instrumented runs in progress) — re-verifying our own freshly built proof on every block is not the fix for that.

## 3. Coverage report: window the data slots

The per-slot `last round attestation aggregate coverage` report filtered the payload maps by data slot `== slot-1`, but the aggregation pipeline matures payloads 2-3 slots after the attestation slot — measured result: **0 report emissions in 599 slots** while the same maps demonstrably held 31/32-coverage payloads (the proposal-side log showed them). The report now windows `(slot-4, slot]`, and the pre-merge snapshot is stamped with the newest data slot present instead of an arbitrary first hash-map iterator key. Unit test covers in-window / boundary / out-of-window / future cases.

## Validation

- `zig build` green; full `zig build test` green on the pre-rework revision; final-revision test run + CI in flight.
- Companion liveness fix: #986 (material-lead sync gating).