### PR TITLE
network: preserve reqresp error codes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.89.tar.gz",
-            .hash = "zig_libp2p-0.2.89-lil2hMltKgA7YdmHAS_eavWH0unkgsQhybBFEWqukws4",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/a46f4e17d871384454f2c3e0841a09d1e9498748.tar.gz",
+            .hash = "zig_libp2p-0.2.89-lil2hHdyKgAxzzAyS1lmqQ2BpE-_QY1OwYEtkwdQY5fv",
         },
         // Optional parallel RS-erasure-coded broadcast transport (ethp2p),
         // wired only under `-Dethp2p=true`. Lazy so the default build neither

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,8 +61,8 @@
             .hash = "thread_pool-0.1.0-m6B8f9j4AAAWx5c9ytLrH_NlntTMxSg049v76xVsgoSw",
         },
         .zig_libp2p = .{
-            .url = "https://github.com/blockblaz/zig-libp2p/archive/a46f4e17d871384454f2c3e0841a09d1e9498748.tar.gz",
-            .hash = "zig_libp2p-0.2.89-lil2hHdyKgAxzzAyS1lmqQ2BpE-_QY1OwYEtkwdQY5fv",
+            .url = "https://github.com/blockblaz/zig-libp2p/archive/refs/tags/v0.2.90.tar.gz",
+            .hash = "zig_libp2p-0.2.90-lil2hHdyKgAfzB0t9KNYv1G-esu4FB0q1R8Wjp2mJVKI",
         },
         // Optional parallel RS-erasure-coded broadcast transport (ethp2p),
         // wired only under `-Dethp2p=true`. Lazy so the default build neither

--- a/pkgs/network/src/ethlibp2p.zig
+++ b/pkgs/network/src/ethlibp2p.zig
@@ -1452,8 +1452,7 @@ fn serverStreamSendResponse(ptr: *anyopaque, response: *const interface.ReqRespR
 fn serverStreamSendError(ptr: *anyopaque, code: u32, message: []const u8) anyerror!void {
     const ctx: *ServerStreamContext = @ptrCast(@alignCast(ptr));
     if (ctx.finished) return error.StreamFinished;
-    _ = code;
-    try ctx.parent.host.sendErrorResponse(ctx.channel_id, message);
+    try ctx.parent.host.sendErrorResponseWithCode(ctx.channel_id, @intCast(code), message);
     ctx.finished = true;
 }
 


### PR DESCRIPTION
## Summary
- bump zig-libp2p to blockblaz/zig-libp2p@a46f4e17d871384454f2c3e0841a09d1e9498748
- use the new coded reqresp error API from zeam's inbound server stream
- preserve `INVALID_REQUEST` response-code bytes for malformed/invalid reqresp requests instead of just closing the stream

Supporting dependency PR: https://github.com/blockblaz/zig-libp2p/pull/300

## Hive context
Suite: https://hive.leanroadmap.org/suite.html?suiteid=1784546141-eb3090c7f9b766cd983e0fb631c26ad7.json&suitename=reqresp&client=zeam_devnet5

The zeam-owned reqresp failures include two explicit protocol assertions:
- `reqresp/blocks_by_range/zero_count`: expected `INVALID_REQUEST`
- `reqresp/blocks_by_range/too_many_blocks`: expected `INVALID_REQUEST`

Zeam's node handler already calls `responder.sendError(constants.RPC_ERR_INVALID_REQUEST, ...)`, but the zig-libp2p QUIC responder path discarded that numeric code and only closed the response stream. Hive's mock reqresp peer expects an actual response chunk whose first byte is `1`, so it observed the wrong wire behavior.

This PR wires the error code through zeam -> zig-libp2p -> QUIC response framing, producing a non-success reqresp response-code chunk before stream close.

## Notes
The same Hive report also contains zeam failures where the client does not produce/catch up to non-genesis blocks within the harness timeout. I traced those separately through status-driven sync and block serving; they are not fixed by this narrow wire-protocol patch and likely need a follow-up focused on checkpoint-sync/status catch-up behavior.

The report also includes many non-zeam failures caused by other clients failing startup; this PR only changes zeam-owned behavior.

## Validation
- `zig fmt --check pkgs/network/src/ethlibp2p.zig`
- `git diff --check`
- `zig build --fetch --summary none`
- zig-libp2p dependency branch: `zig build test --summary all` (508 passed, 2 skipped)
- zeam `zig build test --summary all` was started with Zig 0.16.0, but this local container still cannot complete the repo target because `rustup` is absent (`failed to spawn ... rustup: FileNotFound`); lightweight Zig package groups reached before the slow proof/STF phase passed.
