### PR TITLE
sync: fix range recovery test vector

### DIFF
--- a/pkgs/node/src/blocks_by_range_sync.zig
+++ b/pkgs/node/src/blocks_by_range_sync.zig
@@ -407,8 +407,8 @@ test "shouldCatchUpFromPeerStatus small gaps use by-root not threshold gate" {
 
 test "forkMismatchRecoveryStart re-anchors to a recent justified ancestor" {
     try std.testing.expectEqual(
-        @as(?types.Slot, 9340),
-        forkMismatchRecoveryStart(9649, 9339, 14735, constants.MIN_SLOTS_FOR_BLOCK_REQUESTS),
+        @as(?types.Slot, 12_001),
+        forkMismatchRecoveryStart(12_100, 12_000, 14_735, constants.MIN_SLOTS_FOR_BLOCK_REQUESTS),
     );
 }
 


### PR DESCRIPTION
Fixes the macOS `test (macos-latest)` CI failure from https://github.com/blockblaz/zeam/actions/runs/29247771524/job/86810099947.

## Summary
- correct the `forkMismatchRecoveryStart re-anchors to a recent justified ancestor` test vector that failed in the macOS unit-test job
- the previous fixture used anchor slot 9339 with peer head 14735, which is outside the 3600-slot `blocks_by_range` serving window, so the helper correctly returned null
- the updated fixture keeps the peer head but uses a recent anchor/start pair inside the serving window, matching the test name and helper contract

## Validation
- `zig fmt --check pkgs/node/src/blocks_by_range_sync.zig`
- `git diff --check`
- local workspace Zig 0.16 `zig build test --summary all` still fails in this runner because `rustup` is not installed, but the macOS failure signature from the linked job (`expected 9340, found null`) is gone from the local log.
