### PR TITLE
add block proposal metrics and logs

### DIFF
--- a/pkgs/metrics/README.md
+++ b/pkgs/metrics/README.md
@@ -303,6 +303,42 @@ These are **not** the same as `zeam_compact_attestations_*`: those measure only 
 - **Labels**: None
 - **Sample Collection Event**: On successful return from `getProposalAttestationsUnlocked`
 
+### Block proposer & aggregation lifecycle metrics
+
+Lifecycle counters that complement the timing histograms above. They mark the
+start/outcome of the off-loop proposer worker (`proposeImpl`) and the start of the
+single-message (Type-1 `compactAttestations`) and multi-message (Type-2
+`buildBlockProof`) aggregation phases. Paired with `info` log lines on the same
+events.
+
+#### `zeam_block_proposer_started_total` (Counter)
+- **Description**: Block-proposer worker (`proposeImpl`) invocations started.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: At the top of each `proposeImpl` worker run
+
+#### `zeam_block_proposer_completed_total` (CounterVec)
+- **Description**: Block-proposer worker (`proposeImpl`) terminations.
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: `result` — `success` (block published) | `failed` (any early-return error path)
+- **Sample Collection Event**: On every `proposeImpl` exit (via `defer`)
+
+#### `zeam_single_message_aggregation_total` (Counter)
+- **Description**: `compactAttestations` single-message (Type-1) aggregation passes run during block proposal. Can increment more than once per proposal because the selection loop is fixed-point (re-scans on justification/finalization advance).
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: After each `compactAttestations` call in `getProposalAttestationsUnlocked`
+
+#### `zeam_block_proof_merge_started_total` (Counter)
+- **Description**: Type-2 multi-message STARK merge (`buildBlockProof`) invocations started. Pairs with `zeam_block_proof_merge_time_seconds` (recorded on completion).
+- **Type**: Counter
+- **Unit**: Count (u64)
+- **Labels**: None
+- **Sample Collection Event**: Before the `buildType2BlockProof` call in `buildBlockProof`
+
 
 ## Usage
 

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -221,6 +221,13 @@ const Metrics = struct {
     zeam_proposal_deadline_hits_total: ZeamProposalDeadlineHitsCounter,
     zeam_proposal_partial_prefix_size: ZeamProposalPartialPrefixSizeHistogram,
     zeam_proposal_skipped_empty_total: ZeamProposalSkippedEmptyCounter,
+    // Block proposer lifecycle (proposeImpl worker)
+    zeam_block_proposer_started_total: ZeamBlockProposerStartedCounter,
+    zeam_block_proposer_completed_total: ZeamBlockProposerCompletedCounter,
+    // Single-message attestation aggregation (compactAttestations) lifecycle
+    zeam_single_message_aggregation_total: ZeamSingleMessageAggregationCounter,
+    // Multi-message Type-2 STARK merge lifecycle (buildBlockProof)
+    zeam_block_proof_merge_started_total: ZeamBlockProofMergeStartedCounter,
     // Tick interval duration: actual elapsed time between clock ticks (nominal 0.8s)
     lean_tick_interval_duration_seconds: TickIntervalDurationHistogram,
     /// Wall time for one `xev.Loop.run(.until_done)` in `Clock.run`.
@@ -659,6 +666,11 @@ const Metrics = struct {
     const ZeamProposalDeadlineHitsCounter = metrics_lib.Counter(u64);
     const ZeamProposalPartialPrefixSizeHistogram = metrics_lib.Histogram(f32, &[_]f32{ 0, 1, 2, 4, 8, 16 });
     const ZeamProposalSkippedEmptyCounter = metrics_lib.Counter(u64);
+    // Block proposer / aggregation lifecycle counter types
+    const ZeamBlockProposerStartedCounter = metrics_lib.Counter(u64);
+    const ZeamBlockProposerCompletedCounter = metrics_lib.CounterVec(u64, struct { result: []const u8 });
+    const ZeamSingleMessageAggregationCounter = metrics_lib.Counter(u64);
+    const ZeamBlockProofMergeStartedCounter = metrics_lib.Counter(u64);
     // BeamNode mutex contention histogram types. Buckets span 100us..2s to cover
     // both fast acquisitions and long stalls observed when STF runs under the lock.
     const NodeMutexLabel = struct { site: []const u8 };
@@ -1194,6 +1206,10 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .zeam_proposal_deadline_hits_total = Metrics.ZeamProposalDeadlineHitsCounter.init("zeam_proposal_deadline_hits_total", .{ .help = "Number of compactAttestations runs whose returned prefix was truncated because the caller-supplied deadline elapsed mid-loop." }, .{}),
         .zeam_proposal_partial_prefix_size = Metrics.ZeamProposalPartialPrefixSizeHistogram.init("zeam_proposal_partial_prefix_size", .{ .help = "Number of AttestationData groups fully committed by deadline-aware compactAttestations when the deadline truncated the loop." }, .{}),
         .zeam_proposal_skipped_empty_total = Metrics.ZeamProposalSkippedEmptyCounter.init("zeam_proposal_skipped_empty_total", .{ .help = "Number of interval-0 finalize calls that found no partial proposal body for the proposer's slot." }, .{}),
+        .zeam_block_proposer_started_total = Metrics.ZeamBlockProposerStartedCounter.init("zeam_block_proposer_started_total", .{ .help = "Block-proposer worker (proposeImpl) invocations started." }, .{}),
+        .zeam_block_proposer_completed_total = try Metrics.ZeamBlockProposerCompletedCounter.init(allocator, io, "zeam_block_proposer_completed_total", .{ .help = "Block-proposer worker (proposeImpl) terminations, labeled result=success|failed." }, .{}),
+        .zeam_single_message_aggregation_total = Metrics.ZeamSingleMessageAggregationCounter.init("zeam_single_message_aggregation_total", .{ .help = "compactAttestations single-message (Type-1) aggregation passes run during block proposal." }, .{}),
+        .zeam_block_proof_merge_started_total = Metrics.ZeamBlockProofMergeStartedCounter.init("zeam_block_proof_merge_started_total", .{ .help = "Type-2 multi-message STARK merge (buildBlockProof) invocations started." }, .{}),
         .lean_tick_interval_duration_seconds = Metrics.TickIntervalDurationHistogram.init("lean_tick_interval_duration_seconds", .{ .help = "Elapsed time between clock ticks in seconds (nominal 0.8s = 4s slot / 5 intervals)" }, .{}),
         .zeam_xev_clock_until_done_drain_seconds = Metrics.XevClockUntilDoneDrainHistogram.init("zeam_xev_clock_until_done_drain_seconds", .{ .help = "Wall time in seconds for one xev run(.until_done) in the clock driver (issues #863, #867). Captures completion backlog before the next tickInterval()." }, .{}),
         .zeam_xev_clock_until_done_slow_ge_500ms_total = Metrics.ZeamXevClockUntilDoneSlowGe500msCounter.init("zeam_xev_clock_until_done_slow_ge_500ms_total", .{ .help = "Clock-loop xev run(.until_done) drains with wall time >= 0.5s (#863)." }, .{}),

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -2881,7 +2881,11 @@ pub const BeamChain = struct {
         self.prove_gate.lock();
         defer self.prove_gate.unlock();
         // zeam-specific: time JUST the Type-2 multi-message STARK merge (the proposal
-        // critical-path cost between produceBlock and publish).
+        // critical-path cost between produceBlock and publish). Component count
+        // (distinct AttestationData) is known up front from the produced block.
+        const n_components = produced.block.body.attestations.constSlice().len;
+        zeam_metrics.metrics.zeam_block_proof_merge_started_total.incr();
+        self.logger.info("Type-2 block-proof STARK merge start slot={d} components={d}", .{ produced.block.slot, n_components });
         const merge_start_ns = zeam_utils.monotonicTimestampNs();
         try types.buildType2BlockProof(
             self.allocator,
@@ -2899,7 +2903,6 @@ pub const BeamChain = struct {
         // per-component scaling of the merge. Formatted directly so the label tracks the
         // configured max_attestations_data automatically (the block enforces that bound, so
         // cardinality stays small); the metrics lib dupes label values, so this stack buffer is safe.
-        const n_components = produced.block.body.attestations.constSlice().len;
         var comp_buf: [8]u8 = undefined;
         const components_label = std.fmt.bufPrint(&comp_buf, "{d}", .{n_components}) catch "overflow";
         zeam_metrics.metrics.zeam_block_proof_merge_time_seconds.observe(.{ .components = components_label }, merge_secs) catch {};
@@ -5093,6 +5096,17 @@ pub const BeamChain = struct {
         const worker_timer = zeam_metrics.lean_block_building_time_seconds.start();
         defer _ = worker_timer.observe();
 
+        chain.logger.info("block proposer started slot={d} proposer={d}", .{ slot, proposer_id });
+        zeam_metrics.metrics.zeam_block_proposer_started_total.incr();
+        // Records the proposer outcome across every exit path (all the `.err`
+        // early-returns below leave this "failed"; flipped to "success" right
+        // before the publish-success log).
+        var proposer_result: []const u8 = "failed";
+        defer {
+            zeam_metrics.metrics.zeam_block_proposer_completed_total.incr(.{ .result = proposer_result }) catch {};
+            chain.logger.info("block proposer ended slot={d} proposer={d} result={s}", .{ slot, proposer_id, proposer_result });
+        }
+
         const validator = if (node.validator) |*v| v else return;
 
         // Cap single-message attestation aggregation at `proposal_deadline_pct`% of the
@@ -5158,6 +5172,7 @@ pub const BeamChain = struct {
             chain.logger.err("propose worker: publishBlock failed slot={d}: {any}", .{ slot, e });
             return;
         };
+        proposer_result = "success";
         chain.logger.info("published block for slot={d} root={x}", .{ slot, &produced_block.blockRoot });
     }
 

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -1342,6 +1342,8 @@ pub const ForkChoice = struct {
             // Compact: merge proofs sharing the same AttestationData into one
             // using recursive children aggregation, so each AttestationData
             // appears at most once.
+            const compact_input = agg_attestations.constSlice().len;
+            self.logger.info("single-message aggregation start slot={d}: inputs={d}", .{ slot, compact_input });
             const compact_start_ns = zeam_utils.monotonicTimestampNs();
             const compact_timer = zeam_metrics.zeam_compact_attestations_time_seconds.start();
             const compacted = try types.compactAttestations(
@@ -1357,6 +1359,8 @@ pub const ForkChoice = struct {
             agg_attestations = compacted.attestations;
             attestation_signatures = compacted.signatures;
             zeam_metrics.metrics.zeam_compact_attestations_output_total.incrBy(@intCast(agg_attestations.constSlice().len));
+            zeam_metrics.metrics.zeam_single_message_aggregation_total.incr();
+            self.logger.info("single-message aggregation complete slot={d}: inputs={d} outputs={d}", .{ slot, compact_input, agg_attestations.constSlice().len });
             observeProposalBuildPhase("compact", compact_start_ns);
 
             // Deadline elapsed → ship what we have; another full iteration


### PR DESCRIPTION
Adds info logs and Prometheus counters marking the start/finish of each aggregation phase during block production, so the proposer critical path can be traced end-to-end from logs and dashboards.