### PR TITLE
deps: zig-libp2p v0.2.82 — zeam<->lantern peering fixes (CRYPTO reassembly, handshake deadline, CONNECTION_CLOSE on abandon) + peers metric

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.71.tar.gz",
-            .hash = "zig_libp2p-0.2.71-lil2hP03KgD2MxxiIybgUAsfJIxMH80Yx1aiAjHGPgzo",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.72.tar.gz",
+            .hash = "zig_libp2p-0.2.72-lil2hOdBKgBq6Daqf06W_GODQS9hDVenI4GMcfXp0H3r",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.78.tar.gz",
-            .hash = "zig_libp2p-0.2.78-lil2hFhCKgB4cuMInNhUupG7-gGh0jYArvGwNHg5oFNP",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.79.tar.gz",
+            .hash = "zig_libp2p-0.2.79-lil2hPxEKgAEArsQdqE9V51fkrIM5MgiXlQKQnzk2Mjh",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.74.tar.gz",
-            .hash = "zig_libp2p-0.2.74-lil2hOdBKgDnhZ2Y26q_I8MwyLNxRtHLEq08TQuxtX5R",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.75.tar.gz",
+            .hash = "zig_libp2p-0.2.75-lil2hOdBKgC_QRLzm9omod3CwyCFuCgfvq7Svdc6EKzV",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.73.tar.gz",
-            .hash = "zig_libp2p-0.2.73-lil2hOdBKgDeUj15VEtvh8cDETUDWZFbO5vLupJKyMJT",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.74.tar.gz",
+            .hash = "zig_libp2p-0.2.74-lil2hOdBKgDnhZ2Y26q_I8MwyLNxRtHLEq08TQuxtX5R",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.75.tar.gz",
-            .hash = "zig_libp2p-0.2.75-lil2hOdBKgC_QRLzm9omod3CwyCFuCgfvq7Svdc6EKzV",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.76.tar.gz",
+            .hash = "zig_libp2p-0.2.76-lil2hEtlKgD1eDwDBbvORC1jXQj2Bt5F18krAiKaPQ4N",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.80.tar.gz",
-            .hash = "zig_libp2p-0.2.80-lil2hPxEKgBfE_rNSe8DayO7mFeG4tfztixtBO9GkzS6",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.81.tar.gz",
+            .hash = "zig_libp2p-0.2.81-lil2hAxMKgDlQg9fR9y7ViUY2Y6lq5xB8gRzH-0BHj-r",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.79.tar.gz",
-            .hash = "zig_libp2p-0.2.79-lil2hPxEKgAEArsQdqE9V51fkrIM5MgiXlQKQnzk2Mjh",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.80.tar.gz",
+            .hash = "zig_libp2p-0.2.80-lil2hPxEKgBfE_rNSe8DayO7mFeG4tfztixtBO9GkzS6",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.77.tar.gz",
-            .hash = "zig_libp2p-0.2.77-lil2hOdBKgAm61qDXbzAYzIZUmpbDUShNMU1nIgwy3ks",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.78.tar.gz",
+            .hash = "zig_libp2p-0.2.78-lil2hFhCKgB4cuMInNhUupG7-gGh0jYArvGwNHg5oFNP",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.72.tar.gz",
-            .hash = "zig_libp2p-0.2.72-lil2hOdBKgBq6Daqf06W_GODQS9hDVenI4GMcfXp0H3r",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.73.tar.gz",
+            .hash = "zig_libp2p-0.2.73-lil2hOdBKgDeUj15VEtvh8cDETUDWZFbO5vLupJKyMJT",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.70.tar.gz",
-            .hash = "zig_libp2p-0.2.70-lil2hP83KgDFbSEOMIC2P_2prRxSFkkjhb39Yfu-IQbe",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.71.tar.gz",
+            .hash = "zig_libp2p-0.2.71-lil2hP03KgD2MxxiIybgUAsfJIxMH80Yx1aiAjHGPgzo",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.81.tar.gz",
-            .hash = "zig_libp2p-0.2.81-lil2hAxMKgDlQg9fR9y7ViUY2Y6lq5xB8gRzH-0BHj-r",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.82.tar.gz",
+            .hash = "zig_libp2p-0.2.82-lil2hEVQKgACg1W3D__2guahABzat8J7N4aI-79Ee-Uv",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.76.tar.gz",
-            .hash = "zig_libp2p-0.2.76-lil2hEtlKgD1eDwDBbvORC1jXQj2Bt5F18krAiKaPQ4N",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.77.tar.gz",
+            .hash = "zig_libp2p-0.2.77-lil2hOdBKgAm61qDXbzAYzIZUmpbDUShNMU1nIgwy3ks",
         },
     },
     .paths = .{""},

--- a/pkgs/metrics/src/lib.zig
+++ b/pkgs/metrics/src/lib.zig
@@ -568,7 +568,10 @@ const Metrics = struct {
     const PQSigAggregatedValidCounter = metrics_lib.Counter(u64);
     const PQSigAggregatedInvalidCounter = metrics_lib.Counter(u64);
     // Network peer metric types
-    const LeanConnectedPeersGauge = metrics_lib.GaugeVec(u64, struct { client: []const u8, client_type: []const u8 });
+    // Bare total (parity with lantern/ream/grandine which export a single
+    // `lean_connected_peers` value). Was a per-peer 0/1 GaugeVec, which read as
+    // `1` under a non-summing query and diverged from every other client.
+    const LeanConnectedPeersGauge = metrics_lib.Gauge(u64);
     const PeerConnectionEventsCounter = metrics_lib.CounterVec(u64, struct { direction: []const u8, result: []const u8 });
     const PeerDisconnectionEventsCounter = metrics_lib.CounterVec(u64, struct { direction: []const u8, reason: []const u8 });
     const LibP2pSwarmCommandDroppedCounter = metrics_lib.CounterVec(u64, struct { reason: []const u8 });
@@ -1177,7 +1180,7 @@ pub fn init(allocator: std.mem.Allocator) !void {
         .lean_pq_sig_aggregated_signatures_valid_total = Metrics.PQSigAggregatedValidCounter.init("lean_pq_sig_aggregated_signatures_valid_total", .{ .help = "Total number of valid aggregated signatures" }, .{}),
         .lean_pq_sig_aggregated_signatures_invalid_total = Metrics.PQSigAggregatedInvalidCounter.init("lean_pq_sig_aggregated_signatures_invalid_total", .{ .help = "Total number of invalid aggregated signatures" }, .{}),
         // Network peer metrics
-        .lean_connected_peers = try Metrics.LeanConnectedPeersGauge.init(allocator, io, "lean_connected_peers", .{ .help = "Number of connected peers" }, .{}),
+        .lean_connected_peers = Metrics.LeanConnectedPeersGauge.init("lean_connected_peers", .{ .help = "Number of connected peers" }, .{}),
         .lean_peer_connection_events_total = try Metrics.PeerConnectionEventsCounter.init(allocator, io, "lean_peer_connection_events_total", .{ .help = "Total number of peer connection events" }, .{}),
         .lean_peer_disconnection_events_total = try Metrics.PeerDisconnectionEventsCounter.init(allocator, io, "lean_peer_disconnection_events_total", .{ .help = "Total number of peer disconnection events" }, .{}),
         .zeam_libp2p_swarm_command_dropped_total = try Metrics.LibP2pSwarmCommandDroppedCounter.init(allocator, io, "zeam_libp2p_swarm_command_dropped_total", .{ .help = "Total number of swarm commands dropped before reaching the rust-libp2p event loop, by reason (issue #808)" }, .{}),

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -490,7 +490,6 @@ pub const EthLibp2p = struct {
     /// SignedKey extension carries the secp256k1 host pubkey. Nothing
     /// is written to disk.
     fn startQuicTransport(self: *Self) !void {
-        const now_sec = @divTrunc(zl.wall_time.milliTimestamp(), 1000);
         const host_pub_compressed: [33]u8 = self.host_signer.kp.public_key.toCompressedSec1();
 
         var cert_seed: [32]u8 = undefined;
@@ -504,8 +503,12 @@ pub const EthLibp2p = struct {
                     .sign_ctx = self.host_signer,
                 },
             },
-            .not_before_sec = now_sec - 3600,
-            .not_after_sec = now_sec + 365 * 24 * 3600,
+            // Fixed, effectively-unbounded validity window matching the
+            // reference libp2p-TLS impls (rust-libp2p/rcgen: 1975..4096;
+            // go-libp2p: now-1h..now+100y). Clock-skew independent so no
+            // peer verifier rejects on NotBefore/NotAfter.
+            .not_before_sec = zl.security.libp2p_tls_cert.libp2p_not_before_sec,
+            .not_after_sec = zl.security.libp2p_tls_cert.libp2p_not_after_sec,
             .cert_key_seed = cert_seed,
         });
         defer gen.deinit(self.allocator);

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -2798,15 +2798,6 @@ pub const BeamNode = struct {
         }
     }
 
-    /// Extract client type prefix from a node name like "zeam_0" -> "zeam", fallback "unknown".
-    fn clientTypeFromName(name: ?[]const u8) []const u8 {
-        const n = name orelse return "unknown";
-        if (std.mem.indexOfScalar(u8, n, '_')) |sep| {
-            if (sep > 0) return n[0..sep];
-        }
-        return if (n.len > 0) n else "unknown";
-    }
-
     pub fn onPeerConnected(ptr: *anyopaque, peer_id: []const u8, direction: networks.PeerDirection) !void {
         const self: *Self = @ptrCast(@alignCast(ptr));
 
@@ -2821,9 +2812,8 @@ pub const BeamNode = struct {
 
         // Record metrics
         zeam_metrics.metrics.lean_peer_connection_events_total.incr(.{ .direction = @tagName(direction), .result = "success" }) catch {};
-        const client_name = node_name.name orelse "unknown";
-        const client_type = clientTypeFromName(node_name.name);
-        zeam_metrics.metrics.lean_connected_peers.set(.{ .client = client_name, .client_type = client_type }, 1) catch {};
+        // Total connected peers, matching every other client's bare gauge.
+        zeam_metrics.metrics.lean_connected_peers.set(@intCast(self.network.getPeerCount()));
 
         const handler = self.getReqRespResponseHandler();
         const status = self.chain.getStatus();
@@ -2862,9 +2852,8 @@ pub const BeamNode = struct {
 
             // Record metrics
             zeam_metrics.metrics.lean_peer_disconnection_events_total.incr(.{ .direction = @tagName(direction), .reason = @tagName(reason) }) catch {};
-            const client_name = node_name.name orelse "unknown";
-            const client_type = clientTypeFromName(node_name.name);
-            zeam_metrics.metrics.lean_connected_peers.set(.{ .client = client_name, .client_type = client_type }, 0) catch {};
+            // Total connected peers, matching every other client's bare gauge.
+            zeam_metrics.metrics.lean_connected_peers.set(@intCast(self.network.getPeerCount()));
         }
 
         if (reason == .timeout or reason == .error_) {


### PR DESCRIPTION
Standing dependency branch for the **zeam ↔ lantern peering saga**, now at **zig-libp2p v0.2.82** (zquic **v1.7.81**). What started as "lantern flaps every ~2-3s against zeam" decomposed into **four independent bugs** — three in zquic's CRYPTO/handshake layer, one in zig-libp2p's connection teardown — plus a metric bug, each root-caused with wire captures, live-devnet diagnostics, and lantern's own debug logs.

## Net changes vs `main`

| file | change |
|---|---|
| `build.zig.zon` | zig-libp2p → **v0.2.82** (pulls zquic v1.7.81) |
| `pkgs/metrics/src/lib.zig`, `pkgs/node/src/node.zig` | `lean_connected_peers` is now a **bare total gauge** set from `getPeerCount()` (was a per-peer 0/1 GaugeVec that read `1` under non-summing queries; every other client exports a single total) |
| `pkgs/network/src/ethlibp2p.zig` | libp2p-TLS cert validity window aligned with go/rust-libp2p (earlier commit on this branch) |

## The four transport root causes (fixed upstream)

**1. Initial space — fragmented, reboundaried ClientHello** (zquic v1.7.73).
lantern (ngtcp2/c-lean-libp2p) splits its ~1.4 KB ClientHello into dozens of small CRYPTO frames and retransmits with *different* boundaries each round; zquic's reassembly only accepted exact-frontier segments, needing ~5 RTTs — longer than lantern's handshake timeout. Fixed with overlap-aware reassembly. This made zeam-dials-lantern work.

**2. Handshake space — fragmented client Certificate/Finished flight** (zquic v1.7.76).
The reverse direction, one packet-number space later: zeam's server fed CRYPTO fragments to a TLS parser requiring *whole* messages (bytes consumed unrecoverably on `TruncatedMessage`), and the Handshake-space frame path still had the pre-v1.7.73 exact-frontier gate with a drain that only ran on exact matches. lantern's dials to zeam wedged in `.waiting_finished` forever as app-invisible **zombies** — QUIC-alive via PTO keepalives (verified by tcpdump), never registered — which lantern counted as healthy peers, so it never redialed and dedup-closed every fresh zeam dial ~10 ms after accept. Fixed by accumulating the client flight until a complete `Finished` + straddle-consume + always-drain on both HS CRYPTO paths.

**3. Reorder-buffer eviction starved the frontier + zombies were immortal** (zquic v1.7.79).
Under devnet boot storms, retransmitted fragment sets overflowed the 128-slot reorder buffer, whose eviction dropped the **smallest-offset** slot — the exact segment reassembly needed next. Now evicts the largest. Plus two guarantees: a **15s handshake deadline** (conns never reaching `.connected` are reaped even while the peer keeps ACKing — previously immortal because idle-reap required `.connected`) and rate-limited diagnostics replacing the silent `catch continue` in `pollInboundRegistrations`. Result on the devnet: **all 6 zeam nodes at 31/31 for the first time**, zero wedge diagnostics.

**4. zig-libp2p never sent CONNECTION_CLOSE on local conn abandons** (zig-libp2p v0.2.82) — the residual 27↔31 oscillation.
Confirmed by running one lantern at `--log-level debug` (its "closing duplicate peer connection" is debug-only and was invisible all along): **55 dedup-closes in 90 s while lantern dialed nobody** — both "duplicates" were zeam's own conns. Every zig-libp2p teardown that locally abandoned an outbound conn (20 s dial-handshake timeout, peer-id verification failure, alloc failures, shutdown) freed it silently; the peer often had a completed handshake and kept a **half-open carcass**, then dedup-closed every fresh zeam dial against it — a self-sustaining loop paced by zeam's redial backoff, decaying only via the carcass's ~30 s idle timeout (hence the oscillation). All abandon paths now send `CONNECTION_CLOSE` first; zquic's deadline reap does the same for `.waiting_finished` conns.

Also along the way: `/status` empty-body responder grace 500→20 ms (v0.2.79); the v0.2.76 dedup gate reverted (broke known-peer retry, treated a symptom); v1.7.74/v0.2.78 were temporary diagnostic tags. zquic v1.7.77/78/80 upstream feature releases (ACK Frequency, stream priority, recv-budget) are included via rebase.

## Verification
- zquic + zig-libp2p suites green at every step; new unit tests for reorder eviction and overlap-aware reassembly.
- Devnet at v0.2.81: first-ever 31/31 on all zeam nodes, zero handshake-wedge diagnostics, chain finalizing (head 274 / justified 256 / finalized 192); residual oscillation then root-caused as #4 via lantern debug logs.
- Pending: devnet redeploy at v0.2.82 — expected stable 31/31 with lantern dup-closes ≈ 0 (lantern_0 left on debug logging for direct causal verification).

## Notes
- lantern_0 on the devnet currently runs `--log-level debug` (flipped for diagnosis; revert via ansible when done).
- Follow-up candidates (not this PR): standard simultaneous-open dedup in zig-libp2p; lantern-side `LANTERN_GOSSIPSUB_MAX_CONNS_PER_PEER=8` silent close noted upstream.
