### PR TITLE
deps: bump zig-libp2p v0.2.27 -> v0.2.28 (gossipsub per-topic density-aware graft)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.27.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hN15KABKqKziF62qP3iW26XbtL-0Z17ErgwjII_F",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.28.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAuEKAB-WosG_AqMjf8RJrVCsvQ4vmp0CrEWseuY",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
## What
Bumps `zig_libp2p` v0.2.27 → **v0.2.28**.

The only change in v0.2.28: gossipsub heartbeat graft is now **density-aware per topic** ([zig-libp2p#254](https://github.com/blockblaz/zig-libp2p/pull/254), merged):
- **Sparse** topics (current mesh + available `<= mesh_n`) — the lean per-subnet `attestation_<n>` topics (~8 members) — graft every available subscriber → full mesh, preserving the subnet-aggregation property that gives finality.
- **Dense** topics (`block`/`aggregate`, all 31 nodes) — standard `[mesh_n_low=6, mesh_n_high=12]` band.

This reverts the blanket `mesh_n_low=8` (which densified the big topics, raising block-forward duplication and per-stream backpressure — the driver behind the live bulk gossip-outbox drops, 167×/250s) while keeping sparse subnets fully meshed.

## Dependency chain
- zig-libp2p **v0.2.28** = mesh_n_low per-topic graft (#254 merged)
- zquic pin unchanged at **v1.7.57** (no library change; the zquic interop-CI fix [ch4r10t33r/zquic#223] is workflow-only)

## Verification
zeam compiles clean against v0.2.28 (`zig build`, binary built). 1-line `build.zig.zon` change (url + hash).

## Devnet-verify after deploy
1. **Finality keeps advancing** — sparse subnets must still hit ~8/8 (the must-not-regress check).
2. `bulk outbox cap hit` drops fall from 167×/250s.
3. `lean_gossip_mesh_peers` leaner (dense topics now [6,12]) while `lean_connected_peers` holds 31.