### PR TITLE
node,network: skip min_slot filter on blocks_by_root path

### DIFF
--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -107,6 +107,116 @@ test "Network: preferred blocks_by_root peer is a hint with fallback" {
     try std.testing.expectEqualStrings("fallback-peer", ctx.last_peer.?);
 }
 
+test "Network: blocks_by_root ignores stale peer head_slot (null min_slot)" {
+    // Regression: PR #950 added the min_slot peer filter to selectPeer and the
+    // production call site in node.fetchBlockByRoots passed
+    // `forkChoice.getHead().slot + 1`. Because `latest_status.head_slot` is
+    // only updated on Status handshake / explicit re-status, every connected
+    // peer becomes ineligible once our own head advances past the
+    // boot-time status — turning a transient gossip miss into a permanent
+    // fork ("no peers available to request 1 block(s) by root" warning).
+    // The fix passes `null` for `min_slot` on the blocks_by_root path; this
+    // test pins that behaviour at the network layer.
+    const allocator = std.testing.allocator;
+
+    const Ctx = struct {
+        allocator: Allocator,
+        last_peer: ?[]u8 = null,
+        next_request_id: u64 = 1,
+
+        fn deinit(self: *@This()) void {
+            if (self.last_peer) |peer| self.allocator.free(peer);
+        }
+
+        fn publish(_: *anyopaque, _: *const networks.GossipMessage) anyerror!bool {
+            return true;
+        }
+
+        fn subscribeGossip(_: *anyopaque, _: []networks.GossipTopic, _: networks.OnGossipCbHandler) anyerror!void {}
+        fn onGossip(_: *anyopaque, _: *networks.GossipMessage, _: []const u8) anyerror!void {}
+
+        fn sendRequest(
+            ptr: *anyopaque,
+            peer_id: []const u8,
+            _: *const networks.ReqRespRequest,
+            _: ?networks.OnReqRespResponseCbHandler,
+        ) anyerror!u64 {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            if (self.last_peer) |old| self.last_peer = blk: {
+                self.allocator.free(old);
+                break :blk null;
+            };
+            self.last_peer = try self.allocator.dupe(u8, peer_id);
+            const id = self.next_request_id;
+            self.next_request_id += 1;
+            return id;
+        }
+
+        fn onReqRespRequest(_: *anyopaque, _: *networks.ReqRespRequest, _: networks.ReqRespServerStream) anyerror!void {}
+        fn subscribeReqResp(_: *anyopaque, _: networks.OnReqRespRequestCbHandler) anyerror!void {}
+        fn cancelInflightRequest(_: *anyopaque, _: u64) void {}
+        fn subscribePeers(_: *anyopaque, _: networks.OnPeerEventCbHandler) anyerror!void {}
+    };
+
+    var ctx = Ctx{ .allocator = allocator };
+    defer ctx.deinit();
+
+    var network = try Network.init(allocator, .{
+        .gossip = .{
+            .ptr = &ctx,
+            .publishFn = Ctx.publish,
+            .subscribeFn = Ctx.subscribeGossip,
+            .onGossipFn = Ctx.onGossip,
+        },
+        .reqresp = .{
+            .ptr = &ctx,
+            .sendRequestFn = Ctx.sendRequest,
+            .onReqRespRequestFn = Ctx.onReqRespRequest,
+            .subscribeFn = Ctx.subscribeReqResp,
+            .cancelInflightRequestFn = Ctx.cancelInflightRequest,
+        },
+        .peers = .{ .ptr = &ctx, .subscribeFn = Ctx.subscribePeers },
+    });
+    defer network.deinit();
+
+    try network.connectPeer("stale-peer-a");
+    try network.connectPeer("stale-peer-b");
+
+    // Both peers reported head_slot=3 at handshake (boot), but our own chain
+    // has since advanced — exactly the live-devnet pattern.
+    const stale_status: types.Status = .{
+        .finalized_root = [_]u8{0} ** 32,
+        .finalized_slot = 0,
+        .head_root = [_]u8{0} ** 32,
+        .head_slot = 3,
+    };
+    try std.testing.expect(network.setPeerLatestStatus("stale-peer-a", stale_status));
+    try std.testing.expect(network.setPeerLatestStatus("stale-peer-b", stale_status));
+
+    const handler: networks.OnReqRespResponseCbHandler = .{
+        .ptr = &ctx,
+        .onReqRespResponseCb = struct {
+            fn cb(_: *anyopaque, _: *const networks.ReqRespResponseEvent) anyerror!void {}
+        }.cb,
+    };
+
+    // Pre-fix this would have returned error.NoPeersAvailable for any
+    // min_slot > 3. Post-fix the call site passes null, so dispatch succeeds.
+    const root: types.Root = [_]u8{0xcc} ** 32;
+    var pinned = (try network.ensureBlocksByRootRequest(&[_]types.Root{root}, 0, handler, null, null)).?;
+    defer pinned.deinit(allocator);
+    try std.testing.expect(pinned.peer_id.len > 0);
+    try std.testing.expect(ctx.last_peer != null);
+
+    // And the filter still has bite when set explicitly — proves we only
+    // dropped the filter at the call site, not removed the mechanism.
+    network.finalizePendingRequest(pinned.request_id);
+    try std.testing.expectError(
+        error.NoPeersAvailable,
+        network.ensureBlocksByRootRequest(&[_]types.Root{root}, 0, handler, null, 4),
+    );
+}
+
 pub const StatusRequestContext = struct {
     peer_id: []const u8,
 

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2655,7 +2655,15 @@ pub const BeamNode = struct {
         if (missing_roots.items.len == 0) return;
 
         const handler = self.getReqRespResponseHandler();
-        const maybe_request = self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler, preferred_peer, self.chain.forkChoice.getHead().slot + 1) catch |err| blk: {
+        // No `min_slot` filter on blocks-by-root: a peer can serve a block by
+        // its root regardless of the peer's last-known head_slot. The filter
+        // (PR #950) is meaningful for forward sync (`BlocksByRange`) where we
+        // need a peer at or beyond a target slot; for a root-hash lookup it
+        // only deadlocks repair after our own head advances past a stale
+        // `latest_status.head_slot` (status is refreshed on handshake / explicit
+        // re-status, not per-gossip), turning a transient gossip miss into an
+        // unrecoverable fork.
+        const maybe_request = self.network.ensureBlocksByRootRequest(missing_roots.items, depth, handler, preferred_peer, null) catch |err| blk: {
             switch (err) {
                 error.NoPeersAvailable => {
                     // Previously this path bumped


### PR DESCRIPTION
## Summary

PR #950 added a `min_slot` filter to `selectPeer` and wired the production
`fetchBlockByRoots` call site to pass `forkChoice.getHead().slot + 1`. Because
`PeerInfo.latest_status.head_slot` is only refreshed on the Status RPC handshake
(and explicit re-status sweeps), not per-gossip, every connected peer becomes
ineligible the moment our own head advances past the boot-time status snapshot.
On a running devnet this produces a steady stream of

```
warning: no peers available to request 1 block(s) by root
```

every few slots, emitted while zeam is still fully connected to all its peers
(observed today on a 3-client mainnet-shaped devnet with `total peers: 2` and
zero disconnect events). A transient gossipsub miss then snowballs into an
unrecoverable fork because the repair path can never fire.

The filter is meaningful for **`blocks_by_range`** (forward sync needs a peer
at or beyond the requested slot). For a **`blocks_by_root`** lookup it is wrong:
we already know the block exists from gossip, and any peer that holds it can
serve it regardless of where its head currently sits.

## Change

* Pass `null` for `min_slot` at the `ensureBlocksByRootRequest` call site
  (`pkgs/node/src/node.zig`). The `selectPeerForRangeSyncExcluding` path is
  untouched, so forward sync continues to use the filter as designed.
* Add a `pkgs/node/src/network.zig` regression test that
  * connects two peers with deliberately stale `latest_status.head_slot = 3`,
  * confirms `ensureBlocksByRootRequest(..., null)` still dispatches, and
  * confirms passing an explicit `min_slot = 4` still returns
    `error.NoPeersAvailable` — so we did not weaken the underlying API.

## Test plan

- [x] `zig fmt --check .` (clean)
- [x] `zig build test --summary all` — all packages green; `pkgs/node/src/lib.zig` success (includes new regression test)
- [ ] Manual: rebuild dev image, restart devnet, confirm the `no peers available to request N block(s) by root` warning is gone while connected peers exist