### PR TITLE
node: trigger catch-up on finalization gap, not just head gap (fix sync deadlock)

### DIFF
--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1763,7 +1763,25 @@ pub const BeamNode = struct {
         status: CatchUpPeerStatus,
         our_head_slot: types.Slot,
     ) void {
-        const gap = self.cappedSyncGap(status.head_slot, our_head_slot);
+        var gap = self.cappedSyncGap(status.head_slot, our_head_slot);
+        var start_slot: types.Slot = our_head_slot + 1;
+
+        // Finalization-gap recovery (liveness deadlock fix): a peer that has
+        // finalized PAST our finalized slot while its head is <= ours means we
+        // forked onto a chain that never finalized — our head is "ahead" only on
+        // a minority fork lacking the canonical attestations. Head-gap sync then
+        // computes gap==0 and fetches nothing, so we never reorg to the peer's
+        // finalized chain; getSyncStatus keeps us `peers_materially_ahead`, which
+        // gates off block/attestation production, so finalization never advances
+        // → permanent stall (observed: our head=48/finalized=25 vs peer head=46/
+        // finalized=40). Re-anchor the request to just after OUR finalized slot so
+        // fork-choice receives the peer's canonical finalized blocks and reorgs.
+        const our_finalized_slot = self.chain.forkChoice.getLatestFinalized().slot;
+        if (gap == 0 and status.finalized_slot > our_finalized_slot) {
+            start_slot = our_finalized_slot + 1;
+            gap = self.cappedSyncGap(status.head_slot, our_finalized_slot);
+        }
+
         if (gap == 0) return;
 
         const head_snapshot = self.chain.forkChoice.getHead();
@@ -1772,7 +1790,6 @@ pub const BeamNode = struct {
         if (gap > constants.BLOCKS_BY_RANGE_SYNC_THRESHOLD and
             self.network.peerSupportsBlocksByRange(status.peer_id))
         {
-            const start_slot: types.Slot = our_head_slot + 1;
             const requested_count: u64 = @min(gap, params.MAX_REQUEST_BLOCKS);
             self.logger.info(
                 "peer {s}{f} is far ahead (gap={d} slots), initiating bulk catch-up via blocks_by_range start_slot={d} count={d}",


### PR DESCRIPTION
## Problem

A node that forks onto a minority chain ends up with a **higher head** but a **lower finalized slot** than its peers. Observed live on a 2-node devnet:

```
our head=48 / finalized=25   vs   peer head=46 / finalized=40
```

`getSyncStatus` then reports `peers_materially_ahead` (because `our_finalized(25) < max_peer_finalized(40)`), which **gates off block + attestation + aggregation production**. But `initiateCatchUpFromPeerStatus` computes the sync gap purely from the **head delta**:

```zig
const gap = self.cappedSyncGap(status.head_slot, our_head_slot); // 46 - 48 -> 0
if (gap == 0) return;                                            // bails, fetches nothing
```

When we're *ahead on head* the gap is 0, so catch-up triggers but fetches nothing — we can never reorg onto the peer's canonical finalized chain. Result: a **permanent liveness deadlock** — block-gossip goes silent, head freezes, finalization sticks (seen as ~12 min of `block-gossip silent` with the head pinned).

## Fix

When the head gap is 0 **but a peer has finalized past our finalized slot**, re-anchor the `blocks_by_range` request to `our_finalized_slot + 1` so fork-choice receives the peer's canonical finalized blocks and can **reorg onto them** — advancing our finalization and clearing the `peers_materially_ahead` gate that was blocking production.

## Test

Full node suite (220 tests) passes; builds clean off `main`.