### PR TITLE
node: make source-side attestation checks gossip-only in fork choice

### DIFF
--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4677,19 +4677,26 @@ pub const BeamChain = struct {
         // All fork-choice-derivable validation lives in one shared method on
         // ForkChoice (proto-array existence/slots, source/target/head
         // ancestry, slot-before-head, and the interval-based future-slot
-        // bound). The future-slot bound applies only to gossip — block-
-        // included attestations are trusted under the block's own validation.
+        // bound). `is_gossip` (= !is_from_block) selects the checks that apply
+        // only to a wire vote; a block-embedded attestation is trusted under the
+        // block's own STF validation for those.
         //
-        // The future-slot drop sits before the proto-node lookups inside the
-        // shared method: an attestation for a far-future slot referencing
-        // future blocks would otherwise bottom out at UnknownHeadBlock and
-        // make the caller enqueue a BlocksByRoot for a head that does not
-        // exist anywhere — a fetch-storm amplifier on aggregators.
+        // Gossip-only: the future-slot bound and the source-side
+        // existence/ancestry. The future-slot drop sits before the proto-node
+        // lookups — an attestation for a far-future slot referencing future
+        // blocks would otherwise bottom out at UnknownHeadBlock and make the
+        // caller enqueue a BlocksByRoot for a head that does not exist anywhere,
+        // a fetch-storm amplifier on aggregators. Source existence is skipped for
+        // block attestations because the STF already validated source against the
+        // block's canonical chain, and finalization prunes pre-finalized
+        // ancestors from proto-array — checking it here would drop valid on-chain
+        // votes once finalization advances past their source.
         //
-        // Ancestry is applied on BOTH paths (gossip and block): block-embedded
-        // attestations are also fed to the fork-choice tracker via onAttestation,
-        // so gating it on gossip would reopen the vote-splitting vector for
-        // attestations smuggled inside a block.
+        // Both paths: target/head existence and the head-side ancestry (target
+        // ancestor of head). Block-embedded attestations are fed to the
+        // fork-choice tracker via onAttestation and LMD weight flows along the
+        // head's ancestry, so those stay to close the vote-splitting vector.
+        // Source-side is FFG-only and does not steer LMD weight.
         self.forkChoice.validateAttestationDataForGossip(data, !is_from_block) catch |err| {
             self.logger.debug("attestation validation failed: error={any} slot={d} source={d} target={d} head={d} is_from_block={any}", .{
                 err,
@@ -6456,6 +6463,63 @@ test "attestation validation - comprehensive" {
             error.TargetCheckpointNotAncestorOfHead,
             beam_chain.validateAttestationData(invalid_attestation.message, false),
         );
+    }
+
+    // Test 14: block path (is_from_block=true) skips the source existence check.
+    //
+    // A block attestation's source is validated by the STF against the block's
+    // canonical chain, and finalization prunes pre-finalized ancestors from
+    // proto-array. The fork-choice tracker consumes only head, so an
+    // unknown/pruned source must not drop the vote on the block path — while the
+    // gossip path still rejects it.
+    {
+        const unknown_source = [_]u8{0xFF} ** 32;
+        const att: types.SignedAttestation = .{
+            .validator_id = 0,
+            .message = .{
+                .slot = 2,
+                .head = types.Checkpoint{ .root = mock_chain.blockRoots[2], .slot = 2 },
+                .source = types.Checkpoint{ .root = unknown_source, .slot = 1 },
+                .target = types.Checkpoint{ .root = mock_chain.blockRoots[2], .slot = 2 },
+            },
+            .signature = ZERO_SIGBYTES,
+        };
+        try std.testing.expectError(error.UnknownSourceBlock, beam_chain.validateAttestationData(att.message, false));
+        try beam_chain.validateAttestationData(att.message, true);
+    }
+
+    // Test 15: block path still enforces head existence — head is the only field
+    // the tracker consumes, so an unresolvable head cannot be applied.
+    {
+        const unknown_head = [_]u8{0xDD} ** 32;
+        const att: types.SignedAttestation = .{
+            .validator_id = 0,
+            .message = .{
+                .slot = 2,
+                .head = types.Checkpoint{ .root = unknown_head, .slot = 2 },
+                .source = types.Checkpoint{ .root = mock_chain.blockRoots[1], .slot = 1 },
+                .target = types.Checkpoint{ .root = mock_chain.blockRoots[2], .slot = 2 },
+            },
+            .signature = ZERO_SIGBYTES,
+        };
+        try std.testing.expectError(error.UnknownHeadBlock, beam_chain.validateAttestationData(att.message, true));
+    }
+
+    // Test 16: the head-side ancestry (target ancestor of head) still applies on
+    // the block path — relaxing the source-side does not reopen the vote-splitting
+    // vector. A sibling head is rejected on BOTH paths.
+    {
+        const att: types.SignedAttestation = .{
+            .validator_id = 0,
+            .message = .{
+                .slot = 2,
+                .head = types.Checkpoint{ .root = sibling_head_root, .slot = 2 },
+                .source = types.Checkpoint{ .root = mock_chain.blockRoots[1], .slot = 1 },
+                .target = types.Checkpoint{ .root = mock_chain.blockRoots[2], .slot = 2 },
+            },
+            .signature = ZERO_SIGBYTES,
+        };
+        try std.testing.expectError(error.TargetCheckpointNotAncestorOfHead, beam_chain.validateAttestationData(att.message, true));
     }
 }
 

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -3437,21 +3437,28 @@ pub const ForkChoice = struct {
     ///
     /// Signature, proof, registry-bound, and empty-bits checks are NOT here.
     /// They need chain/state context and are layered by the caller.
-    pub fn validateAttestationDataForGossip(self: *Self, data: types.AttestationData, check_future_slot: bool) GossipAttestationValidationError!void {
+    pub fn validateAttestationDataForGossip(self: *Self, data: types.AttestationData, is_gossip: bool) GossipAttestationValidationError!void {
         self.mutex.lockShared();
         defer self.mutex.unlockShared();
-        return self.validateAttestationDataForGossipUnlocked(data, check_future_slot);
+        return self.validateAttestationDataForGossipUnlocked(data, is_gossip);
     }
 
     // Internal unlocked version - assumes caller holds (at least shared) lock.
-    fn validateAttestationDataForGossipUnlocked(self: *Self, data: types.AttestationData, check_future_slot: bool) GossipAttestationValidationError!void {
+    //
+    // `is_gossip` selects the gossip-admission checks that apply only to a wire
+    // vote: the future-slot bound and the source-side existence/ancestry. A
+    // block-embedded attestation (is_gossip=false) has already had its
+    // source/target/head validated by the STF against the block's canonical
+    // chain, so those are skipped for it. target/head existence and the
+    // head-side ancestry apply on both paths.
+    fn validateAttestationDataForGossipUnlocked(self: *Self, data: types.AttestationData, is_gossip: bool) GossipAttestationValidationError!void {
         // The future-slot bound is hoisted before the proto-node lookups.
         // An attestation for a far-future slot referencing future blocks
         // would otherwise bottom out at UnknownHeadBlock and trigger a
         // BlocksByRoot fetch for a head that does not exist anywhere — a
         // fetch-storm amplifier on aggregators. Rejecting here means the
         // missing root is never derived and the fetch is never enqueued.
-        if (check_future_slot) {
+        if (is_gossip) {
             const now_intervals = self.fcStore.slot_clock.time.load(.monotonic);
             const attestation_start_interval = data.slot * constants.INTERVALS_PER_SLOT;
             if (attestation_start_interval > now_intervals + constants.GOSSIP_DISPARITY_INTERVALS) {
@@ -3459,23 +3466,29 @@ pub const ForkChoice = struct {
             }
         }
 
-        // 1. Source, target, and head blocks must exist in the proto-array.
-        const source_idx = self.protoArray.indices.get(data.source.root) orelse {
+        // 1. Target and head must exist in the proto-array (both paths). Source
+        // existence is gossip-only: a block attestation's source is validated by
+        // the STF against the block's canonical chain, and finalization prunes
+        // pre-finalized ancestors from proto-array — so a valid on-chain vote
+        // whose source sits at/below the finalized boundary must not be dropped
+        // here. The fork-choice tracker consumes only head.
+        const source_idx: ?usize = if (is_gossip) (self.protoArray.indices.get(data.source.root) orelse {
             return GossipAttestationValidationError.UnknownSourceBlock;
-        };
+        }) else null;
         const target_idx = self.protoArray.indices.get(data.target.root) orelse {
             return GossipAttestationValidationError.UnknownTargetBlock;
         };
         const head_idx = self.protoArray.indices.get(data.head.root) orelse {
             return GossipAttestationValidationError.UnknownHeadBlock;
         };
-        const source_node = self.protoArray.nodes.items[source_idx];
         const target_node = self.protoArray.nodes.items[target_idx];
         const head_node = self.protoArray.nodes.items[head_idx];
 
         // 2. Slot relationships. History is linear and monotonic.
-        if (source_node.slot > target_node.slot) {
-            return GossipAttestationValidationError.SourceSlotExceedsTarget;
+        if (source_idx) |si| {
+            if (self.protoArray.nodes.items[si].slot > target_node.slot) {
+                return GossipAttestationValidationError.SourceSlotExceedsTarget;
+            }
         }
         // Invariant: attestation.source.slot <= attestation.target.slot
         if (data.source.slot > data.target.slot) {
@@ -3487,8 +3500,10 @@ pub const ForkChoice = struct {
         }
 
         // 3. Checkpoint slots must match their blocks' slots.
-        if (source_node.slot != data.source.slot) {
-            return GossipAttestationValidationError.SourceCheckpointSlotMismatch;
+        if (source_idx) |si| {
+            if (self.protoArray.nodes.items[si].slot != data.source.slot) {
+                return GossipAttestationValidationError.SourceCheckpointSlotMismatch;
+            }
         }
         if (target_node.slot != data.target.slot) {
             return GossipAttestationValidationError.TargetCheckpointSlotMismatch;
@@ -3497,13 +3512,17 @@ pub const ForkChoice = struct {
             return GossipAttestationValidationError.HeadCheckpointSlotMismatch;
         }
 
-        // 4. Ancestry: fork-choice weight accrues to every ancestor of the
-        // attested head, so a source off the target's chain (or a target off
-        // the head's chain) would steer weight onto a non-canonical branch.
-        // checkpointIsAncestor matches by root, so a sibling block at the same
-        // slot is correctly rejected. Reuse the unlocked walk — we already hold
-        // the shared lock here, so the locked variant would self-deadlock.
-        if (!self.checkpointIsAncestorUnlocked(data.source, data.target)) {
+        // 4. Ancestry. Head-side (target ancestor of head) applies on BOTH paths:
+        // block-embedded attestations are fed to the fork-choice tracker via
+        // onAttestation and LMD weight flows along the head's ancestry, so a
+        // target off the head's chain must be rejected on both paths to close the
+        // vote-splitting vector. Source-side (source ancestor of target) is
+        // FFG-only, does not steer LMD weight, and is already validated by the STF
+        // for block attestations — so it is gossip-only (source may be pruned on
+        // the block path). checkpointIsAncestor matches by root, so a sibling at
+        // the same slot is rejected. Reuse the unlocked walk — we hold the shared
+        // lock here, so the locked variant would self-deadlock.
+        if (is_gossip and !self.checkpointIsAncestorUnlocked(data.source, data.target)) {
             return GossipAttestationValidationError.SourceCheckpointNotAncestorOfTarget;
         }
         if (!self.checkpointIsAncestorUnlocked(data.target, data.head)) {


### PR DESCRIPTION
## Problem

Block-included attestations are validated via `chain.validateAttestationData(data, is_from_block=true)`, which delegates to `forkChoice.validateAttestationDataForGossip`. Its source/target/head existence + ancestry checks query the **proto-array**. Finalization prunes pre-finalized ancestors from proto-array (`forkChoice.rebase`), so a valid on-chain vote whose **source** sits at/below the finalized boundary is dropped (`UnknownSourceBlock`, or `SourceCheckpointNotAncestorOfTarget`) and never applied to the LMD tracker.

Under catch-up sync (finalization advancing in jumps) this fires on nearly every block-included attestation. An observed devnet run: **728 such drops across 292 slots** while the node stalled — finalized frozen, head stuck, own duties silenced by the behind-peers gate.

## Why source doesn't belong in this check (for block attestations)

- `source` is **FFG-only**; the LMD tracker consumes only `head`.
- For a block attestation, source/target/head are already validated by the STF (`process_attestations`: `has_correct_source_root`, `is_source_justified`, `has_correct_head_root`) against the block's **own canonical chain** — the correct reference frame.
- For reference: beacon's `validate_on_attestation` never checks source at all; leanSpec validates block attestations in the STF, not the fork-choice gate.

So the source-side fork-choice checks are redundant for block attestations and only false-reject on pruning.