### PR TITLE
deps: zig-libp2p v0.2.87 — zeam<->lantern peering fixed (non-minimal varints, PING frames, DEBUG_QUIC diagnostics)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.84.tar.gz",
-            .hash = "zig_libp2p-0.2.84-lil2hEVQKgAuYGQWjyevylB7XqaETgncVmx_xPWFlEif",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.85.tar.gz",
+            .hash = "zig_libp2p-0.2.85-lil2hEVQKgAc-YumiXvt0j7y_fKHkfjd45MXx6Y5upx9",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.83.tar.gz",
-            .hash = "zig_libp2p-0.2.83-lil2hEVQKgDQ1uYQPmlHNZBaaUeoJGZS9-4GpEtBiJtJ",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.84.tar.gz",
+            .hash = "zig_libp2p-0.2.84-lil2hEVQKgAuYGQWjyevylB7XqaETgncVmx_xPWFlEif",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.82.tar.gz",
-            .hash = "zig_libp2p-0.2.82-lil2hEVQKgACg1W3D__2guahABzat8J7N4aI-79Ee-Uv",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.83.tar.gz",
+            .hash = "zig_libp2p-0.2.83-lil2hEVQKgDQ1uYQPmlHNZBaaUeoJGZS9-4GpEtBiJtJ",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.86.tar.gz",
-            .hash = "zig_libp2p-0.2.86-lil2hEVQKgB3_JDFAeINtNdheuT1NYiAN_MbRQti4Kpa",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.87.tar.gz",
+            .hash = "zig_libp2p-0.2.87-lil2hEVQKgA40r0yFW6uau6U5hAPQd1q2S-0TJKASnic",
         },
     },
     .paths = .{""},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.85.tar.gz",
-            .hash = "zig_libp2p-0.2.85-lil2hEVQKgAc-YumiXvt0j7y_fKHkfjd45MXx6Y5upx9",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.86.tar.gz",
+            .hash = "zig_libp2p-0.2.86-lil2hEVQKgB3_JDFAeINtNdheuT1NYiAN_MbRQti4Kpa",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Completes the **zeam ↔ lantern peering saga** (follow-up to #1028): zig-libp2p **v0.2.87** → zquic **v1.7.86**. **Devnet-verified fixed**: all 6 zeam nodes pinned at **31/31** (lanterns included), lantern disconnects **0/min** across all zeams, inbound lantern connections registering at zeam for the first time, chain finalizing tightly.

## Net changes vs `main` (which already carries #1028)
- `build.zig.zon`: zig-libp2p → **v0.2.87** (zquic v1.7.86)

## What this bump carries

**The terminal fix — accept non-minimal varints on all receive paths (zquic v1.7.86, RFC 9000 §16).**
ngtcp2 (lantern) encodes packet Length and CRYPTO offset/length varints **non-minimally, prominently on retransmits** (pre-reserved 2-byte length fields). RFC 9000 §16 permits any encoding length and requires receivers to accept it — but zquic's *server* Initial/Handshake receive paths used strict decoding and rejected those frames in silent `catch break/return`s. Result: lantern's first-transmission handshake flights (minimal encodings) completed; every *retransmitted* flight was dropped forever — the connection wedged in `waiting_finished` as an app-invisible zombie that lantern counted as a live peer and deduped fresh dials against. This is precisely why the failure was load-dependent (loss → retransmits), lantern-only (ngtcp2's encoder), inbound-only (zeam-as-server), and immune to every prior fix. zquic had learned this exact lesson once before on the *client* path (see the `varint.zig` test naming "the zeam↔lantern/ngtcp2 handshake bug") — all **67** remaining strict decode sites in `io.zig` are now permissive.

**Also included (the intermediate layers, each real and necessary):**
- **PING (0x01) handling in the Initial/Handshake CRYPTO frame loops** (v1.7.84) — the loops previously `break`-ed on PING, dropping the client flight ngtcp2 coalesces with it.
- **`DEBUG_QUIC=1` runtime handshake diagnostics** (v1.7.82/83/85) — production-build, env-gated (one relaxed atomic load per site when off): packet dispatch w/ shard+DCID, findConn misses, decrypt/TLS failures, flight accumulate/partial/complete, reorder gaps, deadline reaps. These cracked the last two layers by elimination and end diagnostic-only releases for this area. Deploy plumbing: `zeam_debug_quic: 1` (ansible) / `DEBUG_QUIC=1 ./spin-node.sh`.
- **Multi-packet Handshake-flight reassembly hardening** (v1.7.85 diagnostics; v1.7.79 evicts far-frontier reorder slots instead of near; 15s handshake deadline so any future wedge self-heals instead of zombifying; unregistered-conn warnings in `pollInboundRegistrations`).

## How it was found
Wire capture showed "zeam sends its flight, lantern sends its client flight, zeam goes silent." DEBUG_QUIC then eliminated layer after layer on the live devnet: routing/lookup clean (125/125 accepted, 0 findConn misses) → frame loop clean post-PING-fix (0 stops) → reassembly clean (0 partial/out-of-order) → leaving only the uninstrumented strict-varint rejects.

## Verification (devnet, image `7ad69ba`)
- zeam peers: `[31, 31, 31, 31, 31, 31]` sustained 20+ min
- lantern disconnects across all zeams: **0/min** (was ~50/min at zeam_0 alone)
- lantern `-1004` status failures: ~45/min → ~5/min residual (aimed at non-zeam peers)
- handshake-deadline reaps: 0; finality advancing (…192 → 228…)
- zquic + zig-libp2p test suites green at every step
