### PR TITLE
deps: zig-libp2p v0.2.89

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.87.tar.gz",
-            .hash = "zig_libp2p-0.2.87-lil2hEVQKgA40r0yFW6uau6U5hAPQd1q2S-0TJKASnic",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.89.tar.gz",
+            .hash = "zig_libp2p-0.2.89-lil2hMltKgA7YdmHAS_eavWH0unkgsQhybBFEWqukws4",
         },
     },
     .paths = .{""},


### PR DESCRIPTION
Updates `zig_libp2p` from v0.2.87 to v0.2.89 in `build.zig.zon`.