### PR TITLE
deps: bump zig-libp2p -> v0.2.67 (transport finality fixes) + QUIC log hygiene & spec-aligned fetch guard

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.63.tar.gz",
-            .hash = "zig_libp2p-0.2.63-lil2hAXPKQDQhZJ51wvZN4M39B_JU-sSEYaSP0KOgRax",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.64.tar.gz",
+            .hash = "zig_libp2p-0.2.64-lil2hAXPKQDHwPTMqx7xmjoTFh1hi_HjJ2p6_6azsymg",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.64.tar.gz",
-            .hash = "zig_libp2p-0.2.64-lil2hAXPKQDHwPTMqx7xmjoTFh1hi_HjJ2p6_6azsymg",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.66.tar.gz",
+            .hash = "zig_libp2p-0.2.66-lil2hJ3jKQDWJ7FzsA4vbhfzkqUCOQV9xZwAf8sIXZRi",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.66.tar.gz",
-            .hash = "zig_libp2p-0.2.66-lil2hJ3jKQDWJ7FzsA4vbhfzkqUCOQV9xZwAf8sIXZRi",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.67.tar.gz",
+            .hash = "zig_libp2p-0.2.67-lil2hJzjKQAF5_Dd2P31vZTNTvtGoRrC9o-aCN0g5zI6",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,7 +61,7 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.62.tar.gz",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.63.tar.gz",
             .hash = "zig_libp2p-0.2.62-lil2hNS3KQBlOtyx0ZDepR6YkRfqrSgolr0XQowL6hPU",
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.61.tar.gz",
-            .hash = "zig_libp2p-0.2.61-lil2hNS3KQD1cJdJXHmH7A3vSoQoXrv4yLnLsO_OAb2R",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.62.tar.gz",
+            .hash = "zig_libp2p-0.2.62-lil2hNS3KQBlOtyx0ZDepR6YkRfqrSgolr0XQowL6hPU",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -62,7 +62,7 @@
         },
         .zig_libp2p = .{
             .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.63.tar.gz",
-            .hash = "zig_libp2p-0.2.62-lil2hNS3KQBlOtyx0ZDepR6YkRfqrSgolr0XQowL6hPU",
+            .hash = "zig_libp2p-0.2.63-lil2hAXPKQDQhZJ51wvZN4M39B_JU-sSEYaSP0KOgRax",
         },
     },
     .paths = .{""},

--- a/pkgs/cli/src/main.zig
+++ b/pkgs/cli/src/main.zig
@@ -39,9 +39,12 @@ fn quicAwareLogFn(
     args: anytype,
 ) void {
     if (comptime isQuicStackScope(scope)) {
-        // Levels are err=0, warn=1, info=2, debug=3.  We only gate the
-        // chattier levels (>= info); warn/err always pass through.
-        if (comptime @intFromEnum(level) >= @intFromEnum(std.log.Level.info)) {
+        // Levels are err=0, warn=1, info=2, debug=3.  Gate warn/info/debug
+        // behind DEBUG_QUIC (rust-libp2p principle: the QUIC transport's
+        // backpressure/outbox/SLOW-drive chatter is operational noise, off by
+        // default — set DEBUG_QUIC to surface it). Only err always passes
+        // through so a genuine fatal transport failure stays visible.
+        if (comptime @intFromEnum(level) >= @intFromEnum(std.log.Level.warn)) {
             if (!quic_debug_enabled.load(.monotonic)) return;
         }
     }

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -3912,6 +3912,14 @@ pub const BeamChain = struct {
                 }
             }
 
+            // Snapshot the finalized slot once for the loop's stale-fetch guard
+            // below. The lean spec's `prune_stale_attestation_data` treats an
+            // attestation whose `head.slot <= latest_finalized.slot` as STALE
+            // (it can't move fork choice), and the store prunes all block/state
+            // history below finalized — so a `blocks-by-root` fetch for such a
+            // head root is futile (the block is pruned and unservable).
+            const finalized_slot_for_fetch_guard = self.forkChoice.getLatestFinalized().slot;
+
             for (aggregated_attestations) |aggregated_attestation| {
                 var validator_indices = try types.aggregationBitsToValidatorIndices(&aggregated_attestation.aggregation_bits, self.allocator);
                 defer validator_indices.deinit(self.allocator);
@@ -3920,7 +3928,18 @@ pub const BeamChain = struct {
                 self.validateAttestationData(aggregated_attestation.data, true) catch |e| {
                     zeam_metrics.metrics.lean_attestations_invalid_total.incr(.{ .source = "block" }) catch {};
                     if (e == AttestationValidationError.UnknownHeadBlock) {
-                        try missing_roots.append(self.allocator, aggregated_attestation.data.head.root);
+                        // Only enqueue a fetch for a head root we could plausibly
+                        // be served. `validate_attestation` REJECTS unknown
+                        // source/target/head (it never fetches) — the fetch here
+                        // is zeam's own sync helper, not spec. Skip it when the
+                        // head is at/below finalized (spec staleness key
+                        // `head.slot <= latest_finalized.slot`): that block is
+                        // pruned and the fetch only drives a futile req/resp
+                        // storm. The attestation is still dropped exactly as
+                        // before — only the fetch is suppressed.
+                        if (aggregated_attestation.data.head.slot > finalized_slot_for_fetch_guard) {
+                            try missing_roots.append(self.allocator, aggregated_attestation.data.head.root);
+                        }
                     }
                     self.logger.err("invalid aggregated attestation data in block: error={any}", .{e});
                     continue;
@@ -4760,7 +4779,7 @@ pub const BeamChain = struct {
         // AttestationData/Checkpoint convention mismatch is diagnosable from logs.
         const ad = signedAggregation.data;
         self.validateAttestationData(ad, false) catch |err| {
-            self.logger.warn(
+            self.logger.debug(
                 "aggregate-ingest validation failed err={any} slot={d} source=(0x{x},slot={d}) target=(0x{x},slot={d}) head=(0x{x},slot={d})",
                 .{ err, ad.slot, &ad.source.root, ad.source.slot, &ad.target.root, ad.target.slot, &ad.head.root, ad.head.slot },
             );

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4752,7 +4752,20 @@ pub const BeamChain = struct {
     }
 
     pub fn onGossipAggregatedAttestation(self: *Self, signedAggregation: types.SignedAggregatedAttestation) !void {
-        try self.validateAttestationData(signedAggregation.data, false);
+        // Cross-client aggregate-ingest diagnostics: a foreign-subnet aggregate
+        // that fails fork-choice validation is otherwise dropped silently
+        // (node.zig warns only on Unknown*Block-when-not-pending; every other
+        // GossipAttestationValidationError variant propagates as a bare error).
+        // Surface the exact variant + checkpoint fields so a cross-impl
+        // AttestationData/Checkpoint convention mismatch is diagnosable from logs.
+        const ad = signedAggregation.data;
+        self.validateAttestationData(ad, false) catch |err| {
+            self.logger.warn(
+                "aggregate-ingest validation failed err={any} slot={d} source=(0x{x},slot={d}) target=(0x{x},slot={d}) head=(0x{x},slot={d})",
+                .{ err, ad.slot, &ad.source.root, ad.source.slot, &ad.target.root, ad.target.slot, &ad.head.root, ad.head.slot },
+            );
+            return err;
+        };
 
         var validator_indices = try types.aggregationBitsToValidatorIndices(&signedAggregation.proof.participants, self.allocator);
         defer validator_indices.deinit(self.allocator);


### PR DESCRIPTION
Bumps `zig-libp2p` to **v0.2.67** (carrying zquic **v1.7.66**) and adds zeam-side logging/consensus hygiene. This is the batch that took the multi-client devnet (zeam + ethlambda + grandine) from *stuck-at-15/32, never-finalizing* to **deep, sustained finality**.

## Transport fixes (via the zig-libp2p / zquic dependency cascade)
- **Per-stream flow-control tables O(2048) linear scan → O(1) hashmap** (zquic v1.7.65). The dominant defect: `per_stream_send_max` / `per_stream_recv` were fixed `[2048]` arrays scanned linearly *per STREAM frame*, causing ~700 ms–1 s drive laps under a multi-peer mesh (quinn is O(1)). This was the root of the late-ACK → srtt-inflation → pacer-throttle → outbox-drop → handshake-starvation cascade.
- **In-flight tracking cap 16384 → 32768**, heap-allocated `LossDetector.sent` (zquic v1.7.65) — covers a full 32 MB cwnd, kills the untracked-packet loss-detection blind spot.
- **Per-connection pending-send gossip headroom** (zquic v1.7.66) — reserves 8 MB above the 32 MB req/resp budget for the persistent `/meshsub` stream, so a large `blocks_by_range` response can no longer starve gossip (attestation/aggregate) sends.
- **Faster `/meshsub` stuck→reopen, 20 s → 5 s** (zig-libp2p v0.2.67) — a wedged gossip stream (send stalled at the peer's per-stream FC window) reopens in place ~4× sooner, cutting the dropped-gossip window. The timer resets on any outbox progress, so only a *continuously* stalled stream trips it.
- (earlier in the series: per-drive recv delivery budget, demux full socket-drain, send-budget raise.)

## zeam-side changes
- **`DEBUG_QUIC` log gate** — `quicAwareLogFn` now gates **warn** (not just info/debug) for the QUIC-stack scopes (`.zquic`, `.quic_runtime`, …) behind `DEBUG_QUIC`, matching rust-libp2p. The transport's steady-state backpressure/outbox/SLOW-drive chatter is off by default; `err` always passes through; set `DEBUG_QUIC=1` to surface the full stream. (zquic + zig-libp2p READMEs document the convention.)
- **Aggregate-ingest diagnostic → debug** — the cross-client investigation's validation-variant log fired ~3000/10 min once aggregates flowed (`UnknownSourceBlock` is the retryable path); downgraded warn → debug.
- **Skip futile below-finalized block fetches** — don't enqueue a `blocks-by-root` for an aggregated attestation whose head is at/below the finalized slot. Per the lean spec (`fork_choice.py` `prune_stale_attestation_data`), such attestations are stale and the store prunes all history below finalized; `validate_attestation` rejects unknown blocks and never fetches. The block is pruned/unservable, so the fetch only drove a futile req/resp storm (`send_request`-no-conn / `Disconnected` / `unserved`, ~1300/10 min). **Validation outcome is unchanged** — the aggregate is still dropped exactly as before; only the non-spec fetch is suppressed.

## Validation
Live multi-client devnet on this stack: all containers up + fully peered, **coverage all 8 subnets**, **justification + finalization advancing network-wide** (zeam/ethlambda/grandine), finality tracking ~21 slots behind head. The earlier "missing subnets" was always broken peer clients (gean crash-loop on genesis config; lantern/ream not publishing aggregates), never a zeam/zquic/zig-libp2p defect.

zeam: `zig build` clean, node tests pass. No Claude attribution.