### PR TITLE
deps: zig-libp2p v0.2.27 (zquic v1.7.57) — QUIC connection sharding + gossip/req-resp fixes → devnet finalizes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.8.tar.gz",
-            .hash = "zig_libp2p-0.2.8-lil2hMMAJgB0siAnkR_hJS_rMSNip0Y9MqloAV0Wei2k",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.9.tar.gz",
+            .hash = "zig_libp2p-0.2.9-lil2hOoJJgC7Z6D39lgDRfggxa3u53CKhskqm_5extmd",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.21.tar.gz",
-            .hash = "zig_libp2p-0.2.21-lil2hOJjJgDauxNPFNTHlMPz99a_nPRzNPCy0gPXzQOh",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.22.tar.gz",
+            .hash = "zig_libp2p-0.2.22-lil2hDptJgAY41I9uPkFoDHK2FepMK9cEoUAZwUmB5EB",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/d253ddfef5c9fe12afbcd5beb1592ce3bea07a72.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hD0ZKACRSkdzkjyP_mn_OWSWjG7dyH3gdcWOOXkv",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/ee015266be3edfcbf0493ddfd744d07cabef0461.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAEtKACT0DXvB97bfDOtNjAsHiL52LxHXxVSgqMj",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/ee015266be3edfcbf0493ddfd744d07cabef0461.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hAEtKACT0DXvB97bfDOtNjAsHiL52LxHXxVSgqMj",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/9bd90e2a12bd652db7f51bb47d322c25e31a3ef4.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hHMwKAAdKDaLszyUu3c8RlaDFWxUF5vaefVb4DqZ",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.15.tar.gz",
-            .hash = "zig_libp2p-0.2.15-lil2hMtTJgCQ6bguCOpgEYhcX29k-YaJaCKPUZKLvlXd",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.16.tar.gz",
+            .hash = "zig_libp2p-0.2.16-lil2hMtTJgAEAyB8YKYIV89-nZ0Yu7W2pk6VIUng40Nf",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.12.tar.gz",
-            .hash = "zig_libp2p-0.2.12-lil2hEdRJgBl7T8A1LUN_0eSURj2nhNACY4E6x9TIAN0",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.14.tar.gz",
+            .hash = "zig_libp2p-0.2.14-lil2hMtTJgDpAhYdNQdSJ-sP05iqsom43X7mssPfFY1k",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.20.tar.gz",
-            .hash = "zig_libp2p-0.2.20-lil2hB9hJgD-8qankRQ0UnF-eG_LpsIAs6USWGYkDq4E",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.21.tar.gz",
+            .hash = "zig_libp2p-0.2.21-lil2hOJjJgDauxNPFNTHlMPz99a_nPRzNPCy0gPXzQOh",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.23.tar.gz",
-            .hash = "zig_libp2p-0.2.23-lil2hDptJgBc_LBf0WQEaEx08AMMTaAdC6m6hs6cWHKi",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.24.tar.gz",
+            .hash = "zig_libp2p-0.2.24-lil2hFFtJgBAD4ICxV9OSoYMGivgOftK895I68JhgSEp",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.10.tar.gz",
-            .hash = "zig_libp2p-0.2.10-lil2hC05JgCrjpeAKYY6B0P6CTXWGUKmht2x1uwtaNXH",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.11.tar.gz",
+            .hash = "zig_libp2p-0.2.11-lil2hCJGJgBB2g26elXXLDIaclAJMOklhyxF56BTxA11",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.18.tar.gz",
-            .hash = "zig_libp2p-0.2.18-lil2hIpcJgBovfOq9nRoil2XMV8fMyl9HyodQeu8YriB",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.19.tar.gz",
+            .hash = "zig_libp2p-0.2.19-lil2hIhdJgBzzDQ1mV_CgNOlBWeWt8O3ivlK8Dydn0nV",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.16.tar.gz",
-            .hash = "zig_libp2p-0.2.16-lil2hMtTJgAEAyB8YKYIV89-nZ0Yu7W2pk6VIUng40Nf",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.17.tar.gz",
+            .hash = "zig_libp2p-0.2.17-lil2hLxZJgCOUGc760ff5kHx-uQ9_yL7m89q3ipvDXLc",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.25.tar.gz",
-            .hash = "zig_libp2p-0.2.25-lil2hDt1JgArDfbGYnHQN2wcGKjUt9431lXfIjKulGMx",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.26.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hKV2JgCuv5ABt4SLeYtDWJADnODSv4M0nc-DCqmD",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/9bd90e2a12bd652db7f51bb47d322c25e31a3ef4.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hHMwKAAdKDaLszyUu3c8RlaDFWxUF5vaefVb4DqZ",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/cf903a26b221db3a320498b1a981d79934c9b24c.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hHMwKADr1IFq21JNVKHWM8-ylrE66r3ej79NuCLZ",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.17.tar.gz",
-            .hash = "zig_libp2p-0.2.17-lil2hLxZJgCOUGc760ff5kHx-uQ9_yL7m89q3ipvDXLc",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.18.tar.gz",
+            .hash = "zig_libp2p-0.2.18-lil2hIpcJgBovfOq9nRoil2XMV8fMyl9HyodQeu8YriB",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.14.tar.gz",
-            .hash = "zig_libp2p-0.2.14-lil2hMtTJgDpAhYdNQdSJ-sP05iqsom43X7mssPfFY1k",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.15.tar.gz",
+            .hash = "zig_libp2p-0.2.15-lil2hMtTJgCQ6bguCOpgEYhcX29k-YaJaCKPUZKLvlXd",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.11.tar.gz",
-            .hash = "zig_libp2p-0.2.11-lil2hCJGJgBB2g26elXXLDIaclAJMOklhyxF56BTxA11",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.12.tar.gz",
+            .hash = "zig_libp2p-0.2.12-lil2hEdRJgBl7T8A1LUN_0eSURj2nhNACY4E6x9TIAN0",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/8bb7e58f9ae8f14dd588a5a217f48c40d367ed88.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hAnnJwCSEZWWPSu32WjWaRo8r2CeXrf7bU_S9PFw",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/84901b7.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hE__JwBbW9g11B-7VinPw82tYSzliplQOgtkrKO7",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/35228b9.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hAAVKAAItMZ5KguzbES6q3VwLOiyyLApUXITRHPA",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/d253ddfef5c9fe12afbcd5beb1592ce3bea07a72.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hD0ZKACRSkdzkjyP_mn_OWSWjG7dyH3gdcWOOXkv",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.24.tar.gz",
-            .hash = "zig_libp2p-0.2.24-lil2hFFtJgBAD4ICxV9OSoYMGivgOftK895I68JhgSEp",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.25.tar.gz",
+            .hash = "zig_libp2p-0.2.25-lil2hDt1JgArDfbGYnHQN2wcGKjUt9431lXfIjKulGMx",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/cf903a26b221db3a320498b1a981d79934c9b24c.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hHMwKADr1IFq21JNVKHWM8-ylrE66r3ej79NuCLZ",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/6617be92670deae9963c672321adc1d28bd398c0.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hPR5KADLyZdtwUWHD2Ifp6c5ZS0CKcyvY7pwJ10M",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.19.tar.gz",
-            .hash = "zig_libp2p-0.2.19-lil2hIhdJgBzzDQ1mV_CgNOlBWeWt8O3ivlK8Dydn0nV",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.20.tar.gz",
+            .hash = "zig_libp2p-0.2.20-lil2hB9hJgD-8qankRQ0UnF-eG_LpsIAs6USWGYkDq4E",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/6617be92670deae9963c672321adc1d28bd398c0.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hPR5KADLyZdtwUWHD2Ifp6c5ZS0CKcyvY7pwJ10M",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.27.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hN15KABKqKziF62qP3iW26XbtL-0Z17ErgwjII_F",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.9.tar.gz",
-            .hash = "zig_libp2p-0.2.9-lil2hOoJJgC7Z6D39lgDRfggxa3u53CKhskqm_5extmd",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.10.tar.gz",
+            .hash = "zig_libp2p-0.2.10-lil2hC05JgCrjpeAKYY6B0P6CTXWGUKmht2x1uwtaNXH",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/09786d6ddf73e9741e3c118457fb8a5b1f0b5255.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hAnBJwAjEWmzRMQ8NvXjHDIXXeIeu11L7oRODs8b",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/8bb7e58f9ae8f14dd588a5a217f48c40d367ed88.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAnnJwCSEZWWPSu32WjWaRo8r2CeXrf7bU_S9PFw",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/84901b7.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hE__JwBbW9g11B-7VinPw82tYSzliplQOgtkrKO7",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/35228b9.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAAVKAAItMZ5KguzbES6q3VwLOiyyLApUXITRHPA",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.22.tar.gz",
-            .hash = "zig_libp2p-0.2.22-lil2hDptJgAY41I9uPkFoDHK2FepMK9cEoUAZwUmB5EB",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.23.tar.gz",
+            .hash = "zig_libp2p-0.2.23-lil2hDptJgBc_LBf0WQEaEx08AMMTaAdC6m6hs6cWHKi",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.26.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hKV2JgCuv5ABt4SLeYtDWJADnODSv4M0nc-DCqmD",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/09786d6ddf73e9741e3c118457fb8a5b1f0b5255.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAnBJwAjEWmzRMQ8NvXjHDIXXeIeu11L7oRODs8b",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
**Dependency-only** bump (`build.zig.zon` only — zero zeam-side code changes): `zig_libp2p` → **v0.2.27** (which pins **zquic v1.7.57**). This is the cumulative transport / gossip / mesh-formation work that took the 32-validator, 4-subnet QUIC devnet from *"produces blocks but never finalizes"* to **finalizing**. Supersedes #1006.

## Result
The devnet now **finalizes** — `lean_latest_justified_slot` and `lean_latest_finalized_slot` both advance and track the head, with subnet aggregation reaching 6–8/8. Connected peers hold at the full mesh (31/31).

## What landed (in zig-libp2p / zquic)

### QUIC connection sharding — the throughput foundation
A single drive thread saturated at the full 32-peer mesh (multi-hundred-ms iterations → no-ACK teardowns → mesh churn). Connections are now **sharded across N drive threads** (quinn model): one demux thread routes datagrams to the owning shard by shard-tagged connection-ID; a peer→shard ownership table routes all directed work; gossip-outbox + hook-queue + conn-manager are funnelled/per-shard. `drive_shards` **auto-detects from core count**, behaviour-preserving at N=1.

### Gossipsub / mesh formation — the finality unlock
- **`mesh_n_low` 6 → 8** so sparse per-subnet `attestation_<n>` topic meshes converge to (near-)full — aggregators were parked at 5–6/8, never reaching ⅔ quorum.
- **Priority/bulk atomic-frame `/meshsub` outbox** — large blocks no longer head-of-line-block (nor wire-desync) the small, time-sensitive attestation frames sharing the per-peer stream.
- **Wedge-reopen-in-place** — a flow-control-stalled gossip stream reopens on the *same* connection instead of tearing it down, so peers hold the full mesh instead of dropping and failing to re-dial.
- Inbound gossip-validation backlog hardening (batch-drain + never-drop-blocks).

### QUIC transport reliability
- **req/resp slot-leak fix** — every raw-app stream-open path (req/resp, gossip, publish, identify, autonat) now releases its zquic stream slot (+ a 15s orphan reaper); fixes the inbound-leg req/resp fallback failing permanently after ~64 requests. Plus uncapped server-initiated stream tracking and a zquic retired-slot guard against retransmit slot-resurrection.
- **Flow-control windows** widened 10/15 → 16/24 MiB (absorbs transient read-lag on long-lived gossip streams).
- onAck made O(acked) (deque), non-reaping ACK flush, interleaved inbound socket drain (earlier mesh-churn fixes).

## Pins
`zig-libp2p v0.2.27` → `zquic v1.7.57` — both released and merged to their respective mainlines. Deps-only; no zeam code changes required (the runtime talks to `NetworkInterface`, not transport internals).
