### PR TITLE
deps: bump zig-libp2p -> v0.2.60 

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.29.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hB-UKACcGTOdhQsYFtqLcy1Iaa9ZXeWgXJt89Yit",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.30.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hK6YKAB35TNhDqKZSRS3Q2fqUitBh-IxwUgAuZSi",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.53.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hB5JKQB9wGJlbHgBTXkL-0-5vWhe3qNmMn06Wfvy",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.54.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hO1QKQAPPDnTiauByBytOC9MiOCBZr6teMZEaNDW",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.44.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hInRKACRQ5O7lq7-dTPx0ALlFspHF9GL4nfqpo0s",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.45.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hNPbKAAZQt2JEtZ-iZHMhVIl4b53vMsg_TvwQJSg",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.57.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hEhvKQAucf6drAEcfmIac9uNcVsUNZvp7T1JmX8Q",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.58.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hOWUKQDGgIjlT6hcVWSIi0U-5Ro_gh9rc_XVBZ8y",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.35.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hICOKAAZPip2nHf63zTTRKiHDEC5AQ1eOFES9mEU",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.36.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hO-rKACVHb9_W_NDuDYTN6-TuxyrK2shNC2zY6lq",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.32.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hOSgKADCq08RUdqPsT7jIr1cy-G-UwUs9Qn9nX_H",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.30.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hK6YKAB35TNhDqKZSRS3Q2fqUitBh-IxwUgAuZSi",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.52.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hEBGKQAw20OCnd--rvSIMCXJSVGWKDjgl5Cx6PYP",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.53.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hB5JKQB9wGJlbHgBTXkL-0-5vWhe3qNmMn06Wfvy",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.45.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hNPbKAAZQt2JEtZ-iZHMhVIl4b53vMsg_TvwQJSg",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.47.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hMvkKABg3UITMdvBSXCWPezGZcl_c01CfUDYO9fq",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.27.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hN15KABKqKziF62qP3iW26XbtL-0Z17ErgwjII_F",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.29.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hB-UKACcGTOdhQsYFtqLcy1Iaa9ZXeWgXJt89Yit",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.40.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hAvDKAC9St7_s2N6wrjpmlHXnsGkmbyjEJEpMkzN",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.41.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hJvFKAC7TehACyyY2eo-x3K_iVedtoLkcKsdW0nQ",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.31.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hLWaKABQV9lg_546R4mFVgkWWZTWvIrnByC8oEWR",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.32.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hOSgKADCq08RUdqPsT7jIr1cy-G-UwUs9Qn9nX_H",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.59.tar.gz",
-            .hash = "zig_libp2p-0.2.59-lil2hCOnKQCWY6aqIF_9HKsvdRwJgZ8sTDLBmxotwxBd",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.60.tar.gz",
+            .hash = "zig_libp2p-0.2.60-lil2hOm8KQCFpeiaxmd9viJT4UoZ18xX8xrreJ8at8N3",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.30.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hK6YKAB35TNhDqKZSRS3Q2fqUitBh-IxwUgAuZSi",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.34.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hICOKADKpiFDWe5qRedR7_JtHRIMJMZy-iDUO9Vi",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.43.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hFHLKABjKPojd1RuC5wrn2vCRDWpwC1k1Dowtdx0",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.44.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hInRKACRQ5O7lq7-dTPx0ALlFspHF9GL4nfqpo0s",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.30.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hK6YKAB35TNhDqKZSRS3Q2fqUitBh-IxwUgAuZSi",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.31.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hLWaKABQV9lg_546R4mFVgkWWZTWvIrnByC8oEWR",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.60.tar.gz",
-            .hash = "zig_libp2p-0.2.60-lil2hOm8KQCFpeiaxmd9viJT4UoZ18xX8xrreJ8at8N3",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.61.tar.gz",
+            .hash = "zig_libp2p-0.2.61-lil2hNS3KQD1cJdJXHmH7A3vSoQoXrv4yLnLsO_OAb2R",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.50.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hAYXKQAwojXQHjBvBZi264MsckO5ny8_feL2gQ0I",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.51.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hHg-KQCb7rP1R-_n_yaVs9pPq_KcUdNc05_5TOzq",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.49.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hH_8KAAuD3op3w78YU8NbEn3xWM_D8aK6O8ix9EB",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.50.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAYXKQAwojXQHjBvBZi264MsckO5ny8_feL2gQ0I",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.56.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hOVoKQB6nyRXB2-ykHdJ4_puIQmTDpMfxKyqCvKA",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.57.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hEhvKQAucf6drAEcfmIac9uNcVsUNZvp7T1JmX8Q",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.37.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hF60KABGm_nFOVn-FqcHbn6odWXh11d00VVOrztr",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.38.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hF60KAACWj6pyE1RWYzNvztLX1ZNkM2FhoXa_rmL",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.46.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hGzfKADRpuh4L_S9sSO90Piw111f0Z2NWREwvwif",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.45.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hNPbKAAZQt2JEtZ-iZHMhVIl4b53vMsg_TvwQJSg",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.51.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hHg-KQCb7rP1R-_n_yaVs9pPq_KcUdNc05_5TOzq",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.52.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hEBGKQAw20OCnd--rvSIMCXJSVGWKDjgl5Cx6PYP",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.55.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hHdkKQD8PWIo7zcUT7Rv8566p1s_2f359aFsAwT3",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.56.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hOVoKQB6nyRXB2-ykHdJ4_puIQmTDpMfxKyqCvKA",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.38.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hF60KAACWj6pyE1RWYzNvztLX1ZNkM2FhoXa_rmL",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.39.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hJO7KAADVItuzZj3Y9SzVgQAidHsu6c56jV_DaUF",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.34.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hICOKADKpiFDWe5qRedR7_JtHRIMJMZy-iDUO9Vi",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.35.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hICOKAAZPip2nHf63zTTRKiHDEC5AQ1eOFES9mEU",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.47.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hMvkKABg3UITMdvBSXCWPezGZcl_c01CfUDYO9fq",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.48.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hJjxKAAI5Ea7xE35Gtd3u_Kqk7i__l273DYtAwKU",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.39.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hJO7KAADVItuzZj3Y9SzVgQAidHsu6c56jV_DaUF",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.40.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hAvDKAC9St7_s2N6wrjpmlHXnsGkmbyjEJEpMkzN",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.58.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hOWUKQDGgIjlT6hcVWSIi0U-5Ro_gh9rc_XVBZ8y",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.59.tar.gz",
+            .hash = "zig_libp2p-0.2.59-lil2hCOnKQCWY6aqIF_9HKsvdRwJgZ8sTDLBmxotwxBd",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.45.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hNPbKAAZQt2JEtZ-iZHMhVIl4b53vMsg_TvwQJSg",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.46.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hGzfKADRpuh4L_S9sSO90Piw111f0Z2NWREwvwif",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.42.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hGfHKADZVhq9HreSOkb182fh_sd1l9n7gcsXYDcd",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.43.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hFHLKABjKPojd1RuC5wrn2vCRDWpwC1k1Dowtdx0",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.36.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hO-rKACVHb9_W_NDuDYTN6-TuxyrK2shNC2zY6lq",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.37.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hF60KABGm_nFOVn-FqcHbn6odWXh11d00VVOrztr",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.48.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hJjxKAAI5Ea7xE35Gtd3u_Kqk7i__l273DYtAwKU",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.49.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hH_8KAAuD3op3w78YU8NbEn3xWM_D8aK6O8ix9EB",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.54.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hO1QKQAPPDnTiauByBytOC9MiOCBZr6teMZEaNDW",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.55.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hHdkKQD8PWIo7zcUT7Rv8566p1s_2f359aFsAwT3",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.41.tar.gz",
-            .hash = "zig_libp2p-0.2.26-lil2hJvFKAC7TehACyyY2eo-x3K_iVedtoLkcKsdW0nQ",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.42.tar.gz",
+            .hash = "zig_libp2p-0.2.26-lil2hGfHKADZVhq9HreSOkb182fh_sd1l9n7gcsXYDcd",
         },
     },
     .paths = .{""},

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -5650,10 +5650,20 @@ pub const BeamChain = struct {
         // `shouldCatchUpFromPeerStatus` directly so a peer that reports
         // a higher head triggers catch-up without a state transition.
 
-        // Our head or finalization is behind peer finalization.
-        // Include the exact peers whose finalized slots make this node report
-        // `peers_materially_ahead`, so logs can name the source of the decision.
-        const behind_peer_finalization = our_head_slot < max_peer_finalized_slot or our_finalized_slot < max_peer_finalized_slot;
+        // Materially behind == DEEP SYNC: we are missing finalized blocks a peer
+        // already has, i.e. our HEAD is behind the peer's finalized slot. Gate ONLY
+        // on head lag.
+        //
+        // A finalized lag with a SYNCED head (our_head_slot >= max_peer_finalized_slot
+        // but our_finalized_slot < max_peer_finalized_slot) is NOT deep sync — we
+        // already hold every block the peer has finalized; we simply haven't
+        // locally finalized that far yet. That is a consensus OUTCOME, not a data
+        // gap, and the cure is to PARTICIPATE (aggregate/attest/propose), not skip.
+        // Gating on `our_finalized_slot < max_peer_finalized_slot` here deadlocks:
+        // a node at head=337/finalized=0 with a peer at finalized=6 skips
+        // aggregation forever, so finalization never advances and it stays "behind"
+        // (live: all 32 nodes head-synced, justified frozen at 9, finalized 0–6).
+        const behind_peer_finalization = our_head_slot < max_peer_finalized_slot;
         if (behind_peer_finalization) {
             var info = self.behindPeersStatus(our_head_slot, our_finalized_slot, max_peer_finalized_slot);
             var cause_guard = self.connected_peers.iterateLocked();
@@ -5662,7 +5672,7 @@ pub const BeamChain = struct {
             while (cause_iter.next()) |entry| {
                 const peer_info = entry.value_ptr;
                 if (peer_info.latest_status) |status| {
-                    if (status.finalized_slot > our_head_slot or status.finalized_slot > our_finalized_slot) {
+                    if (status.finalized_slot > our_head_slot) {
                         info.peers_materially_ahead.addPeer(peer_info.peer_id, status.finalized_slot);
                     }
                 }


### PR DESCRIPTION
Bumps zig-libp2p through the transport **drive-loop saturation** fix arc that took the devnet from "never finalizes" to deep, converged finality.

## The problem
Under full 32-node participation, a single QUIC drive thread (per shard) could be monopolized by one phase — starving the inbound UDP socket → packet loss → cwnd collapse → outbox overflow → attestations dropped → coverage decay → finality stall. Each release bounded the next unbounded phase.

## Release arc (zig-libp2p → zquic)
| ver | fix |
|-----|-----|
| **v0.2.56** | dial-timeout teardown UAF/segfault — sweep all 5 client-aliasing structures before free (+ zquic v1.7.61 idempotent `Client.deinit`) |
| **v0.2.57** | per-lap byte-budget cap *within* a chunk — stop a single 3 MB chunk flooding zquic pending in one lap |
| **v0.2.58** | auto drive-shards floor-2 (cores/2, ≥3 cores → ≥2 threads) + **completed** the outbound-client UAF sweep + liveness backstop |
| **v0.2.59** | per-drive **send** budget (zquic v1.7.62) + per-lap **outbound** wall-clock budget + round-robin |
| **v0.2.60** | per-drive **recv** wall-clock bound (20 ms) + per-lap **inbound_streams** budget + round-robin — the last two unbounded phases |

Plus a **consensus-layer** fix in this branch (`c307e697`): `getSyncStatus` reported deep-sync (→ skip all duties) on a finalized-lag even with a synced head — a deadlock that froze finality with every node head-synced. Now gated on head lag only.

Also: the internal `.version` fields in both `build.zig.zon`s were frozen (zquic `1.7.0`, zig-libp2p `0.2.26`) while tags advanced — now bumped to match every tag, so the dependency id reads `zig_libp2p-0.2.60` properly.

## Result (live devnet, 8/16-core hosts, 4–8 drive shards)
- **No crashes** across multi-hour runs (`SEG=0`).
- Finality went from frozen → **deep and converged**: v0.2.59 reached finalized **464** with all 32 nodes together (vs the old leader-only 96..491 spread).
- Every per-lap drive phase (outbound send, outbound recv, inbound_streams) is now wall-clock-bounded, so no single conn/phase can starve inbound.

**Live validation of v0.2.60 in progress** — confirming the bounded phases hold finality indefinitely (past the ~45-min mark where v0.2.59's residual `inbound_streams` saturation re-appeared). Residual drive-loop budget tuning tracked as it's observed.

No zeam protocol changes — all transport fixes are in zig-libp2p/zquic.
