### PR TITLE
Port leanSpec rejection hardening fixes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ssz = .{
-            .url = "git+https://github.com/blockblaz/ssz.zig#1afdc1293fc4920f117b850a457d37889b248583",
-            .hash = "ssz-0.0.9-Lfwd6zHhAwC-rfj3kWup3QyMGdKDFiTysMLr1s7fsvjB",
+            .url = "git+https://github.com/blockblaz/ssz.zig#9aaa4a1f4055c1961b38fd248aad95ba0551158c",
+            .hash = "ssz-0.0.9-Lfwd61O-AwB0lcKewyjmUs64s6cbflC4KWhFPkOvUoqD",
         },
         .zigcli = .{
             .url = "git+https://github.com/jiacai2050/zigcli#621920da8f2235c6b9c15addf353e7747e1e899c",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ssz = .{
-            .url = "git+https://github.com/blockblaz/ssz.zig#9aaa4a1f4055c1961b38fd248aad95ba0551158c",
-            .hash = "ssz-0.0.9-Lfwd61O-AwB0lcKewyjmUs64s6cbflC4KWhFPkOvUoqD",
+            .url = "git+https://github.com/blockblaz/ssz.zig#1afdc1293fc4920f117b850a457d37889b248583",
+            .hash = "ssz-0.0.9-Lfwd6zHhAwC-rfj3kWup3QyMGdKDFiTysMLr1s7fsvjB",
         },
         .zigcli = .{
             .url = "git+https://github.com/jiacai2050/zigcli#621920da8f2235c6b9c15addf353e7747e1e899c",

--- a/pkgs/node/src/chain.zig
+++ b/pkgs/node/src/chain.zig
@@ -4797,11 +4797,14 @@ pub const BeamChain = struct {
                 data.head.slot,
                 is_from_block,
             });
-            // GossipAttestationValidationError is a strict subset of
+            // GossipAttestationValidationError variants are a subset of
             // AttestationValidationError (identical variant names), so the
             // error value coerces directly — callers that branch on a specific
             // reason (e.g. the block-import path enqueueing a BlocksByRoot fetch
             // on UnknownHeadBlock) still match the same global error value.
+            // Note: HeadNotDescendantOfFinalized is also present in
+            // AttestationValidationError; no fetch is enqueued for it because
+            // the block is pruned and unservable.
             return err;
         };
 
@@ -5980,6 +5983,9 @@ const AttestationValidationError = error{
     HeadOlderThanTarget,
     SourceCheckpointNotAncestorOfTarget,
     TargetCheckpointNotAncestorOfHead,
+    /// Head block's chain does not descend from the finalized checkpoint.
+    /// Hard reject — the block is pruned and unservable; no fetch is enqueued.
+    HeadNotDescendantOfFinalized,
     AttestationSlotBeforeHead,
     AttestationTooFarInFuture,
     EmptyAggregationBits,

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -3537,8 +3537,20 @@ pub const ForkChoice = struct {
         if (!self.checkpointIsAncestorUnlocked(data.target, data.head)) {
             return GossipAttestationValidationError.TargetCheckpointNotAncestorOfHead;
         }
-        if (is_gossip and !self.checkpointIsAncestorUnlocked(self.fcStore.latest_finalized, data.head)) {
-            return GossipAttestationValidationError.HeadNotDescendantOfFinalized;
+        if (is_gossip) {
+            // Reject gossip attestations whose head is not in the finalized
+            // subtree. When head.slot >= finalized.slot the finalized
+            // checkpoint must be an ancestor of the head; when the head
+            // references a block at or below the finalized slot we check the
+            // reverse — the head must be an ancestor of finalized (i.e. it
+            // was on the canonical chain that led to finalization).
+            const in_finalized_subtree = if (data.head.slot >= self.fcStore.latest_finalized.slot)
+                self.checkpointIsAncestorUnlocked(self.fcStore.latest_finalized, data.head)
+            else
+                self.checkpointIsAncestorUnlocked(data.head, self.fcStore.latest_finalized);
+            if (!in_finalized_subtree) {
+                return GossipAttestationValidationError.HeadNotDescendantOfFinalized;
+            }
         }
 
         // 5. A vote cannot have observed its head before that head existed.

--- a/pkgs/node/src/forkchoice.zig
+++ b/pkgs/node/src/forkchoice.zig
@@ -3436,8 +3436,9 @@ pub const ForkChoice = struct {
     ///  2. Checkpoint slot ordering: source.slot <= target.slot, head.slot >= target.slot.
     ///  3. Checkpoint slots match their blocks' slots (source, target, head).
     ///  4. Ancestry: source lies on target's chain, target lies on head's chain.
-    ///  5. The vote's slot does not precede the head it claims to have seen.
-    ///  6. The vote's slot has started locally within the disparity margin.
+    ///  5. Gossip votes must keep their head under the finalized subtree.
+    ///  6. The vote's slot does not precede the head it claims to have seen.
+    ///  7. The vote's slot has started locally within the disparity margin.
     ///
     /// The future-slot bound applies only to gossip; block-included
     /// attestations are trusted under the block's own validation and pass
@@ -3536,6 +3537,9 @@ pub const ForkChoice = struct {
         if (!self.checkpointIsAncestorUnlocked(data.target, data.head)) {
             return GossipAttestationValidationError.TargetCheckpointNotAncestorOfHead;
         }
+        if (is_gossip and !self.checkpointIsAncestorUnlocked(self.fcStore.latest_finalized, data.head)) {
+            return GossipAttestationValidationError.HeadNotDescendantOfFinalized;
+        }
 
         // 5. A vote cannot have observed its head before that head existed.
         if (data.slot < data.head.slot) {
@@ -3600,6 +3604,7 @@ pub const GossipAttestationValidationError = error{
     HeadOlderThanTarget,
     SourceCheckpointNotAncestorOfTarget,
     TargetCheckpointNotAncestorOfHead,
+    HeadNotDescendantOfFinalized,
     AttestationSlotBeforeHead,
     AttestationTooFarInFuture,
 };
@@ -5755,6 +5760,36 @@ const RebaseTestContext = struct {
         self.mock_chain.deinit(self.allocator);
     }
 };
+
+test "validateAttestationDataForGossip rejects head outside finalized subtree" {
+    const allocator = std.testing.allocator;
+    var ctx = try RebaseTestContext.init(allocator, 4);
+    defer ctx.deinit();
+
+    // Finalize D on the canonical branch A->B->C->D while the attestation head
+    // is I on the sibling branch C->G->H->I. Source/target/head all exist and
+    // have valid ancestry among themselves, but the head is not below finalized.
+    ctx.fork_choice.fcStore.latest_finalized = .{
+        .root = createTestRoot(0xDD),
+        .slot = 5,
+    };
+
+    const data = types.AttestationData{
+        .slot = 7,
+        .source = .{ .root = createTestRoot(0xCC), .slot = 3 },
+        .target = .{ .root = createTestRoot(0x22), .slot = 6 },
+        .head = .{ .root = createTestRoot(0x33), .slot = 7 },
+    };
+
+    try std.testing.expectError(
+        GossipAttestationValidationError.HeadNotDescendantOfFinalized,
+        ctx.fork_choice.validateAttestationDataForGossip(data, true),
+    );
+
+    // Block-carried attestations are not gossip-admitted; the state transition
+    // owns their canonical-chain validation.
+    try ctx.fork_choice.validateAttestationDataForGossip(data, false);
+}
 
 test "getProposalAttestations: high-target keys survive cap with stale low-target backlog" {
     const allocator = std.testing.allocator;

--- a/pkgs/types/src/state.zig
+++ b/pkgs/types/src/state.zig
@@ -132,6 +132,13 @@ pub const BeamState = struct {
     pub fn getJustification(self: *const Self, allocator: Allocator, justifications: *std.AutoHashMapUnmanaged(Root, []u8)) !void {
         // need to cast to usize for slicing ops but does this makes the STF target arch dependent?
         const num_validators = self.validatorCount();
+        if (num_validators == 0) {
+            return StateTransitionError.EmptyValidatorRegistry;
+        }
+        const expected_vote_count = self.justifications_roots.len() * num_validators;
+        if (self.justifications_validators.len() != expected_vote_count) {
+            return StateTransitionError.InvalidJustificationVotesLength;
+        }
         // Initialize justifications from state
         for (self.justifications_roots.constSlice(), 0..) |blockRoot, i| {
             if (std.mem.eql(u8, &blockRoot, &utils.ZERO_HASH)) {
@@ -551,7 +558,10 @@ pub const BeamState = struct {
                         var iter = justifications.iterator();
                         while (iter.next()) |entry| {
                             const root = entry.key_ptr.*;
-                            const slot = block_cache.get(root) orelse return StateTransitionError.InvalidJustificationRoot;
+                            const slot = block_cache.get(root) orelse {
+                                try roots_to_remove.append(allocator, root);
+                                continue;
+                            };
                             if (slot <= finalized_slot) {
                                 try roots_to_remove.append(allocator, root);
                             }
@@ -957,6 +967,41 @@ test "process_attestations silently skips pre-finalized target attestations" {
     try state.process_attestations(std.testing.allocator, attestations_list, logger, null);
 }
 
+test "process_attestations rejects malformed justification vote layout" {
+    var logger_config = zeam_utils.getTestLoggerConfig();
+    const logger = logger_config.logger(null);
+    var state = try makeGenesisState(std.testing.allocator, 3);
+    defer state.deinit();
+
+    const pending_root = [_]u8{7} ** 32;
+    var pending_roots = try JustificationRoots.init(std.testing.allocator);
+    errdefer pending_roots.deinit();
+    try pending_roots.append(pending_root);
+
+    var pending_validators = try JustificationValidators.init(std.testing.allocator);
+    errdefer pending_validators.deinit();
+    try pending_validators.append(true);
+    try pending_validators.append(false);
+
+    state.justifications_roots.deinit();
+    state.justifications_roots = pending_roots;
+    state.justifications_validators.deinit();
+    state.justifications_validators = pending_validators;
+
+    var attestations_list = try block.AggregatedAttestations.init(std.testing.allocator);
+    defer attestations_list.deinit();
+
+    try std.testing.expectError(
+        StateTransitionError.InvalidJustificationVotesLength,
+        state.process_attestations(std.testing.allocator, attestations_list, logger, null),
+    );
+}
+
+test "slot before finalized is not justifiable" {
+    try std.testing.expectEqual(false, try utils.IsJustifiableSlot(10, 9));
+    try std.testing.expectEqual(false, try utils.IsJustifiableSlot(100, 90));
+}
+
 test "cloneForProjection clones projection fields and leaves historical_block_hashes empty" {
     const allocator = std.testing.allocator;
     var logger_config = zeam_utils.getTestLoggerConfig();
@@ -1264,17 +1309,23 @@ test "pruning keeps pending justifications" {
     defer block_5.deinit();
     try state.process_block_header(std.testing.allocator, block_5, logger);
 
-    // Phase 3: Seed a pending justification.
+    // Phase 3: Seed one pending canonical justification plus one off-chain
+    // pending tally that can come from a malformed decoded state.
     const slot_3_root = try state.historical_block_hashes.get(3);
+    const phantom_root = [_]u8{0xff} ** 32;
 
     var pending_roots = try JustificationRoots.init(std.testing.allocator);
     errdefer pending_roots.deinit();
     try pending_roots.append(slot_3_root);
+    try pending_roots.append(phantom_root);
 
     var pending_validators = try JustificationValidators.init(std.testing.allocator);
     errdefer pending_validators.deinit();
     try pending_validators.append(true);
     try pending_validators.append(false);
+    try pending_validators.append(false);
+    try pending_validators.append(false);
+    try pending_validators.append(true);
     try pending_validators.append(false);
 
     state.justifications_roots.deinit();
@@ -1311,13 +1362,17 @@ test "pruning keeps pending justifications" {
     try std.testing.expectEqual(@as(Slot, 2), state.latest_justified.slot);
 
     var found = false;
+    var found_phantom = false;
     for (state.justifications_roots.constSlice()) |root| {
         if (std.mem.eql(u8, &root, &slot_3_root)) {
             found = true;
-            break;
+        }
+        if (std.mem.eql(u8, &root, &phantom_root)) {
+            found_phantom = true;
         }
     }
     try std.testing.expect(found);
+    try std.testing.expect(!found_phantom);
 }
 
 // Helper: build a chain block_1..block_6 shaped for the finalization scenario.
@@ -1455,7 +1510,7 @@ fn buildFinalizedSlot4Chain(
 // justified without re-entering the finalization-advance scan from below the
 // finalized boundary — which would otherwise call IsJustifiableSlot with a
 // candidate slot smaller than the finalized slot and abort state transition
-// with `InvalidJustifiableSlot`.
+// with a not-justifiable answer.
 test "stale finalized source justifies without rewinding finalization" {
     var logger_config = zeam_utils.getTestLoggerConfig();
     const logger = logger_config.logger(null);

--- a/pkgs/types/src/utils.zig
+++ b/pkgs/types/src/utils.zig
@@ -28,7 +28,7 @@ pub const RootHex = [64]u8;
 pub const ZERO_HASH = [_]u8{0x00} ** 32;
 pub const ZERO_SIGBYTES = [_]u8{0} ** SIGSIZE;
 
-pub const StateTransitionError = error{ InvalidParentRoot, InvalidPreState, InvalidPostState, InvalidExecutionPayloadHeaderTimestamp, InvalidJustifiableSlot, InvalidValidatorId, InvalidBlockSignatures, InvalidLatestBlockHeader, InvalidProposer, InvalidJustificationIndex, InvalidJustificationCapacity, InvalidJustificationTargetSlot, InvalidJustificationRoot, InvalidSlotIndex, DuplicateAttestationData, TooManyAttestationData };
+pub const StateTransitionError = error{ InvalidParentRoot, InvalidPreState, InvalidPostState, InvalidExecutionPayloadHeaderTimestamp, InvalidJustifiableSlot, InvalidValidatorId, InvalidBlockSignatures, InvalidLatestBlockHeader, InvalidProposer, InvalidJustificationIndex, InvalidJustificationCapacity, InvalidJustificationTargetSlot, InvalidJustificationRoot, InvalidJustificationVotesLength, EmptyValidatorRegistry, InvalidSlotIndex, DuplicateAttestationData, TooManyAttestationData };
 
 const json = std.json;
 
@@ -65,7 +65,7 @@ pub fn freeJsonValue(val: *json.Value, allocator: Allocator) void {
 // prepare the state to be pre state of the slot
 pub fn IsJustifiableSlot(finalized: types.Slot, candidate: types.Slot) !bool {
     if (candidate < finalized) {
-        return StateTransitionError.InvalidJustifiableSlot;
+        return false;
     }
 
     const delta: f32 = @floatFromInt(candidate - finalized);


### PR DESCRIPTION
Ports the robustness fixes from leanEthereum/leanSpec PRs 1177, 1178, 1179, and 1180 into zeam.

Mapping:
- leanSpec #1177: bump `blockblaz/ssz.zig` to `9aaa4a1`, which rejects zero first offsets for variable-size SSZ lists.
- leanSpec #1178: make `IsJustifiableSlot` total for candidates before finalized and reject malformed flat justification bookkeeping (`EmptyValidatorRegistry`, `InvalidJustificationVotesLength`, zero roots already rejected).
- leanSpec #1179: reject gossip attestations whose head is not a descendant of the current finalized checkpoint, while leaving block-contained attestations to state-transition validation.
- leanSpec #1180: when finalization rebases pending tallies, drop roots absent from the chain slot map instead of aborting with `InvalidJustificationRoot`.

Tests added/updated:
- malformed justification vote-list layout rejection
- pre-finalized justifiability returns false
- finalization pruning drops off-chain pending tally but keeps canonical pending tally
- gossip finalized-subtree rejection with block-path non-rejection

Local validation:
- `zig fmt --check build.zig.zon pkgs/types/src/utils.zig pkgs/types/src/state.zig pkgs/node/src/forkchoice.zig`
- `git diff --check`

Could not run `zig build test --summary all` in this workspace: installed Zig is `0.15.2`, while the repo declares `minimum_zig_version = "0.16.0"`; dependency build scripts fail before zeam code compiles (`Build.Graph` has no field `io` in gremlin/libxev/zig_yaml, plus zigcli API mismatch).