### PR TITLE
deps: bump zig-libp2p -> v0.2.69 (now_ms fix + reap diagnostic)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.67.tar.gz",
-            .hash = "zig_libp2p-0.2.67-lil2hJzjKQAF5_Dd2P31vZTNTvtGoRrC9o-aCN0g5zI6",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.69.tar.gz",
+            .hash = "zig_libp2p-0.2.69-lil2hIYQKgA29cUdEngNuNqx612JcewQVOv1IlW5xLAL",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Bumps zig-libp2p to **v0.2.69**, which contains:

- **v0.2.68**: the `now_ms` request-deadline fix (`Host.sendRequest` was passing `timeout_ms` as the wall clock, expiring every request on the first tick). [blockblaz/zig-libp2p#295](https://github.com/blockblaz/zig-libp2p/pull/295)
- **v0.2.69**: peer + protocol + stall-mode context in the inbound reqresp reap log, so the next capture pins the residual `zeam↔lantern` reqresp stall (never-negotiated vs no-request-body vs partial) instead of a generic `no response in 30000ms`. [blockblaz/zig-libp2p#296](https://github.com/blockblaz/zig-libp2p/pull/296)

Supersedes #1017 (v0.2.68). Only `build.zig.zon` changes (url + hash → v0.2.69).
