### PR TITLE
deps: bump zig-libp2p -> v0.2.68 (reqresp now_ms deadline fix)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.67.tar.gz",
-            .hash = "zig_libp2p-0.2.67-lil2hJzjKQAF5_Dd2P31vZTNTvtGoRrC9o-aCN0g5zI6",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.68.tar.gz",
+            .hash = "zig_libp2p-0.2.68-lil2hAgMKgABQIRtIick0IWdDYYt89Qa1vWTaPvU7D1f",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Bumps zig-libp2p to **v0.2.68**, which fixes the `zeam↔lantern` connection flapping seen on the devnet.

## Root cause (in v0.2.67)
`Host.sendRequest` passed its `timeout_ms` (~8000) into `req_resp.sendRequest`'s `now_ms: i64` parameter. The deadline is derived as `now_ms + cfg.request_timeout_ms`, so it landed ~16 s **after the Unix epoch** → the next `req_resp.tick` sweep expired the request in a few ms with `StreamTimedOut`. Fast round-trips won the race (masking it against most peers); the slow **listener-opens-status-stream-back-to-the-dialer** path (only lantern does this) lost it almost every time → request failed in ~5 ms → peer closed the connection → flap → subnet2 coverage 1/4, dragging finality.

## Fix
[blockblaz/zig-libp2p#295](https://github.com/blockblaz/zig-libp2p/pull/295): pass the real wall clock. Regression test (listener-opens-reqresp-to-dialer) 20/20 post-fix; full `zig build test` green. No zquic change.

Only `build.zig.zon` changes here (url + hash → v0.2.68).