### PR TITLE
shadow: drop obsolete quinn-udp patch (fixes auto-rebase Cargo.lock conflict)

### DIFF
--- a/docs/shadow-simulation.md
+++ b/docs/shadow-simulation.md
@@ -1,0 +1,80 @@
+# Running zeam under the Shadow network simulator
+
+`devnet5-shadow` is a self-contained setup for running a zeam devnet under the
+[Shadow](https://shadow.github.io) discrete-event network simulator. It layers a
+few Shadow-specific adjustments on top of the devnet5 line.
+
+## What this branch adds
+
+- **`-Dno-jemalloc` build option.** Drops the jemalloc global allocator and uses
+  the system allocator instead. jemalloc's first-init reads `/etc/malloc.conf`
+  via `readlink` while holding its non-recursive init lock; under Shadow that
+  `readlink` is the shim's first intercepted syscall, whose lazy init calls
+  `fopen` → `malloc` and re-enters jemalloc, self-deadlocking at startup
+  (reported upstream as shadow/shadow#3763). The system allocator avoids it.
+- **lean-quickstart shadow-automation tip.** The `lean-quickstart` submodule
+  points at the shadow-automation branch tip so the harness can drive the
+  simulation.
+
+## QUIC under Shadow (handled by zig-libp2p)
+
+zeam's networking is pure [zig-libp2p](https://github.com/blockblaz/zig-libp2p)
+(Zig QUIC via zquic) — there is no longer any rust/quinn dependency, so the old
+vendored `quinn-udp` fallback this branch used to carry is gone.
+
+Shadow's syscall shim does not implement `recvmmsg(2)`, which zig-libp2p's
+batched UDP receive path uses. As of zig-libp2p **v0.2.65** the receive path
+detects this (`recvmmsg` → `ENOSYS`) and automatically falls back to a
+per-datagram `recvfrom` loop for the rest of the run, so QUIC handshakes
+complete and peers connect under Shadow with **no special flag or patch**
+(see zig-libp2p#291). `main` already pins zig-libp2p ≥ v0.2.67, so this works
+out of the box.
+
+## Build
+
+```sh
+zig build -Dno-jemalloc -Doptimize=ReleaseSafe
+```
+
+Use at least `ReleaseSafe` (optimized, with runtime safety checks) — or
+`-Doptimize=ReleaseFast` for maximum speed. The default prover (`dummy`) already
+builds the multisig/leanMultisig devnet5 prover (no `-Dprover` needed). No
+networking-specific flag is required: the Shadow `recvfrom` fallback lives in
+zig-libp2p and engages automatically.
+
+**RAM note:** optimizing the ~240 MB prover staticlib is memory-hungry — LLVM can
+need >28 GB and OOM a 32 GB host. On a constrained box, add swap (e.g. 16–24 GB)
+or use a larger machine. Avoid `Debug` for real runs: it is unoptimized (much
+slower under Shadow) and uses the leak-detecting allocator that never returns
+freed pages to the OS, so node RSS ratchets up — treat it only as a last resort
+on a very small host.
+
+## Run
+
+Shadow does not charge CPU time, so the recursive-STARK prover would otherwise
+run "free" in virtual time, making the simulation unrepresentative. Model its
+cost with the `--shadow-xmss-*-rate` node flags — each sleeps `n / rate`
+nanoseconds of virtual time for an `n`-unit operation. Add them to the
+`zeam node` args in your `shadow.yaml` (tune the rates to your measured prover
+cost):
+
+```
+zeam node ... \
+  --shadow-xmss-merge-rate 2 \
+  --shadow-xmss-aggregate-signatures-rate 5 \
+  --shadow-xmss-verify-aggregated-signatures-rate 100
+```
+
+Then run the simulation:
+
+```sh
+shadow shadow.yaml
+```
+
+## Expected result
+
+A 4-node devnet boots and finalizes in lockstep 3SF (finalized = head − 3) at
+4 s slots — e.g. `head=59 / justified=57 / finalized=56`. The first ~2 slots are
+slow (QUIC peer connections + genesis warmup); after that it advances steadily.
+An optimized (`ReleaseSafe`/`ReleaseFast`) build runs near or faster than
+wall-clock; an unoptimized `Debug` build is several times slower per slot.


### PR DESCRIPTION
## What & why

The **Shadow Branch Auto-Rebase** workflow has been failing on every push to `main` ([example run](https://github.com/blockblaz/zeam/actions/runs/28479196746)) with a `rust/Cargo.lock` conflict while replaying the shadow patch commit onto main.

Root cause: the shadow patch carried a **vendored `quinn-udp` fallback** (`rust/patch/quinn-udp` + `[patch.crates-io]` + hand-edited `rust/Cargo.lock`/`Cargo.toml`). That patch is now **obsolete** — zeam's QUIC networking is pure zig-libp2p (zquic), not rust/quinn, and the Shadow `recvmmsg → recvfrom` fallback lives in zig-libp2p as of **v0.2.65** (`main` already pins **v0.2.67**) and engages automatically on `ENOSYS`. The hand-edited `rust/Cargo.lock` was the recurring conflict, and it bought nothing.

## Change

Rewrites the shadow patch commit to drop **all** rust/quinn-udp content, keeping only the still-relevant Shadow-only bits:

- ❌ removed: `rust/patch/quinn-udp/*`, `[patch.crates-io] quinn-udp` in `rust/Cargo.toml`, the `rust/Cargo.lock` edit
- ✅ kept: `docs/shadow-simulation.md` (updated to describe the zig-libp2p Shadow path instead of quinn-udp) and the `lean-quickstart` shadow-automation tip

With the rust patch gone, the shadow branch no longer touches `rust/Cargo.lock`, so the auto-rebase applies cleanly going forward.

## ⚠️ How to merge

`shadow` is a single-patch, force-pushed branch (the auto-rebase rewrites it), so this can't land as a normal merge commit — that would keep the old conflicting patch in history. **Force-update `shadow` to this branch's tip instead:**

```sh
git fetch origin
git push --force-with-lease origin origin/fix/shadow-strip-quinn-udp:shadow
```

(or I can do it once you've reviewed). This PR is the review artifact for that replacement; the noisy file diff vs `shadow` is just `main` catching up — the only substantive change is dropping the rust/quinn-udp patch.
