### PR TITLE
metrics, node: add zeam_block_proof_merge_time_seconds (Type-2 merge latency by component count)

### DIFF
--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -181,6 +181,8 @@ const Metrics = struct {
     // Block production metrics
     lean_block_building_time_seconds: BlockBuildingTimeHistogram,
     lean_block_building_payload_aggregation_time_seconds: BlockPayloadAggregationTimeHistogram,
+    // zeam-specific: Type-2 multi-message STARK merge time (buildBlockProof), the proposal critical-path cost.
+    zeam_block_proof_merge_time_seconds: BlockProofMergeTimeHistogram,
     lean_block_aggregated_payloads: BlockAggregatedPayloadsHistogram,
     lean_block_building_success_total: BlockBuildingSuccessCounter,
     lean_block_building_failures_total: BlockBuildingFailuresCounter,
@@ -606,6 +608,7 @@ const Metrics = struct {
     // Block production metric types
     const BlockBuildingTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1 });
     const BlockPayloadAggregationTimeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4 });
+    const BlockProofMergeTimeHistogram = metrics_lib.HistogramVec(f32, struct { components: []const u8 }, &[_]f32{ 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 5 });
     const BlockAggregatedPayloadsHistogram = metrics_lib.Histogram(f32, &[_]f32{ 1, 2, 4, 8, 16, 32, 64, 128 });
     // Total participant count summed across all aggregated_attestations in
     // a block. Each attestation can have up to NUM_VALIDATORS participants;
@@ -1167,6 +1170,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         // Block production metrics
         .lean_block_building_time_seconds = Metrics.BlockBuildingTimeHistogram.init("lean_block_building_time_seconds", .{ .help = "Time taken to build a block" }, .{}),
         .lean_block_building_payload_aggregation_time_seconds = Metrics.BlockPayloadAggregationTimeHistogram.init("lean_block_building_payload_aggregation_time_seconds", .{ .help = "Time taken to build aggregated_payloads during block building" }, .{}),
+        .zeam_block_proof_merge_time_seconds = try Metrics.BlockProofMergeTimeHistogram.init(allocator, io, "zeam_block_proof_merge_time_seconds", .{ .help = "buildBlockProof Type-2 multi-message STARK merge time (proposal critical path), labeled by components = number of distinct AttestationData merged into the block proof" }, .{}),
         .lean_block_aggregated_payloads = Metrics.BlockAggregatedPayloadsHistogram.init("lean_block_aggregated_payloads", .{ .help = "Number of aggregated_payloads in a block" }, .{}),
         .lean_block_building_success_total = Metrics.BlockBuildingSuccessCounter.init("lean_block_building_success_total", .{ .help = "Successful block builds" }, .{}),
         .lean_block_building_failures_total = Metrics.BlockBuildingFailuresCounter.init("lean_block_building_failures_total", .{ .help = "Failed block builds (exception in build_block)" }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2880,6 +2880,9 @@ pub const BeamChain = struct {
         // co-held while we wait on prove_gate (leaf acquisition — no deadlock).
         self.prove_gate.lock();
         defer self.prove_gate.unlock();
+        // zeam-specific: time JUST the Type-2 multi-message STARK merge (the proposal
+        // critical-path cost between produceBlock and publish).
+        const merge_start_ns = zeam_utils.monotonicTimestampNs();
         try types.buildType2BlockProof(
             self.allocator,
             &state_snapshot.validators,
@@ -2891,6 +2894,16 @@ pub const BeamChain = struct {
             proposer_sig,
             out_proof,
         );
+        const merge_secs: f32 = @as(f32, @floatFromInt(zeam_utils.monotonicTimestampNs() - merge_start_ns)) / 1_000_000_000.0;
+        // Label by component count (distinct AttestationData) so the histogram shows the
+        // per-component scaling of the merge. Formatted directly so the label tracks the
+        // configured max_attestations_data automatically (the block enforces that bound, so
+        // cardinality stays small); the metrics lib dupes label values, so this stack buffer is safe.
+        const n_components = produced.block.body.attestations.constSlice().len;
+        var comp_buf: [8]u8 = undefined;
+        const components_label = std.fmt.bufPrint(&comp_buf, "{d}", .{n_components}) catch "overflow";
+        zeam_metrics.metrics.zeam_block_proof_merge_time_seconds.observe(.{ .components = components_label }, merge_secs) catch {};
+        self.logger.info("Type-2 block-proof STARK merge slot={d} components={d}: {d:.3}s", .{ produced.block.slot, n_components, merge_secs });
     }
 
     pub fn constructAttestationData(self: *Self, opts: AttestationConstructionParams) !types.AttestationData {

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -5117,10 +5117,10 @@ pub const BeamChain = struct {
 
         // TODO - since signing needs to be architectrually seggregated from the nodes, move following section needs to move to validator_client
         // 1. signing by the validator to get proposer signature
-        // 2. building block proof
-        // 3. calling the publish
+        // 2. building block proof as done underneath
+        // 3. returning the signed block as array of gossip objects like in mayBeDoAttestation which will make node handle the publish in its onInterval
         //
-        // All this needs to happen from the mayBeDoProposal
+        // All this needs to happen from the mayBeDoProposal which will first call node to produce and return the block with signtaures
         // This also frees up the node from building the merge proof in the architecture where validator client runs separately from node
         // alleviating node from the hardwork so that it can also serve validators altruistically
         const proposer_signature = validator.key_manager.signBlockRoot(proposer_id, &produced_block.blockRoot, @intCast(slot)) catch |e| {
@@ -5128,7 +5128,7 @@ pub const BeamChain = struct {
             return;
         };
 
-        chain.logger.debug("produced block signed, building block proof for slot={d} proposer={d} root={x}", .{
+        chain.logger.info("produced block signed, building block proof for slot={d} proposer={d} root={x}", .{
             slot,
             proposer_id,
             &produced_block.blockRoot,

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -5115,11 +5115,24 @@ pub const BeamChain = struct {
 
         chain.logger.info("produced block for slot={d} proposer={d} root={x}", .{ slot, proposer_id, &produced_block.blockRoot });
 
+        // TODO - since signing needs to be architectrually seggregated from the nodes, move following section needs to move to validator_client
+        // 1. signing by the validator to get proposer signature
+        // 2. building block proof
+        // 3. calling the publish
+        //
+        // All this needs to happen from the mayBeDoProposal
+        // This also frees up the node from building the merge proof in the architecture where validator client runs separately from node
+        // alleviating node from the hardwork so that it can also serve validators altruistically
         const proposer_signature = validator.key_manager.signBlockRoot(proposer_id, &produced_block.blockRoot, @intCast(slot)) catch |e| {
             chain.logger.err("propose worker: signBlockRoot failed slot={d}: {any}", .{ slot, e });
             return;
         };
 
+        chain.logger.debug("produced block signed, building block proof for slot={d} proposer={d} root={x}", .{
+            slot,
+            proposer_id,
+            &produced_block.blockRoot,
+        });
         var proof = types.MultiMessageAggregate.init(chain.allocator) catch return;
         var proof_owned = true;
         defer if (proof_owned) proof.deinit();


### PR DESCRIPTION
## What

Adds a dedicated metric for the **Type-2 multi-message STARK merge** in `buildBlockProof` — the recursive-STARK operation that folds the per-attestation Type-1 proofs + the proposer signature into the single `SignedBlock.proof`.

- **`zeam_block_proof_merge_time_seconds`** — a `HistogramVec` labeled by **`components`** = number of distinct `AttestationData` merged into the block proof. Buckets `0.1 … 5s`.
- Recorded in `chain.zig:buildBlockProof`, timing **only** `buildType2BlockProof` (taken *after* `prove_gate` is acquired, so it measures pure merge compute, not gate-wait).
- Also emits a log line: `Type-2 block-proof STARK merge slot=N components=C: X.XXXs`.

## Why

The merge sits on the **proposal critical path** between `produceBlock` and `publishBlock` — the `SignedBlock` can't be assembled until `.proof` (the Type-2) is built, so a block produced on time at i0 is published an interval (or more) late. Until now this cost was only visible buried inside the catch-all `lean_block_building_time_seconds` (whole `proposeImpl`) or inferable from produce→publish log gaps. A dedicated, component-labeled histogram makes the latency — and its scaling with block fullness — observable directly in prod (`rate(_sum)/rate(_count)` by `components`).

## Measured (3-validator beam sim, ReleaseFast)

| `components` | mean | min | max |
|---|---|---|---|
| 0 (proposer-sig-only proof) | **0.68s** | 0.62 | 0.76 |
| 1 | **1.19s** | 1.05 | 1.38 |

- **~0.68s floor** even for an empty block (irreducible recursive-STARK base cost).
- **~0.51s per additional `AttestationData`** → extrapolates to ~4.8s at `MAX_ATTESTATIONS_DATA=8`, consistent with prior recursive-merge measurements.

This quantifies why a timely block can't carry a freshly-merged proof under the per-interval budget, and motivates moving the merge off the propose→publish path (precompute) rather than bounding it with a deadline (a recursive-STARK prove can't be truncated mid-flight).

## Notes

- Pure additive metric; no behavioral change to consensus.
- No Rust touched. `zig fmt --check` passes.