### PR TITLE
fix(xmss): advance key preparation window before signing (crash at slot 131072)

### DIFF
--- a/rust/hashsig-glue/src/lib.rs
+++ b/rust/hashsig-glue/src/lib.rs
@@ -28,7 +28,11 @@ use config::*;
 
 use leansig::serialization::Serializable;
 use leansig::signature::SignatureScheme;
+// Exposes get_activation_interval / get_prepared_interval / advance_preparation
+// on the secret key, needed to slide the signing window forward (see sign()).
+use leansig::signature::SignatureSchemeSecretKey;
 use leansig::MESSAGE_LENGTH;
+use std::sync::Mutex;
 
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -42,9 +46,12 @@ pub type HashSigPublicKey = XmssPublicKey;
 pub type HashSigSignature = XmssSignature;
 pub type HashSigPrivateKey = XmssSecretKey;
 
-#[repr(C)]
+// Not `#[repr(C)]`: Zig only ever holds this behind an `opaque` pointer and
+// never inspects its layout, and the `Mutex` field is not FFI-safe. The lock
+// guards the interior mutation done by `sign` (advance_preparation) so the
+// shared key handle can be signed from multiple worker threads safely.
 pub struct PrivateKey {
-    inner: HashSigPrivateKey,
+    inner: Mutex<HashSigPrivateKey>,
 }
 
 #[repr(C)]
@@ -57,8 +64,9 @@ pub struct Signature {
     pub inner: HashSigSignature,
 }
 
-/// KeyPair structure for FFI - holds both public and private keys
-#[repr(C)]
+/// KeyPair structure for FFI - holds both public and private keys.
+/// Not `#[repr(C)]` because `PrivateKey` now holds a non-FFI-safe `Mutex`;
+/// Zig only accesses this via `opaque` pointers, never by layout.
 pub struct KeyPair {
     pub public_key: PublicKey,
     pub private_key: PrivateKey,
@@ -78,7 +86,9 @@ pub enum VerificationError {
 
 impl PrivateKey {
     pub fn new(inner: HashSigPrivateKey) -> Self {
-        Self { inner }
+        Self {
+            inner: Mutex::new(inner),
+        }
     }
 
     pub fn generate<R: rand::CryptoRng>(
@@ -97,8 +107,33 @@ impl PrivateKey {
         message: &[u8; MESSAGE_LENGTH],
         epoch: u32,
     ) -> Result<Signature, SigningError> {
-        let sig = XmssScheme::sign(&self.inner, epoch, message)
-            .map_err(|_| SigningError::SigningFailed)?;
+        let mut sk = self.inner.lock().map_err(|_| SigningError::SigningFailed)?;
+        let target = epoch as u64;
+
+        // leansig's sign() panics (aborting the process) if the epoch is outside
+        // the key's activation window. Return a recoverable error instead so a
+        // spent key just fails to sign rather than crashing the node.
+        if !sk.get_activation_interval().contains(&target) {
+            return Err(SigningError::SigningFailed);
+        }
+
+        // The secret key only keeps two consecutive bottom trees "prepared" in
+        // memory at once, covering 2^(LOG_LIFETIME/2 + 1) epochs starting at 0
+        // (131072 for LOG_LIFETIME=32). Signing an epoch beyond that window
+        // requires sliding it forward with advance_preparation, otherwise
+        // leansig's sign() panics with "key not yet prepared" — this is the
+        // crash seen at slot 131072. advance_preparation self-limits at the
+        // activation boundary, so guard against a non-advancing loop.
+        while !sk.get_prepared_interval().contains(&target) {
+            let before = sk.get_prepared_interval();
+            sk.advance_preparation();
+            if sk.get_prepared_interval() == before {
+                return Err(SigningError::SigningFailed);
+            }
+        }
+
+        let sig =
+            XmssScheme::sign(&sk, epoch, message).map_err(|_| SigningError::SigningFailed)?;
         Ok(Signature::new(sig))
     }
 }
@@ -500,7 +535,11 @@ pub unsafe extern "C" fn hashsig_private_key_to_bytes(
     unsafe {
         let private_key_ref = &*private_key;
 
-        let sk_bytes = xmss_secret_key_to_ssz(&private_key_ref.inner);
+        let sk_guard = match private_key_ref.inner.lock() {
+            Ok(g) => g,
+            Err(_) => return 0,
+        };
+        let sk_bytes = xmss_secret_key_to_ssz(&sk_guard);
 
         if sk_bytes.len() > buffer_len {
             return 0;
@@ -616,5 +655,42 @@ mod test_scheme {
                 0
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod advance_preparation_tests {
+    use leansig::signature::generalized_xmss::instantiations_aborting::lifetime_2_to_the_8::SchemeAbortingTargetSumLifetime8Dim46Base8 as TestScheme;
+    use leansig::signature::{SignatureScheme, SignatureSchemeSecretKey};
+    use leansig::MESSAGE_LENGTH;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    // Reproduces the slot-131072 crash shape at small scale. With LOG_LIFETIME=8
+    // each bottom tree covers 2^4=16 epochs, so the key is only "prepared" for
+    // the first 32 epochs [0,32) even though it is activated for more. Signing an
+    // epoch past that window is exactly what panicked in production; the fix is
+    // to advance_preparation until the window covers it.
+    #[test]
+    fn advance_preparation_lets_key_sign_past_initial_window() {
+        let mut rng = StdRng::from_seed([7u8; 32]);
+        let (_pk, mut sk) = TestScheme::key_gen(&mut rng, 0, 40);
+        let epoch: u64 = 35;
+
+        // Precondition: fresh key is not prepared for epoch 35.
+        assert!(!sk.get_prepared_interval().contains(&epoch));
+
+        // The advance loop the glue's sign() runs.
+        while !sk.get_prepared_interval().contains(&epoch) {
+            let before = sk.get_prepared_interval();
+            sk.advance_preparation();
+            assert_ne!(sk.get_prepared_interval(), before, "advance must make progress");
+        }
+
+        let msg = [0u8; MESSAGE_LENGTH];
+        assert!(
+            TestScheme::sign(&sk, epoch as u32, &msg).is_ok(),
+            "signing must succeed once the window is advanced"
+        );
     }
 }

--- a/rust/hashsig-glue/src/lib.rs
+++ b/rust/hashsig-glue/src/lib.rs
@@ -132,8 +132,7 @@ impl PrivateKey {
             }
         }
 
-        let sig =
-            XmssScheme::sign(&sk, epoch, message).map_err(|_| SigningError::SigningFailed)?;
+        let sig = XmssScheme::sign(&sk, epoch, message).map_err(|_| SigningError::SigningFailed)?;
         Ok(Signature::new(sig))
     }
 }
@@ -684,7 +683,11 @@ mod advance_preparation_tests {
         while !sk.get_prepared_interval().contains(&epoch) {
             let before = sk.get_prepared_interval();
             sk.advance_preparation();
-            assert_ne!(sk.get_prepared_interval(), before, "advance must make progress");
+            assert_ne!(
+                sk.get_prepared_interval(),
+                before,
+                "advance must make progress"
+            );
         }
 
         let msg = [0u8; MESSAGE_LENGTH];


### PR DESCRIPTION
Fixes the node crash at slot 131072.

## Symptom

zeam nodes aborted the signing worker at exactly slot 131072, e.g. on the attestation path:

```
[s=131072 i=2] ...
chain.BeamChain.attestImpl
validator_client.ValidatorClient.mayBeDoAttestation
```

The abort is a Rust panic inside leansig's `sign()`:

```
Signing: key not yet prepared for this epoch, try calling sk.advance_preparation.
```

## Root cause

The generalized-XMSS secret key only keeps **two consecutive bottom trees** in memory at a time (its "prepared interval"). For `LOG_LIFETIME = 32` each bottom tree covers `2^16` epochs, so the prepared window is `2 * 2^16 = 131072` epochs, starting at `[0, 131072)`. Signing an epoch at or beyond `131072` requires sliding that window forward with `advance_preparation()`.

The keys are generated correctly (manifest: `num_active_epochs: 262144` = `2^18`), so the *activation* window is fine. The bug is that neither `hashsig-glue` nor zeam ever advanced the *prepared* window, so the first epoch past 131071 tripped leansig's `assert!(prepared_interval.contains(epoch))` and aborted the process. leansig even ships the intended pattern (advance in a loop until prepared, then sign).

## Fix (`rust/hashsig-glue`)

- `PrivateKey` wraps its secret key in a `Mutex` so the shared key handle (an `opaque` pointer on the Zig side, signed from parallel workers) can be mutated safely.
- `sign()` advances the prepared window (`advance_preparation` in a loop, with a no-progress guard) until it covers the requested epoch, then signs.
- Both leansig asserts — activation window and prepared window — are pre-checked and converted into a recoverable `SigningFailed` error, so a genuinely spent key fails to sign instead of aborting the node.

Zig is unaffected: it holds these structs only behind `opaque` pointers, so dropping `#[repr(C)]` from `PrivateKey`/`KeyPair` is safe.

## Validation

- `cargo build -p hashsig-glue`, `cargo clippy -p hashsig-glue`, `cargo fmt` all clean.
- New regression test (`advance_preparation_lets_key_sign_past_initial_window`) uses the `2^8` test scheme (prepared window 32, activated for 48) and signs at epoch 35, reproducing the crash shape and verifying advance-then-sign works.

## Known minor

The first signature that crosses a `2^16`-epoch bottom-tree boundary pays the `advance_preparation` cost (one bottom-tree recompute) inline, which may delay that single signature at the boundary slot. A follow-up could advance proactively in the background.
