### PR TITLE
ci: target devnet5 in hive workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/hive-scheduled-failure.md
+++ b/.github/ISSUE_TEMPLATE/hive-scheduled-failure.md
@@ -17,8 +17,8 @@ This issue is auto-opened by the `hive` workflow and updated in place by later s
 
 ### Notes
 
-- The upstream `clients/zeam` Dockerfile in `ethereum/hive` selects the devnet4
-  binary from the pre-published `blockblaz/zeam:devnet4` image (no tag build
+- The upstream `clients/zeam` Dockerfile in `ethereum/hive` selects devnet
+  binaries from pre-published `blockblaz/zeam:devnetN` images (no tag build
   arg), so a failure here may reflect the published image rather than HEAD of
   `main`. Check the published image tag before assuming a regression in-tree.
 - Logs, per-test results, and the hiveview output are attached to the workflow

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -11,16 +11,15 @@
 # Hive side (upstream ethereum/hive):
 #   - Client definition:  clients/zeam/
 #   - Simulator:          simulators/lean
-#   - Client profiles:    simulators/lean/clients/{devnet3,devnet4}.yaml
+#   - Client profiles:    simulators/lean/clients/{devnet3,devnet4,devnet5}.yaml
 #
 # Known limitation (tracked for follow-up, not this PR):
-#   The upstream zeam Dockerfile in ethereum/hive selects the devnet3 binary
-#   from a pinned source revision (build arg `zeam_devnet3_revision`) and the
-#   devnet4 binary from the pre-published `blockblaz/zeam:devnet4` Docker Hub
-#   image (no tag build arg). As a result, PR-label-triggered runs currently
-#   exercise the published devnet4 image rather than the exact PR HEAD binary.
+#   The upstream zeam Dockerfile in ethereum/hive selects devnet binaries from
+#   pre-published `blockblaz/zeam:devnetN` Docker Hub images (no tag build arg).
+#   As a result, PR-label-triggered runs currently exercise the published
+#   devnet image rather than the exact PR HEAD binary.
 #   To test an arbitrary PR commit, we will need an upstream hive change that
-#   exposes a `zeam_devnet4_tag` build arg (or equivalent) and a per-PR image
+#   exposes a `zeam_devnet_tag` build arg (or equivalent) and a per-PR image
 #   push to Docker Hub/GHCR. Tracked separately.
 
 name: hive
@@ -41,10 +40,11 @@ on:
         description: 'Lean devnet profile to select from simulators/lean/clients/'
         required: false
         type: choice
-        default: 'devnet4'
+        default: 'devnet5'
         options:
           - devnet3
           - devnet4
+          - devnet5
       hive_repository:
         description: 'Hive repo hosting the Lean simulator + zeam client definition'
         required: false
@@ -67,7 +67,7 @@ permissions:
 
 jobs:
   hive:
-    name: hive (lean / ${{ github.event.inputs.devnet || vars.HIVE_DEVNET || 'devnet4' }})
+    name: hive (lean / ${{ github.event.inputs.devnet || vars.HIVE_DEVNET || 'devnet5' }})
     runs-on: ubuntu-latest
     # Gate PR runs behind the `run-hive` label. Scheduled and manual runs always pass this check.
     if: >-
@@ -87,7 +87,7 @@ jobs:
 
           DEVNET="${{ github.event.inputs.devnet }}"
           [ -z "$DEVNET" ] && DEVNET="${{ vars.HIVE_DEVNET }}"
-          [ -z "$DEVNET" ] && DEVNET="devnet4"
+          [ -z "$DEVNET" ] && DEVNET="devnet5"
 
           HIVE_REPOSITORY="${{ github.event.inputs.hive_repository }}"
           [ -z "$HIVE_REPOSITORY" ] && HIVE_REPOSITORY="${{ vars.HIVE_REPOSITORY }}"
@@ -183,7 +183,7 @@ jobs:
 
       # The upstream `clients/zeam` Dockerfile in ethereum/hive does an
       # `apt-get update && apt-get install` over the public Ubuntu mirrors and
-      # a `docker pull blockblaz/zeam:devnet4` before any zeam-specific code
+      # a `docker pull blockblaz/zeam:devnetN` before any zeam-specific code
       # runs. Both are transient-failure prone on shared GitHub runners and
       # produce a build-time failure (exit 100) that does not indicate a
       # regression in-tree. Retry the hive invocation once with a small
@@ -418,10 +418,9 @@ jobs:
             parts.push(
               `Artifacts (logs, test results) are attached to the workflow run.`,
               ``,
-              `> **Note:** the upstream \`clients/zeam\` Dockerfile pulls the devnet4 binary`,
-              `> from the pre-published \`blockblaz/zeam:devnet4\` image and the devnet3`,
-              `> binary from a pinned source revision, so this run does not exercise the`,
-              `> exact PR HEAD binary. Per-PR binary coverage requires an upstream hive change`,
+              `> **Note:** the upstream \`clients/zeam\` Dockerfile pulls devnet binaries`,
+              `> from pre-published \`blockblaz/zeam:devnetN\` images, so this run does`,
+              `> not exercise the exact PR HEAD binary. Per-PR binary coverage requires an upstream hive change`,
               `> (see the note at the top of the workflow file).`,
             );
             const body = parts.join('\n');


### PR DESCRIPTION
## Summary
- switch the zeam Hive workflow default from devnet4 to devnet5
- add devnet5 to the manual workflow dispatch choices
- refresh the PR comment and scheduled-failure issue notes so they describe the current upstream `clients/zeam` Dockerfile behavior

## Context
The linked public Hive run is `rpc-compat` for `zeam_devnet5`, with test 204 (`state finalized endpoint tracks latest finalized slot`) timing out against zeam image commit `b95f3f1`:
https://hive.leanroadmap.org/suite.html?suiteid=1783053818-c06f6520e6b1bba2f40681a2f5defef9.json&suitename=rpc-compat&client=zeam_devnet5#test-204

The in-repo Hive workflow was still defaulting to `devnet4` and did not offer `devnet5`, so scheduled/manual zeam Hive coverage was not tracking the profile that failed externally.

## Validation
- `git diff --check`

PyYAML is not installed in this workspace, so I could not run a parser-based YAML validation locally.
