### PR TITLE
ci(release): drop GHA build cache from docker push (unblock releases)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -255,8 +255,13 @@ jobs:
         build-args: |
           GIT_COMMIT=${{ needs.create-tags.outputs.release_sha }}
           GIT_BRANCH=${{ needs.create-tags.outputs.docker_tag || github.event.pull_request.head.ref }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # No GHA build cache here: `cache-to: type=gha,mode=max` on the large
+        # zeam image (prover staticlib + rust deps), written by both matrix legs
+        # at once, exhausts the repo's GHA cache quota and buildkit aborts the
+        # whole solve with "error writing layer blob: failed to reserve cache",
+        # failing the push and blocking the release (v0.5.8 and v0.5.9 both hit
+        # this). Dockerfile.prebuilt just packages an already-built binary, so
+        # the layer cache saves little; reliability of the release push wins.
         provenance: false
 
   create-manifest:


### PR DESCRIPTION
## Problem

The devnet5 release workflow has failed the last two releases (v0.5.8 and v0.5.9) at the docker push step:

```
#16 ERROR: failed to push docker.io/.../zeam:0.5.9-amd64: ... error writing layer blob: failed to reserve cache
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

The tags get created but no image is published (`create-manifest` and `create-github-release` are then skipped).

## Root cause

The `Build and push Docker image` step in `auto-release.yml` uses:

```yaml
cache-from: type=gha
cache-to: type=gha,mode=max
```

`failed to reserve cache` is the GitHub Actions cache backend rejecting a `reserveCache` call. `mode=max` exports every layer of the large zeam image (the ~240 MB prover staticlib plus rust deps), and both matrix legs (amd64 + arm64) write to the same cache at once, exhausting the repo's 10 GB GHA cache quota. When the cache export fails, buildkit aborts the whole build-and-push solve, so the image never pushes. It is not transient flakiness: it fires at the same step on every run.

## Fix

Remove the GHA build cache from the release push. `Dockerfile.prebuilt` only packages an already-built binary, so the layer cache saves almost nothing here, and a release must never be blocked by a best-effort build cache.

## Follow-up (completing v0.5.9)

The `v0.5.9` / `Devnet5` git tags already exist from the failed run, and `create-tags` hard-fails if a version tag already exists. So after this merges, the stuck v0.5.9 release needs to be re-driven with the fixed workflow, either by deleting the dangling `v0.5.9`/`Devnet5` tags and re-opening the release PR, or by cutting it as a new version label. I can do that once this is in.
