### PR TITLE
deps: zig-libp2p (standing branch)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.69.tar.gz",
-            .hash = "zig_libp2p-0.2.69-lil2hIYQKgA29cUdEngNuNqx612JcewQVOv1IlW5xLAL",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.70.tar.gz",
+            .hash = "zig_libp2p-0.2.70-lil2hP83KgDFbSEOMIC2P_2prRxSFkkjhb39Yfu-IQbe",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.67.tar.gz",
-            .hash = "zig_libp2p-0.2.67-lil2hJzjKQAF5_Dd2P31vZTNTvtGoRrC9o-aCN0g5zI6",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.69.tar.gz",
+            .hash = "zig_libp2p-0.2.69-lil2hIYQKgA29cUdEngNuNqx612JcewQVOv1IlW5xLAL",
         },
     },
     .paths = .{""},

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -1091,14 +1091,26 @@ pub const EthLibp2p = struct {
         };
         errdefer self.allocator.free(peer_owned);
 
-        var request = interface.ReqRespRequest.deserialize(self.allocator, method, r.payload) catch |e| {
-            self.logger.err(
-                "network-{d}:: inbound rpc SSZ decode method={s} from={s} failed: {any}",
-                .{ self.params.networkId, @tagName(method), peer_str, e },
-            );
-            self.allocator.free(peer_owned);
-            return;
-        };
+        // Empty-body /status interop: rust-libp2p (lantern) and gean open a
+        // /status stream and send NO request body — they expect the responder
+        // to reply with its Status without a request. zig-libp2p (v0.2.70+) now
+        // dispatches that empty stream with a "" payload instead of reaping it.
+        // Our status responder ignores the request Status entirely (returns
+        // chain.getStatus()), so a zeroed default is fine. Accept it here rather
+        // than failing SSZ decode (PayloadTooSmall) and dropping the response —
+        // which left the peer without an answer and kept it flapping. Scoped to
+        // .status only; blocks_by_* still require a valid decoded request.
+        var request = if (method == .status and r.payload.len == 0)
+            interface.ReqRespRequest{ .status = std.mem.zeroes(types.Status) }
+        else
+            interface.ReqRespRequest.deserialize(self.allocator, method, r.payload) catch |e| {
+                self.logger.err(
+                    "network-{d}:: inbound rpc SSZ decode method={s} from={s} failed: {any}",
+                    .{ self.params.networkId, @tagName(method), peer_str, e },
+                );
+                self.allocator.free(peer_owned);
+                return;
+            };
         defer request.deinit();
 
         const stream_ctx = self.allocator.create(ServerStreamContext) catch |e| {


### PR DESCRIPTION
Standing branch for zig-libp2p dependency bumps — reused in place per bump (no more per-version branches). Rebuild `0xpartha/zeam:local` from this branch.

## Current pin: **zig-libp2p v0.2.70** + a zeam-side status-decode fix

This branch bundles the transport/reqresp fixes that resolved the multi-client (zeam ↔ ethlambda/grandine/gean/ream/lantern) devnet interop issues:

### zig-libp2p (via `build.zig.zon`)
- **v0.2.68** — `Host.sendRequest` passed `timeout_ms` into the `now_ms` param, so every request's deadline landed ~decades in the past and the next tick expired it with `StreamTimedOut` in a few ms. Now passes the real wall clock. ([zig-libp2p#295](https://github.com/blockblaz/zig-libp2p/pull/295))
- **v0.2.69** — enriched the inbound-reqresp reap log with `peer/proto/handshake_done/req_bytes/fin` so a stall names its cause instead of a generic "no response in 30000ms". ([zig-libp2p#296](https://github.com/blockblaz/zig-libp2p/pull/296))
- **v0.2.70** — answer an inbound `/status` stream that has **no request body**. rust-libp2p (lantern) and other clients open `/status`, complete multistream-select, then send zero bytes and never FIN; zeam was the only client that waited for a decodable body, so it reaped the stream after 30 s and the peer flapped. Now dispatches the status responder with an empty payload after a 500 ms grace (scoped to `.status`; `blocks_by_*` unchanged). ([zig-libp2p#297](https://github.com/blockblaz/zig-libp2p/pull/297))

### zeam (`pkgs/network/src/ethlibp2p.zig`)
- **Accept empty-body inbound `/status`.** With v0.2.70 dispatching a `""` payload, `ReqRespRequest.deserialize(.status, "")` failed with `error.PayloadTooSmall`, so the handler logged an error and returned **without responding**. The status responder ignores the request `Status` anyway (returns `chain.getStatus()`), so an empty payload is now accepted as a zeroed default `Status` and dispatched normally. Scoped to `.status` + empty payload; `blocks_by_root/range` still require a valid decoded request.

## Verified on the devnet
- `PayloadTooSmall` → **0**, inbound status reaps → **0** (dispatch firing), empty `/status` is answered.
- Network **finalizes deeply** (finalized 330 / justified 346 / head 364 at last check) across all six client types.

## Known residual (NOT this PR — lantern-side)
A separate connection-admission churn remains: zeam dials lantern (lantern doesn't dial back), and lantern **remote-closes zeam's connection ~8 ms after accept**, intermittently. It's not the status reqresp (fixed) and not duplicate-connection (no inbound leg) — it's lantern's connection management. Cosmetic (lantern still participates; finality is healthy); to be filed with the lantern team.
