### PR TITLE
deps: bump zig-libp2p v0.2.8 → v0.2.23 (zquic v1.7.56 + QUIC churn + req/resp-over-inbound + gossipsub finality + attestation-load throughput + RFC 9221 DATAGRAM)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.8.tar.gz",
-            .hash = "zig_libp2p-0.2.8-lil2hMMAJgB0siAnkR_hJS_rMSNip0Y9MqloAV0Wei2k",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.9.tar.gz",
+            .hash = "zig_libp2p-0.2.9-lil2hOoJJgC7Z6D39lgDRfggxa3u53CKhskqm_5extmd",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.21.tar.gz",
-            .hash = "zig_libp2p-0.2.21-lil2hOJjJgDauxNPFNTHlMPz99a_nPRzNPCy0gPXzQOh",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.22.tar.gz",
+            .hash = "zig_libp2p-0.2.22-lil2hDptJgAY41I9uPkFoDHK2FepMK9cEoUAZwUmB5EB",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.15.tar.gz",
-            .hash = "zig_libp2p-0.2.15-lil2hMtTJgCQ6bguCOpgEYhcX29k-YaJaCKPUZKLvlXd",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.16.tar.gz",
+            .hash = "zig_libp2p-0.2.16-lil2hMtTJgAEAyB8YKYIV89-nZ0Yu7W2pk6VIUng40Nf",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.12.tar.gz",
-            .hash = "zig_libp2p-0.2.12-lil2hEdRJgBl7T8A1LUN_0eSURj2nhNACY4E6x9TIAN0",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.14.tar.gz",
+            .hash = "zig_libp2p-0.2.14-lil2hMtTJgDpAhYdNQdSJ-sP05iqsom43X7mssPfFY1k",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.20.tar.gz",
-            .hash = "zig_libp2p-0.2.20-lil2hB9hJgD-8qankRQ0UnF-eG_LpsIAs6USWGYkDq4E",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.21.tar.gz",
+            .hash = "zig_libp2p-0.2.21-lil2hOJjJgDauxNPFNTHlMPz99a_nPRzNPCy0gPXzQOh",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.23.tar.gz",
-            .hash = "zig_libp2p-0.2.23-lil2hDptJgBc_LBf0WQEaEx08AMMTaAdC6m6hs6cWHKi",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.24.tar.gz",
+            .hash = "zig_libp2p-0.2.24-lil2hFFtJgBAD4ICxV9OSoYMGivgOftK895I68JhgSEp",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.10.tar.gz",
-            .hash = "zig_libp2p-0.2.10-lil2hC05JgCrjpeAKYY6B0P6CTXWGUKmht2x1uwtaNXH",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.11.tar.gz",
+            .hash = "zig_libp2p-0.2.11-lil2hCJGJgBB2g26elXXLDIaclAJMOklhyxF56BTxA11",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.18.tar.gz",
-            .hash = "zig_libp2p-0.2.18-lil2hIpcJgBovfOq9nRoil2XMV8fMyl9HyodQeu8YriB",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.19.tar.gz",
+            .hash = "zig_libp2p-0.2.19-lil2hIhdJgBzzDQ1mV_CgNOlBWeWt8O3ivlK8Dydn0nV",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.16.tar.gz",
-            .hash = "zig_libp2p-0.2.16-lil2hMtTJgAEAyB8YKYIV89-nZ0Yu7W2pk6VIUng40Nf",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.17.tar.gz",
+            .hash = "zig_libp2p-0.2.17-lil2hLxZJgCOUGc760ff5kHx-uQ9_yL7m89q3ipvDXLc",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.25.tar.gz",
-            .hash = "zig_libp2p-0.2.25-lil2hDt1JgArDfbGYnHQN2wcGKjUt9431lXfIjKulGMx",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.26.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hKV2JgCuv5ABt4SLeYtDWJADnODSv4M0nc-DCqmD",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.17.tar.gz",
-            .hash = "zig_libp2p-0.2.17-lil2hLxZJgCOUGc760ff5kHx-uQ9_yL7m89q3ipvDXLc",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.18.tar.gz",
+            .hash = "zig_libp2p-0.2.18-lil2hIpcJgBovfOq9nRoil2XMV8fMyl9HyodQeu8YriB",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.14.tar.gz",
-            .hash = "zig_libp2p-0.2.14-lil2hMtTJgDpAhYdNQdSJ-sP05iqsom43X7mssPfFY1k",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.15.tar.gz",
+            .hash = "zig_libp2p-0.2.15-lil2hMtTJgCQ6bguCOpgEYhcX29k-YaJaCKPUZKLvlXd",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.11.tar.gz",
-            .hash = "zig_libp2p-0.2.11-lil2hCJGJgBB2g26elXXLDIaclAJMOklhyxF56BTxA11",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.12.tar.gz",
+            .hash = "zig_libp2p-0.2.12-lil2hEdRJgBl7T8A1LUN_0eSURj2nhNACY4E6x9TIAN0",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.24.tar.gz",
-            .hash = "zig_libp2p-0.2.24-lil2hFFtJgBAD4ICxV9OSoYMGivgOftK895I68JhgSEp",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.25.tar.gz",
+            .hash = "zig_libp2p-0.2.25-lil2hDt1JgArDfbGYnHQN2wcGKjUt9431lXfIjKulGMx",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.19.tar.gz",
-            .hash = "zig_libp2p-0.2.19-lil2hIhdJgBzzDQ1mV_CgNOlBWeWt8O3ivlK8Dydn0nV",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.20.tar.gz",
+            .hash = "zig_libp2p-0.2.20-lil2hB9hJgD-8qankRQ0UnF-eG_LpsIAs6USWGYkDq4E",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.9.tar.gz",
-            .hash = "zig_libp2p-0.2.9-lil2hOoJJgC7Z6D39lgDRfggxa3u53CKhskqm_5extmd",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.10.tar.gz",
+            .hash = "zig_libp2p-0.2.10-lil2hC05JgCrjpeAKYY6B0P6CTXWGUKmht2x1uwtaNXH",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.22.tar.gz",
-            .hash = "zig_libp2p-0.2.22-lil2hDptJgAY41I9uPkFoDHK2FepMK9cEoUAZwUmB5EB",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.23.tar.gz",
+            .hash = "zig_libp2p-0.2.23-lil2hDptJgBc_LBf0WQEaEx08AMMTaAdC6m6hs6cWHKi",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Dependency-only bump: `zig_libp2p` **v0.2.8 → v0.2.14** (no zeam-side code changes). This is the cumulative transport/gossip work to get the 32-validator, 4-subnet QUIC devnet from "blocks but never finalizes" toward finality. Each bump is a self-contained fix; summary below in the order they were found.

## Transport stability (QUIC)
- **v0.2.9 — mesh-churn fix.** The single drive thread drained the shared inbound UDP socket only once per iteration, so under 31-peer gossip the 8 MB recv buffer overflowed and the kernel dropped datagrams — including peers' ACKs — causing "no ACK 60s" teardowns and redial storms (confirmed live: UDP `RcvbufErrors` climbing). Fix: interleave a cheap `pumpInbound` between the heavy drive-loop phases.
- **v0.2.10 — req/resp rides the inbound leg.** `startOutboundRequest` only used `outbound_by_peer`, so any request to a peer that dialed us (inbound-only — most of a full mesh) failed 100% with `send_request … no outbound conn`. Now falls back to a server-initiated bidi stream on the inbound leg, symmetric with the gossip fallback. Also fixed the ~15% request-reap flake by gating the inbound req/resp reap on `fullyReceived()` (FIN **and** all bytes reassembled) instead of bare `finReceived()`.

## Finality blocker (gossipsub) — the key fix
- **v0.2.11 — gossipsub PRUNE on GRAFT for an unsubscribed topic.** *This is what unblocked attestation propagation.* The inbound GRAFT handler never replied PRUNE for a topic it didn't subscribe to (libp2p gossipsub v1.1 §3.3.3 violation). The lean per-subnet attestation topic `attestation_<n>` is **sparse** — only the 8 subnet validators join — so a member with empty `remote_interest` grafts random connected peers to reach `mesh_n_low`; those non-subscribers stayed silent (no PRUNE), so the grafter never backed off, never grafted the real subnet members, and the sparse mesh never converged. Result: aggregators saw `gossip_sigs=subnet=1/8` (own attestation only), built blocks with empty attestations, never reached the 2/3 quorum, never finalized. The dense `block` topic hid the bug (every grafted peer is a block subscriber). Confirmed via `consensus.log`: a node published 554 attestations and received 0 back. Fix + regression test. **Live result:** `gossip_sigs` climbed off the stuck `1/8` to `2-4/8`.

## Load vs. throughput (the churn that surfaced once attestations flowed)
Once v0.2.11 made attestations actually propagate, that *new* traffic became the load that churned the nodes receiving it (conn peers 32 → 15-17; `recovery: in-flight tracking cap (16384) reached`). The in-flight-cap warning is a symptom of connections whose peers already stopped ACKing, not the cause; the root is the single drive loop not sustaining ACKs under the small-packet attestation rate. Fixed as a pair:
- **v0.2.12 — gossip-outbox coalescing (load).** The persistent `/meshsub` outbox drained one frame per packet, so each ~100-300 B forwarded attestation became its own mostly-empty 1-RTT packet. Now consecutive self-delimiting gossip frames are packed into one MTU-chunked write (~a dozen per packet), wire-identical to per-frame sends.
- **v0.2.14 — client-side sendmmsg batching (throughput, zquic v1.7.51).** The outbound (client) leg carries the bulk of gossip forwarding but sent one `sendto(2)` per packet while the server already coalesced. Added `Client.send_batch` mirroring the server and routed the hot 1-RTT paths through it, flushed every drive iteration.

## Note on the zquic version jump
v0.2.14 moves zquic **v1.7.47 → v1.7.51**. Beyond my client-send batching, that bundles the parallel upstream zquic work (v1.7.48-50): per-PN-space loss detection + PTO, out-of-order STREAM reassembly (#183), separate empty-FIN on a blocked CC/pacer gate (#214 — the residual reqresp-over-inbound flake), NEW_TOKEN, and stateless-reset limits. zig-libp2p compiles + full suite green against it (489/490; 1 soak skip).

## Validation
- zig-libp2p unit + gossipsub + soak suites green at every bump.
- Live devnet: v0.2.11 confirmed `gossip_sigs` climbing 1/8 → 2-4/8 (attestations propagating for the first time). The load/throughput pair (v0.2.12 + v0.2.14) is **pending the next image rebuild** — expect the churn under attestation load to subside and `gossip_sigs` to keep climbing toward the 6/8 quorum finality needs, with `lean_latest_finalized_slot` advancing past 0.

Draft until finality is confirmed live.
