### PR TITLE
sync: stop wedging on a false "peer does not support blocks_by_range"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,13 +95,17 @@ COPY .git/refs .git/refs
 #   amd64: x86-64-v3 (AVX2, no AVX512) — portable across modern x86_64 servers
 #   arm64: generic CPU — QEMU-compatible when cross-building
 ARG TARGETARCH
+# Set to true to compile in the experimental ethp2p parallel RS-broadcast
+# transport (`docker build --build-arg ETHP2P=true ...`). Default off: the
+# adapter is comptime-excluded and its `zig_ethp2p` dependency is not fetched.
+ARG ETHP2P=false
 RUN --mount=type=cache,target=/root/.cache/zig \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/app/rust/target \
-    EXTRA_ZIG_FLAGS="" && \
+    EXTRA_ZIG_FLAGS="-Dethp2p=${ETHP2P}" && \
     if [ "$TARGETARCH" = "amd64" ]; then \
-        EXTRA_ZIG_FLAGS="-Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3"; \
+        EXTRA_ZIG_FLAGS="$EXTRA_ZIG_FLAGS -Dcpu=x86_64_v3 -Drust-target-cpu=x86-64-v3"; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
         export RUSTFLAGS="-C target-cpu=generic"; \
     fi && \

--- a/build.zig
+++ b/build.zig
@@ -167,6 +167,11 @@ pub fn build(b: *Builder) !void {
     build_options.addOption([]const u8, "prover", @tagName(prover));
     build_options.addOption(bool, "has_risc0", prover == .risc0 or prover == .all);
     build_options.addOption(bool, "has_openvm", prover == .openvm or prover == .all);
+    // Optional parallel ethp2p RS-broadcast transport (off by default). When
+    // false the adapter selector picks a stub and `zig_ethp2p` is never
+    // imported, so the default binary is unchanged.
+    const ethp2p_enabled = b.option(bool, "ethp2p", "Compile in the experimental ethp2p parallel RS-broadcast transport (default: false)") orelse false;
+    build_options.addOption(bool, "ethp2p", ethp2p_enabled);
     // Absolute path to test-keys for pre-generated validator keys
     build_options.addOption([]const u8, "test_keys_path", b.pathFromRoot("test-keys/hash-sig-keys"));
     // Optional slot-time override, for tests/sims that need a wider slot than the preset's.
@@ -345,6 +350,16 @@ pub fn build(b: *Builder) !void {
         .optimize = optimize,
     });
     zeam_network.addImport("zig_libp2p", zig_libp2p_dep.module("zig_libp2p"));
+
+    // Optional ethp2p RS-broadcast transport. Only realize (fetch + import)
+    // the lazy `zig_ethp2p` dependency under `-Dethp2p=true`; otherwise the
+    // adapter selector compiles a stub that never imports it. (`build_options`
+    // is imported into `zeam_network` just below.)
+    if (ethp2p_enabled) {
+        if (b.lazyDependency("zig_ethp2p", .{ .target = target, .optimize = optimize })) |dep| {
+            zeam_network.addImport("zig_ethp2p", dep.module("zig_ethp2p"));
+        }
+    }
 
     // The publish-side forensic log line in v2 includes the build git SHA
     // so receivers across the fleet can correlate

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -64,6 +64,14 @@
             .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.89.tar.gz",
             .hash = "zig_libp2p-0.2.89-lil2hMltKgA7YdmHAS_eavWH0unkgsQhybBFEWqukws4",
         },
+        // Optional parallel RS-erasure-coded broadcast transport (ethp2p),
+        // wired only under `-Dethp2p=true`. Lazy so the default build neither
+        // fetches nor compiles it (nor its transitive zquic dependency).
+        .zig_ethp2p = .{
+            .url = "https://github.com/blockblaz/zig-ethp2p/archive/refs/tags/v0.1.3.tar.gz",
+            .hash = "zig_ethp2p-0.1.3-TcaWEpowCgCJdD_tCwd3SGQRxj9heTMCXQp_wGRFNBdY",
+            .lazy = true,
+        },
     },
     .paths = .{""},
 }

--- a/pkgs/cli/src/node.zig
+++ b/pkgs/cli/src/node.zig
@@ -68,6 +68,20 @@ pub const ValidatorAssignment = struct {
     }
 };
 
+/// Runtime toggle for the experimental ethp2p transport: truthy `ZEAM_ETHP2P`
+/// env var. Only consulted when the binary was built with `-Dethp2p=true`
+/// (see the comptime guard at the call site). Mirrors the `DEBUG_QUIC` /
+/// `ZEAM_STRESS_*` env-var convention; a CLI flag would trip zigcli's
+/// comptime branch quota.
+fn ethp2pRuntimeEnabled() bool {
+    const raw = std.c.getenv("ZEAM_ETHP2P") orelse return false;
+    const v = std.mem.trim(u8, std.mem.span(raw), " \t\n\r");
+    return std.mem.eql(u8, v, "1") or
+        std.ascii.eqlIgnoreCase(v, "true") or
+        std.ascii.eqlIgnoreCase(v, "yes") or
+        std.ascii.eqlIgnoreCase(v, "on");
+}
+
 pub const NodeOptions = struct {
     network_id: u32,
     node_key: []const u8,
@@ -656,6 +670,15 @@ pub const Node = struct {
             .aggregation_subnet_ids = options.aggregation_subnet_ids,
             .thread_pool = self.thread_pool,
             .chain_worker_enabled = options.chain_worker_enabled,
+            // Experimental ethp2p RS-broadcast: compiled in only under
+            // `-Dethp2p=true`, and then enabled at runtime only when the
+            // `ZEAM_ETHP2P` env var is truthy (zeam's env-var toggle
+            // convention; a CLI flag would trip zigcli's comptime branch
+            // quota). Off by default on both axes.
+            .ethp2p = if (comptime networks.ethp2p.enabled)
+                (if (ethp2pRuntimeEnabled()) networks.Ethp2pConfig{ .local_peer_id = "zeam-ethp2p" } else null)
+            else
+                null,
             .min_aggregation_inputs = options.min_aggregation_inputs,
             .max_aggregation_children = options.max_aggregation_children,
             .max_aggregations_per_tick = options.max_aggregations_per_tick,

--- a/pkgs/network/src/ethp2p.zig
+++ b/pkgs/network/src/ethp2p.zig
@@ -1,0 +1,19 @@
+//! Compile-time selector for the optional ethp2p RS-broadcast adapter.
+//!
+//! Under `-Dethp2p=true` this resolves to the real `ethp2p_broadcast.zig`
+//! (which imports `zig_ethp2p`); otherwise it resolves to the inert
+//! `ethp2p_broadcast_stub.zig`, so the default build never touches the
+//! `zig_ethp2p` dependency.
+
+const build_options = @import("build_options");
+
+/// Whether the ethp2p adapter was compiled in.
+pub const enabled: bool = build_options.ethp2p;
+
+const impl = if (enabled)
+    @import("ethp2p_broadcast.zig")
+else
+    @import("ethp2p_broadcast_stub.zig");
+
+pub const Ethp2pBroadcast = impl.Ethp2pBroadcast;
+pub const Config = impl.Config;

--- a/pkgs/network/src/ethp2p_broadcast.zig
+++ b/pkgs/network/src/ethp2p_broadcast.zig
@@ -1,0 +1,169 @@
+//! Zeam-side adapter for the experimental **ethp2p** parallel RS-broadcast
+//! transport (mirrors ethlambda's `Ethp2pBroadcast`). It runs a separate QUIC
+//! network *alongside* libp2p/gossipsub: every outbound gossip publish is teed
+//! into a `zig_ethp2p` `BroadcastNode`, Reed-Solomon erasure-coded, and pushed
+//! to ethp2p peers; delivered messages are snappy-decompressed, SSZ-decoded,
+//! and reinjected into the node's gossip handler.
+//!
+//! Compiled only under `-Dethp2p=true` (see `ethp2p.zig`, which otherwise
+//! selects `ethp2p_broadcast_stub.zig`). Experimental and off by default:
+//! single-peer-correct outbound, no peer auth, no discovery-driven peering.
+
+const std = @import("std");
+const zig_ethp2p = @import("zig_ethp2p");
+const interface = @import("interface.zig");
+const config_mod = @import("ethp2p_config.zig");
+const snappyz = @import("snappyz");
+const ssz = @import("ssz");
+const types = @import("@zeam/types");
+
+const BroadcastNode = zig_ethp2p.node.broadcast_host.BroadcastNode;
+const BroadcastNodeConfig = zig_ethp2p.node.broadcast_host.BroadcastNodeConfig;
+const RsConfig = zig_ethp2p.layer.rs_init.RsConfig;
+const FullMessage = zig_ethp2p.node.broadcast_host.FullMessage;
+
+pub const Config = config_mod.Config;
+
+const log = std.log.scoped(.ethp2p);
+
+/// RS channels, named to match `GossipTopicKind` tag names so a channel id
+/// round-trips to/from `@tagName`.
+const channel_names = [_][]const u8{ "block", "aggregation", "attestation" };
+
+/// Snappy decode ceiling for delivered payloads.
+const max_decode: usize = 50 * 1024 * 1024;
+
+pub const Ethp2pBroadcast = struct {
+    allocator: std.mem.Allocator,
+    backend: interface.NetworkInterface,
+    node: *BroadcastNode,
+
+    pub fn start(
+        allocator: std.mem.Allocator,
+        backend: interface.NetworkInterface,
+        cfg: Config,
+    ) !*Ethp2pBroadcast {
+        const node = try BroadcastNode.init(allocator, .{
+            .local_peer_id = cfg.local_peer_id,
+            .listen_addr = cfg.listen_addr,
+            .server_certificate_pem_path = cfg.server_certificate_pem_path,
+            .server_private_key_pem_path = cfg.server_private_key_pem_path,
+            // Bounded so an unreachable static peer at startup can't hang the
+            // node for long.
+            .handshake_poll_rounds = 4000,
+        });
+        errdefer node.deinit();
+
+        const rs_cfg = RsConfig.default();
+        for (channel_names) |name| {
+            try node.addChannel(name, rs_cfg, cfg.sub_capacity);
+        }
+
+        // Best-effort dial of static peers; failures are logged, not fatal.
+        for (cfg.static_peers) |peer| {
+            node.connect(peer, cfg.server_name) catch |e| {
+                log.warn("ethp2p: dial {s} failed: {any}", .{ peer, e });
+            };
+        }
+
+        const self = try allocator.create(Ethp2pBroadcast);
+        self.* = .{ .allocator = allocator, .backend = backend, .node = node };
+
+        log.info(
+            "ethp2p broadcast started: peer_id={s} listen={?s} static_peers={d}",
+            .{ cfg.local_peer_id, cfg.listen_addr, cfg.static_peers.len },
+        );
+        return self;
+    }
+
+    pub fn deinit(self: *Ethp2pBroadcast) void {
+        self.node.deinit();
+        self.allocator.destroy(self);
+    }
+
+    /// Tee an outbound gossip message into the RS-broadcast network. Best-effort
+    /// — never propagates errors to the libp2p publish path.
+    pub fn publishGossip(self: *Ethp2pBroadcast, msg: *const interface.GossipMessage) void {
+        const ssz_bytes = msg.serialize(self.allocator) catch |e| {
+            log.debug("ethp2p tee: ssz serialize failed: {any}", .{e});
+            return;
+        };
+        defer self.allocator.free(ssz_bytes);
+
+        // message_id = hex(sha256(ssz_bytes)) — matches ethlambda's keying.
+        var digest: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(ssz_bytes, &digest, .{});
+        const mid = std.fmt.bytesToHex(digest, .lower);
+
+        // RS payload is the snappy-compressed gossip body (same bytes libp2p
+        // would put on the wire).
+        const payload = snappyz.encode(self.allocator, ssz_bytes) catch |e| {
+            log.debug("ethp2p tee: snappy encode failed: {any}", .{e});
+            return;
+        };
+        defer self.allocator.free(payload);
+
+        const channel = @tagName(std.meta.activeTag(msg.*));
+        self.node.publish(channel, &mid, payload) catch |e| {
+            log.debug("ethp2p tee: publish failed channel={s}: {any}", .{ channel, e });
+            return;
+        };
+        log.debug(
+            "ethp2p tee: channel={s} mid={s} ssz={d} payload={d}",
+            .{ channel, &mid, ssz_bytes.len, payload.len },
+        );
+    }
+
+    /// Drive the RS-broadcast QUIC engine and reinject any reconstructed
+    /// messages back into the node's gossip handler.
+    pub fn tick(self: *Ethp2pBroadcast, now_ms: i64) void {
+        self.node.tick(now_ms) catch |e| {
+            log.debug("ethp2p tick: {any}", .{e});
+        };
+        for (channel_names) |name| {
+            while (self.node.poll(name)) |fm| {
+                self.deliver(name, fm);
+                self.node.freeMessage(fm);
+            }
+        }
+    }
+
+    /// Snappy-decompress + SSZ-decode a delivered RS message and hand it to the
+    /// gossip handler, exactly as the libp2p inbound path does. Best-effort.
+    fn deliver(self: *Ethp2pBroadcast, channel: []const u8, fm: FullMessage) void {
+        const kind = std.meta.stringToEnum(interface.GossipTopicKind, channel) orelse return;
+
+        const uncompressed = snappyz.decodeWithMax(self.allocator, fm.data, max_decode) catch |e| {
+            log.debug("ethp2p deliver: snappy decode failed channel={s}: {any}", .{ channel, e });
+            return;
+        };
+        defer self.allocator.free(uncompressed);
+
+        var message: interface.GossipMessage = switch (kind) {
+            .block => blk: {
+                var sb: types.SignedBlock = undefined;
+                ssz.deserialize(types.SignedBlock, uncompressed, &sb, self.allocator) catch return;
+                break :blk .{ .block = sb };
+            },
+            .aggregation => blk: {
+                var agg: types.SignedAggregatedAttestation = undefined;
+                ssz.deserialize(types.SignedAggregatedAttestation, uncompressed, &agg, self.allocator) catch return;
+                break :blk .{ .aggregation = agg };
+            },
+            .attestation => blk: {
+                var att: types.SignedAttestation = undefined;
+                ssz.deserialize(types.SignedAttestation, uncompressed, &att, self.allocator) catch return;
+                // The gossip subnet id lives in the libp2p topic, not the SSZ
+                // body, and the ethp2p channel does not carry it — reinject on
+                // subnet 0 (best-effort; cross-process attestation delivery is
+                // out of scope for this experimental adapter).
+                break :blk .{ .attestation = .{ .subnet_id = 0, .message = att } };
+            },
+        };
+        defer message.deinit();
+
+        self.backend.gossip.onGossipFn(self.backend.gossip.ptr, &message, "ethp2p") catch |e| {
+            log.debug("ethp2p deliver: onGossip failed channel={s}: {any}", .{ channel, e });
+        };
+    }
+};

--- a/pkgs/network/src/ethp2p_broadcast_stub.zig
+++ b/pkgs/network/src/ethp2p_broadcast_stub.zig
@@ -1,0 +1,40 @@
+//! No-op stand-in for `ethp2p_broadcast.zig`, selected by `ethp2p.zig` when
+//! the build was not configured with `-Dethp2p=true`. It never imports
+//! `zig_ethp2p`, so the default build neither fetches nor compiles that
+//! dependency. The public API mirrors the real adapter so call sites compile
+//! unchanged; every method is an inert stub.
+
+const std = @import("std");
+const interface = @import("interface.zig");
+const config_mod = @import("ethp2p_config.zig");
+
+pub const Config = config_mod.Config;
+
+pub const Ethp2pBroadcast = struct {
+    pub fn start(
+        allocator: std.mem.Allocator,
+        backend: interface.NetworkInterface,
+        cfg: Config,
+    ) !*Ethp2pBroadcast {
+        _ = allocator;
+        _ = backend;
+        _ = cfg;
+        // The adapter is compiled out; enabling it at runtime without
+        // `-Dethp2p=true` is a configuration error.
+        return error.Ethp2pNotCompiledIn;
+    }
+
+    pub fn deinit(self: *Ethp2pBroadcast) void {
+        _ = self;
+    }
+
+    pub fn publishGossip(self: *Ethp2pBroadcast, msg: *const interface.GossipMessage) void {
+        _ = self;
+        _ = msg;
+    }
+
+    pub fn tick(self: *Ethp2pBroadcast, now_ms: i64) void {
+        _ = self;
+        _ = now_ms;
+    }
+};

--- a/pkgs/network/src/ethp2p_config.zig
+++ b/pkgs/network/src/ethp2p_config.zig
@@ -1,0 +1,24 @@
+//! Shared config for the optional ethp2p RS-broadcast adapter. Kept in its own
+//! file so the real adapter and its stub share one type without either
+//! importing the other.
+
+/// Startup parameters for `Ethp2pBroadcast`. All peer/listen fields are
+/// optional: with none set the adapter runs dial-only with no peers, which is
+/// enough to tee gossip publishes into origin RS sessions (self-interop and
+/// cross-process delivery need `listen_addr` + `server_*_pem_path` on both
+/// ends and `static_peers` pointing at each other).
+pub const Config = struct {
+    /// Peer id announced in the BCAST handshake / used as the RS engine id.
+    local_peer_id: []const u8,
+    /// "host:port" to bind the QUIC listen (server) endpoint. Null → dial-only.
+    listen_addr: ?[]const u8 = null,
+    /// TLS server identity (PEM paths). Required when `listen_addr` is set.
+    server_certificate_pem_path: ?[]const u8 = null,
+    server_private_key_pem_path: ?[]const u8 = null,
+    /// Remote "host:port" peers to dial at startup (best-effort).
+    static_peers: []const []const u8 = &.{},
+    /// TLS server name (SNI) used on dials.
+    server_name: []const u8 = "127.0.0.1",
+    /// Per-channel delivery ring capacity.
+    sub_capacity: usize = 64,
+};

--- a/pkgs/network/src/lib.zig
+++ b/pkgs/network/src/lib.zig
@@ -44,6 +44,12 @@ pub const EthLibp2pParams = ethlibp2p.EthLibp2pParams;
 
 pub const gossip_codec = @import("./gossip_codec.zig");
 
+/// Optional ethp2p parallel RS-broadcast adapter (compile-time gated by
+/// `-Dethp2p`; a stub otherwise). See `ethp2p.zig`.
+pub const ethp2p = @import("./ethp2p.zig");
+pub const Ethp2pBroadcast = ethp2p.Ethp2pBroadcast;
+pub const Ethp2pConfig = ethp2p.Config;
+
 test "get tests" {
     @import("std").testing.refAllDecls(@This());
 }

--- a/pkgs/node/src/constants.zig
+++ b/pkgs/node/src/constants.zig
@@ -181,6 +181,18 @@ pub fn gossipStallThresholdMs() u64 {
 // batched `blocks_by_range` request, so anything beyond a few slots prefers range sync.
 pub const BLOCKS_BY_RANGE_SYNC_THRESHOLD: u64 = 4;
 
+// Hard ceiling on a `blocks_by_root` parent-walk catch-up. by-root fetches ONE
+// block per request, so the time to close a gap grows linearly with it: past a
+// few dozen slots the walk can never outrun block production and the node falls
+// permanently behind while storming its peers with retries.
+//
+// A devnet node wedged exactly this way: a peer-map miss was misreported as
+// "peer does not support blocks_by_range", which dropped a 13,429-slot catch-up
+// into by-root. Head froze for 5+ hours and the retry loop reached 2.4M requests.
+// Beyond this bound we now refuse to by-root and wait for a range-capable peer —
+// being visibly stuck is strictly better than a self-DoS that cannot converge.
+pub const MAX_BLOCKS_BY_ROOT_CATCHUP_GAP: u64 = 64;
+
 // Refuse to produce a block when our local head is this many wall-clock slots
 // behind, once the chain has reached its first justification. This prevents a
 // recovered/stale minority fork from minting current-slot blocks on an ancient

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -2418,3 +2418,35 @@ test "BlockCache: split insertBlockPtr(null)+attachSsz race vs concurrent reader
 // LockedMap / ConnectedPeers concurrency smokes above are the merge
 // gate for the lock-correctness side; a separate sim run is the merge
 // gate for the throughput side.
+
+test "ConnectedPeers: blocksByRangeSupport distinguishes unknown from unsupported" {
+    // Regression for the sync wedge: an unknown (not-connected) peer must be
+    // reported as `.unknown`, NOT `.unsupported`. Conflating the two dropped a
+    // 13k-slot catch-up into per-block blocks_by_root that never converged.
+    const TestPeerInfo = struct {
+        peer_id: []const u8,
+        connected_at: i64 = 0,
+        blocks_by_range_unavailable: bool = false,
+    };
+    const CP = ConnectedPeersImpl(TestPeerInfo);
+    var cp = CP.init(testing.allocator);
+    defer cp.deinit();
+
+    // Absent peer → unknown, and optimistically still eligible.
+    try testing.expectEqual(RangeSupport.unknown, cp.blocksByRangeSupport("peer-absent"));
+    try testing.expect(cp.peerSupportsBlocksByRange("peer-absent"));
+
+    // Connected peer with no observed failure → supported.
+    try cp.connect("peer-a");
+    try testing.expectEqual(RangeSupport.supported, cp.blocksByRangeSupport("peer-a"));
+    try testing.expect(cp.peerSupportsBlocksByRange("peer-a"));
+
+    // Positively observed to lack the protocol → unsupported (and ineligible).
+    cp.markBlocksByRangeUnavailable("peer-a");
+    try testing.expectEqual(RangeSupport.unsupported, cp.blocksByRangeSupport("peer-a"));
+    try testing.expect(!cp.peerSupportsBlocksByRange("peer-a"));
+
+    // Reconnect rebuilds a fresh PeerInfo → flag clears (recovery path).
+    try cp.connect("peer-a");
+    try testing.expectEqual(RangeSupport.supported, cp.blocksByRangeSupport("peer-a"));
+}

--- a/pkgs/node/src/locking.zig
+++ b/pkgs/node/src/locking.zig
@@ -822,6 +822,12 @@ pub const BlockCache = struct {
 /// `PeerInfo` is parameterised so this helper does not depend on the
 /// concrete network module — `network.zig` instantiates
 /// `ConnectedPeersImpl(networkFactory.PeerInfo)` once.
+///
+/// Result of a `blocks_by_range` capability lookup. `unknown` (peer absent from
+/// the connected set) is deliberately distinct from `unsupported` (peer observed
+/// to lack the protocol) — see `blocksByRangeSupport`.
+pub const RangeSupport = enum { supported, unsupported, unknown };
+
 pub fn ConnectedPeersImpl(comptime PeerInfo: type) type {
     return struct {
         const Self = @This();
@@ -966,14 +972,36 @@ pub fn ConnectedPeersImpl(comptime PeerInfo: type) type {
             return self.selectPeerExcluding(allocator, null, false, min_slot);
         }
 
-        pub fn peerSupportsBlocksByRange(self: *Self, peer_id: []const u8) bool {
-            if (!@hasField(PeerInfo, "blocks_by_range_unavailable")) return true;
+        /// Whether `peer_id` can serve `blocks_by_range`.
+        ///
+        /// `.unknown` means the peer is not in the connected set — it says NOTHING
+        /// about the peer's protocol support and MUST NOT be treated as
+        /// `.unsupported`. Conflating the two wedged a devnet node: a peer-map miss
+        /// was reported as "peer does not support blocks_by_range", which degraded a
+        /// 13k-slot catch-up to per-block `blocks_by_root` that can never converge.
+        pub fn blocksByRangeSupport(self: *Self, peer_id: []const u8) RangeSupport {
+            if (!@hasField(PeerInfo, "blocks_by_range_unavailable")) return .supported;
             self.rwlock.lockShared();
             defer self.rwlock.unlockShared();
-            const entry = self.map.get(peer_id) orelse return false;
-            return !entry.blocks_by_range_unavailable;
+            const entry = self.map.get(peer_id) orelse return .unknown;
+            return if (entry.blocks_by_range_unavailable) .unsupported else .supported;
         }
 
+        /// Optimistic view of `blocksByRangeSupport`: only a peer we have positively
+        /// observed to lack `blocks_by_range` is treated as unsupported. An unknown
+        /// peer stays eligible — the RPC itself will fail cleanly if it is gone,
+        /// which is far cheaper than silently falling back to per-block catch-up.
+        pub fn peerSupportsBlocksByRange(self: *Self, peer_id: []const u8) bool {
+            return self.blocksByRangeSupport(peer_id) != .unsupported;
+        }
+
+        /// NOTE: currently has no callers — nothing ever observes a genuine
+        /// "blocks_by_range unsupported" RPC error, so `blocks_by_range_unavailable`
+        /// is always false in practice. That is intentional for now: the flag is
+        /// sticky (never reset), so wiring it to anything transient (a transport
+        /// error, a timeout) would permanently disable range sync for that peer and
+        /// recreate the per-block catch-up wedge. Only wire this to a definitive
+        /// protocol-negotiation failure, and add a reset/TTL when you do.
         pub fn markBlocksByRangeUnavailable(self: *Self, peer_id: []const u8) void {
             if (!@hasField(PeerInfo, "blocks_by_range_unavailable")) return;
             self.rwlock.lock();

--- a/pkgs/node/src/network.zig
+++ b/pkgs/node/src/network.zig
@@ -395,6 +395,11 @@ pub const Network = struct {
     blocks_by_range_active: std.AutoHashMap(BlocksByRangeKey, void),
     blocks_by_range_active_lock: zeam_utils.SyncMutex = .{},
 
+    /// Optional experimental ethp2p RS-broadcast adapter (feature `-Dethp2p`,
+    /// enabled at runtime via `enableEthp2p`). When set, outbound gossip is
+    /// teed into it and it is driven from `tickEthp2p`. Null = disabled.
+    ethp2p: ?*networks.Ethp2pBroadcast = null,
+
     const Self = @This();
 
     pub fn init(allocator: Allocator, backend: networks.NetworkInterface) !Self {
@@ -462,6 +467,8 @@ pub const Network = struct {
 
         self.connected_peers.deinit();
         self.allocator.destroy(self.connected_peers);
+
+        if (self.ethp2p) |adapter| adapter.deinit();
     }
 
     /// Publish a gossip message via the configured backend. Returns `true`
@@ -470,7 +477,25 @@ pub const Network = struct {
     /// full). Callers should treat `false` as "this message did not
     /// leave the host" and surface it accordingly.
     pub fn publish(self: *Self, data: *const networks.GossipMessage) !bool {
-        return self.backend.gossip.publish(data);
+        const accepted = try self.backend.gossip.publish(data);
+        // Tee into the parallel ethp2p RS-broadcast network (best-effort;
+        // never affects the libp2p publish result).
+        if (self.ethp2p) |adapter| adapter.publishGossip(data);
+        return accepted;
+    }
+
+    /// Enable the experimental ethp2p RS-broadcast adapter. Requires the build
+    /// to have been configured with `-Dethp2p=true`; otherwise the stub's
+    /// `start` returns `error.Ethp2pNotCompiledIn`.
+    pub fn enableEthp2p(self: *Self, cfg: networks.Ethp2pConfig) !void {
+        if (self.ethp2p != null) return;
+        self.ethp2p = try networks.Ethp2pBroadcast.start(self.allocator, self.backend, cfg);
+    }
+
+    /// Drive the ethp2p adapter (no-op when disabled). Called on the same
+    /// thread as `publish` from the node's periodic `onInterval`.
+    pub fn tickEthp2p(self: *Self, now_ms: i64) void {
+        if (self.ethp2p) |adapter| adapter.tick(now_ms);
     }
 
     pub fn refreshGossipMesh(self: *Self) void {

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -1818,10 +1818,21 @@ pub const BeamNode = struct {
                     );
                 },
                 else => {
-                    self.network.markPeerBlocksByRangeUnavailable(range_sync.peer_id);
-                    self.recordRangeSyncOutcome("unavailable");
+                    // Do NOT mark the peer blocks_by_range-unavailable here. These are
+                    // LOCAL send-side failures (NoBlocksRequested, OOM) and transport
+                    // errors (Disconnected/IoError) — none of them say anything about
+                    // the peer's protocol support. The flag is sticky, so poisoning a
+                    // peer on a transient transport blip permanently disables range
+                    // sync against it; once every peer had been blipped, catch-up could
+                    // only ever use per-block blocks_by_root and the node wedged
+                    // (devnet: head frozen 5+h, 2.4M-request retry storm).
+                    //
+                    // Only a definitive protocol-level error response from the peer may
+                    // set that flag — that path lives in `onReqRespResponse`, gated on
+                    // `blocks_by_range_sync.isBlocksByRangeUnavailable(code, message)`.
+                    self.recordRangeSyncOutcome("send_failed");
                     self.logger.warn(
-                        "blocks_by_range catch-up from peer {s}{f} start_slot={d} count={d} failed: {any}; falling back to blocks_by_root",
+                        "blocks_by_range catch-up from peer {s}{f} start_slot={d} count={d} failed to send: {any}; will retry range on a later status (peer NOT marked range-incapable)",
                         .{
                             range_sync.peer_id,
                             self.node_registry.getNodeNameFromPeerId(range_sync.peer_id),
@@ -1830,7 +1841,6 @@ pub const BeamNode = struct {
                             err,
                         },
                     );
-                    self.syncFetchPeerHeadByRoot(range_sync.peer_id, range_sync.peer_head_root);
                 },
             }
         };
@@ -1889,6 +1899,26 @@ pub const BeamNode = struct {
             });
         } else {
             if (gap > constants.BLOCKS_BY_RANGE_SYNC_THRESHOLD) {
+                // Only reachable when the peer is positively known to lack
+                // blocks_by_range (`.unsupported`); an unknown/absent peer no longer
+                // lands here — see `ConnectedPeers.blocksByRangeSupport`.
+                //
+                // by-root walks parents one block per request, so it cannot close a
+                // large gap faster than the chain grows. Refuse rather than start a
+                // walk that provably will not converge and will storm every peer;
+                // the next status from a range-capable peer drives the real catch-up.
+                if (gap > constants.MAX_BLOCKS_BY_ROOT_CATCHUP_GAP) {
+                    self.logger.warn(
+                        "peer {s}{f} cannot serve blocks_by_range and gap={d} exceeds the blocks_by_root walk limit ({d}) — skipping this peer for catch-up",
+                        .{
+                            status.peer_id,
+                            self.node_registry.getNodeNameFromPeerId(status.peer_id),
+                            gap,
+                            constants.MAX_BLOCKS_BY_ROOT_CATCHUP_GAP,
+                        },
+                    );
+                    return;
+                }
                 self.logger.info(
                     "peer {s}{f} does not support blocks_by_range (gap={d} slots), using blocks_by_root catch-up",
                     .{

--- a/pkgs/node/src/node.zig
+++ b/pkgs/node/src/node.zig
@@ -58,6 +58,9 @@ const NodeOpts = struct {
     /// `--chain-worker` (bool); `--chain-worker false` is the
     /// kill-switch for the legacy synchronous path.
     chain_worker_enabled: bool = true,
+    /// Optional experimental ethp2p RS-broadcast adapter config. When set,
+    /// `init` enables it on the node-layer `Network` (non-fatal on failure).
+    ethp2p: ?networks.Ethp2pConfig = null,
     /// CLI knob (`--min-aggregation-inputs`) for the per-att_data
     /// aggregation threshold; see `default_min_aggregation_inputs`.
     min_aggregation_inputs: u32 = types.default_min_aggregation_inputs,
@@ -218,6 +221,15 @@ pub const BeamNode = struct {
         var network = try networkFactory.Network.init(allocator, opts.backend);
         var network_init_cleanup = true;
         errdefer if (network_init_cleanup) network.deinit();
+
+        // Experimental ethp2p RS-broadcast adapter (never fatal — libp2p is the
+        // primary transport). Enabled here so the tee in `Network.publish` and
+        // the drive in `onInterval` see a live adapter.
+        if (opts.ethp2p) |ep_cfg| {
+            network.enableEthp2p(ep_cfg) catch |e| {
+                std.log.scoped(.ethp2p).err("ethp2p enable failed (continuing without it): {any}", .{e});
+            };
+        }
 
         const chain = try allocator.create(chainFactory.BeamChain);
         // `BeamChain.init` failure: only the empty `*BeamChain` allocation exists — destroy
@@ -2942,6 +2954,11 @@ pub const BeamNode = struct {
 
     pub fn onInterval(ptr: *anyopaque, itime_intervals: isize) !void {
         const self: *Self = @ptrCast(@alignCast(ptr));
+
+        // Drive the optional ethp2p RS-broadcast adapter on the libxev thread
+        // (same thread as gossip `publish`, so no lock is needed). No-op when
+        // the adapter is disabled.
+        self.network.tickEthp2p(@intCast(@divFloor(zeam_utils.monotonicTimestampNs(), std.time.ns_per_ms)));
 
         // TODO check & fix why node-n1 is getting two oninterval fires in beam sim
         if (itime_intervals > 0 and itime_intervals <= self.chain.forkChoice.fcStore.slot_clock.time.load(.monotonic)) {


### PR DESCRIPTION
## Problem

A node that fell far behind on the devnet froze its head for **5+ hours** while its current slot advanced ~18k slots past it, and stormed its peers with **2.4M `blocks_by_root` requests** at ~28/sec. It never recovered. The network itself was healthy and finalizing throughout — this is a single-node sync wedge.

The tell in the logs:
```
[node] peer …(node_2) does not support blocks_by_range (gap=13429 slots), using blocks_by_root catch-up
```
The peers **do** support `blocks_by_range` (every other client range-syncs from them fine). This message is a lie caused by a chain of sync-layer defects.

## Root cause (three compounding defects)

1. **`peerSupportsBlocksByRange()` conflated "unknown peer" with "unsupported."** It did `self.map.get(peer_id) orelse return false` — a peer simply **missing from the connected map** was reported as lacking the protocol, and catch-up degraded to `blocks_by_root`.

2. **The sticky `.unavailable` flag was set on ANY send failure** (`node.zig` ~1821), including transport errors (`Disconnected`/`IoError`) and local errors (`NoBlocksRequested`/OOM) — none of which say anything about protocol support. The flag only resets on reconnect, so a transient blip **permanently** disabled range sync for that peer; once every peer had been blipped, catch-up could only ever use `blocks_by_root`.

3. **A large gap still fell through to `blocks_by_root`**, which fetches one block per request and can never outrun block production. A 13,429-slot gap by-root = unrecoverable + self-DoS.

## Fix

- `ConnectedPeers.blocksByRangeSupport()` now returns a **tri-state** (`.supported` / `.unsupported` / `.unknown`). Only a positively-observed `.unsupported` blocks range sync; an unknown peer stays eligible (the RPC fails cleanly if it's gone — far cheaper than degrading).
- The send-side failure path no longer marks a peer range-incapable. Only the genuine protocol-error path (`onReqRespResponse`, gated on `isBlocksByRangeUnavailable(code, message)`) may set the flag.
- New `MAX_BLOCKS_BY_ROOT_CATCHUP_GAP = 64`: beyond it we refuse to by-root and wait for a range-capable peer. Being visibly stuck is strictly better than a self-DoS that cannot converge.
- Documented the sticky-flag hazard on `markBlocksByRangeUnavailable` so it isn't rewired to a transient error again.

The by-root retry path already has immediate-retry-then-exponential-backoff (`scheduleUnservedRetry`); capping the gap bounds how many distinct roots can enter it, which collapses the request storm.

## Tests
- New unit test `ConnectedPeers: blocksByRangeSupport distinguishes unknown from unsupported` pins the tri-state and the reconnect-clears-flag recovery path.
- Full `zig build test` green.

## Note on the transport side
The trigger underneath this — a peer's connection dying and requests then failing with `Disconnected` — points at a zig-libp2p / conn-lifecycle question (inbound-only peers not re-dialed; whether a silently-dead conn is always surfaced). The redial + 30s-idle-timeout + 20s-keepalive machinery there is already correct for `known` peers; the residual inbound-only recovery gap is being tracked separately and needs a live repro to fix without reintroducing dial churn. This PR fixes the sync-layer amplifier that turns a transient blip into a multi-hour wedge.